### PR TITLE
chore(ci): ajoute le socle d'intégration continue et l'outillage qualité

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installe Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Installe les paquets (editable) et les dépendances de test
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e src/automatheque -e src/automatheque.schema -e src/automatheque.factrice
+          pip install pytest pytest-cov
+
+      - name: Lance les tests avec couverture
+        run: pytest src --cov=automatheque --cov-report=term-missing
+
+  qualite:
+    name: Qualité (lint, format, types) — rapport
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installe Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Installe les paquets et l'outillage qualité
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e src/automatheque -e src/automatheque.schema -e src/automatheque.factrice
+          pip install ruff mypy
+
+      # NB : ruff et mypy sont volontairement en mode « rapport » (non bloquant)
+      # tant que le nettoyage du code n'est pas réalisé (cf. issue #17).
+      # Une fois le code nettoyé, retirer les « continue-on-error » pour les
+      # rendre bloquants.
+      - name: Lint (ruff check)
+        continue-on-error: true
+        run: ruff check src
+
+      - name: Format (ruff format --check)
+        continue-on-error: true
+        run: ruff format --check src
+
+      - name: Vérification de types (mypy)
+        continue-on-error: true
+        run: mypy src/automatheque/automatheque

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 requirements.txt
 **/.venv
 **/build
+.coverage
+htmlcov/
+coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Hooks pre-commit pour automatheque (cf. issue #16).
+# Installation : `pip install pre-commit && pre-commit install`
+# Lancement manuel sur tout le dépôt : `pre-commit run --all-files`
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      # Lint avec correction automatique
+      - id: ruff
+        args: [--fix]
+      # Formatage
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,33 @@
 packages = ["src/*"]
 version = "0.9.9"
 python-version = "3.11"
+
+# --- Outillage qualité (cf. issue #16) ---
+
+[tool.ruff]
+target-version = "py39"
+# Les setup.py sont générés par monas, on ne les lint/formate pas.
+extend-exclude = ["**/setup.py"]
+
+[tool.ruff.lint]
+# Démarrage volontairement permissif (erreurs, imports inutiles, tri des
+# imports). À durcir progressivement une fois le code nettoyé (cf. issue #17).
+select = ["E", "F", "W", "I"]
+
+[tool.mypy]
+python_version = "3.9"
+ignore_missing_imports = true
+namespace_packages = true
+explicit_package_bases = true
+mypy_path = "src/automatheque"
+
+[tool.pytest.ini_options]
+testpaths = ["src"]
+addopts = "-ra"
+
+[tool.coverage.run]
+branch = true
+source = ["automatheque"]
+
+[tool.coverage.report]
+show_missing = true


### PR DESCRIPTION
## Objectif

Met en place le filet de sécurité (CI + outillage qualité) préalable aux
autres améliorations du dépôt. PR volontairement **config-only** : aucune
modification de code source (le nettoyage du code est suivi dans #17).

fix #16

## Contenu

- **`.github/workflows/ci.yml`** — workflow GitHub Actions :
  - job `tests` : matrice Python 3.9 → 3.12, installation des 3 paquets en
    editable, `pytest` avec couverture (**bloquant**) ;
  - job `qualite` : `ruff check`, `ruff format --check` et `mypy` en mode
    **rapport (non bloquant)** en attendant le nettoyage du code.
- **`pyproject.toml`** (racine) — configuration `ruff` (lint + tri des
  imports), `mypy`, `pytest` et `coverage`.
- **`.pre-commit-config.yaml`** — hooks `ruff`, `ruff-format` et hygiène de
  fichiers.
- **`.gitignore`** — ignore les artefacts de couverture (`.coverage`,
  `htmlcov/`, `coverage.xml`).

## Choix : ruff/mypy en mode rapport

Le code actuel comporte des constats `ruff` (imports inutiles, `except` nus…)
et `mypy` (annotation invalide, types manquants) qui relèvent du nettoyage
**#17**. Pour garder cette PR focalisée et la CI **verte**, ces vérifications
tournent en `continue-on-error`. Elles seront rendues **bloquantes** une fois
#17 traité (retirer les `continue-on-error` dans le workflow).

## Vérification locale

- `pytest src --cov=automatheque` → **2 passés**, couverture ~42 % (pas de
  seuil bloquant pour l'instant, cf. #18).
- `ruff check` / `ruff format --check` / `mypy` → remontent bien leurs
  constats sans faire échouer le job.

## Suite

- #17 : nettoyage qualité (puis durcir ruff/mypy en bloquant).
- #18 : étendre la couverture de tests.