### PR TITLE
chore(ci): ajoute le socle d'intégration continue et l'outillage qualité

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installe Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Installe les paquets (editable) et les dépendances de test
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e src/automatheque -e src/automatheque.schema -e src/automatheque.factrice
+          pip install pytest pytest-cov
+
+      - name: Lance les tests avec couverture
+        run: pytest src --cov=automatheque --cov-report=term-missing
+
+  qualite:
+    name: Qualité (lint, format, types) — rapport
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installe Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Installe les paquets et l'outillage qualité
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e src/automatheque -e src/automatheque.schema -e src/automatheque.factrice
+          pip install ruff mypy
+
+      # NB : ruff et mypy sont volontairement en mode « rapport » (non bloquant)
+      # tant que le nettoyage du code n'est pas réalisé (cf. issue #17).
+      # Une fois le code nettoyé, retirer les « continue-on-error » pour les
+      # rendre bloquants.
+      - name: Lint (ruff check)
+        continue-on-error: true
+        run: ruff check src
+
+      - name: Format (ruff format --check)
+        continue-on-error: true
+        run: ruff format --check src
+
+      - name: Vérification de types (mypy)
+        continue-on-error: true
+        run: mypy src/automatheque/automatheque

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 requirements.txt
 **/.venv
 **/build
+.coverage
+htmlcov/
+coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Hooks pre-commit pour automatheque (cf. issue #16).
+# Installation : `pip install pre-commit && pre-commit install`
+# Lancement manuel sur tout le dépôt : `pre-commit run --all-files`
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      # Lint avec correction automatique
+      - id: ruff
+        args: [--fix]
+      # Formatage
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,33 @@
 packages = ["src/*"]
 version = "0.9.9"
 python-version = "3.11"
+
+# --- Outillage qualité (cf. issue #16) ---
+
+[tool.ruff]
+target-version = "py39"
+# Les setup.py sont générés par monas, on ne les lint/formate pas.
+extend-exclude = ["**/setup.py"]
+
+[tool.ruff.lint]
+# Démarrage volontairement permissif (erreurs, imports inutiles, tri des
+# imports). À durcir progressivement une fois le code nettoyé (cf. issue #17).
+select = ["E", "F", "W", "I"]
+
+[tool.mypy]
+python_version = "3.9"
+ignore_missing_imports = true
+namespace_packages = true
+explicit_package_bases = true
+mypy_path = "src/automatheque"
+
+[tool.pytest.ini_options]
+testpaths = ["src"]
+addopts = "-ra"
+
+[tool.coverage.run]
+branch = true
+source = ["automatheque"]
+
+[tool.coverage.report]
+show_missing = true


### PR DESCRIPTION
Met en place le filet de sécurité préalable aux autres améliorations :
- Workflow GitHub Actions : matrice Python 3.9 -> 3.12, installation des trois paquets en editable, tests pytest avec couverture.
- Configuration ruff (lint + tri des imports) et mypy dans le pyproject racine, ainsi que la configuration pytest/coverage.
- Hooks pre-commit (ruff, ruff-format, hygiène de fichiers).
- Ignore les artefacts de couverture (.coverage, htmlcov, coverage.xml).

ruff et mypy sont volontairement en mode rapport (non bloquant) tant que le nettoyage du code n'est pas réalisé (cf. #17).

fix #16