### PR TITLE
chore: tri des TODO/FIXME (issues thématiques #24–#27)

### DIFF
--- a/src/automatheque.factrice/automatheque/factrice/app/__init__.py
+++ b/src/automatheque.factrice/automatheque/factrice/app/__init__.py
@@ -4,7 +4,7 @@
 
 Application pour envoyer des mails simplement en utilisant la connexion configurée dans config.ini.
 
-TODO pouvoir faire `cat contenu | factrice sujet email`
+TODO(#27) pouvoir faire `cat contenu | factrice sujet email`
 
 Usage:
   factrice [--via-esmtp] <sujet> <adresse_mail_cible> <texte_du_mail>

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -53,12 +53,12 @@ class ExpeditriceSmtp(Expeditrice):
     # Cas 3 : token oauth
     # défaut à false
     oauth=0
-    oauth_cmd=/chemin/vers/script/generation_token # TODO livrer en dépendances ?
+    oauth_cmd=/chemin/vers/script/generation_token # TODO(#27) livrer en dépendances ?
     oauth_client_id=XyXyXyX
     ```
     """
 
-    config: ConfigParser = attr.ib(default=None)  # TODO validator
+    config: ConfigParser = attr.ib(default=None)  # TODO(#24) validator
     s: smtplib.SMTP = attr.ib(init=False)
     preparatrice = attr.ib(init=False, default=PreparatriceSmtp)
 
@@ -141,7 +141,7 @@ class ExpeditriceSmtp(Expeditrice):
 
 @attr.s
 class ExpeditriceEsmtp:
-    config: ConfigParser = attr.ib(default=None)  # TODO validator
+    config: ConfigParser = attr.ib(default=None)  # TODO(#24) validator
 
     def __attrs_post_init__(self):
         self.config = self.config if self.config else charge_configuration()
@@ -155,10 +155,10 @@ class ExpeditriceEsmtp:
         :return: Path du fichier
         """
         if courriel.emetteur is None:
-            courriel.emetteur = "osuser@localhost"  # TODO ?
+            courriel.emetteur = "osuser@localhost"  # TODO(#27) émetteur configurable
 
         date = datetime.now().strftime("%Y%m%d-%H%M%s")
-        # TODO nom fic
+        # TODO(#27) nom fic
         fic = fichier_sortie or Path("/tmp/") / f"{date}_{courriel.sujet}.txt"
         with open(fic, "w") as f:
             contenu = PreparatriceSmtp().prepare(courriel).as_string()
@@ -178,7 +178,7 @@ class ExpeditriceEsmtp:
             process = self.executant.exec(*args, stdin=f)
 
         try:
-            process.check_returncode()  # TODO attention raise !
+            process.check_returncode()  # TODO(#26) attention raise !
         except Exception as e:
             LOGGER.exception(process.stderr)
             # raise e

--- a/src/automatheque.schema/automatheque/schema/texte/courriel.py
+++ b/src/automatheque.schema/automatheque/schema/texte/courriel.py
@@ -28,7 +28,7 @@ class Courriel:
     pieces_jointes: List[Path] = attr.ib(init=False, factory=list, kw_only=True)
     _date_envoi: datetime = attr.ib(
         init=False, default=datetime.now(), kw_only=True
-    )  # TODO vérifier les timezones
+    )  # TODO(#25) vérifier les timezones
     teste_adresse_valide: Callable[[str], Tuple[bool, str]] = attr.ib(
         init=False, default=lambda e: ("@" in e, ""), kw_only=True
     )

--- a/src/automatheque/automatheque/configuration.py
+++ b/src/automatheque/automatheque/configuration.py
@@ -42,7 +42,7 @@ def charge_configuration(fichiers_supplementaires=None, ecraser=False, recharger
                 continue
 
             _charge_fichier_configuration(fichier, charge_configuration.config)
-            break  # TODO sauf si on veut charger les 2 fichiers ?
+            break  # TODO(#27) sauf si on veut charger les 2 fichiers ?
     # Si on veut conserver la configuration de automatheque, alors on charge
     # sa configuration en dernier :
     if not ecraser:
@@ -69,10 +69,10 @@ def _recup_fichier_config_log(config):
     défaut.
     """
     try:
-        # TODO on ne doit pas forcer l'existence de la config 'log'
+        # TODO(#26) on ne doit pas forcer l'existence de la config 'log'
         fichier_config_log = config.get("log", "fichier_config", fallback="log.json")
     except NoOptionError:
-        # TODO créer une exception custom
+        # TODO(#26) créer une exception custom
         msg = """Pas de configuration pour le fichier de log.
         Rappel structure:
         [log]

--- a/src/automatheque/automatheque/greffon/greffon.py
+++ b/src/automatheque/automatheque/greffon/greffon.py
@@ -75,6 +75,6 @@ class Greffon(RegistreGreffons):
         return False
 
     def _signale_appel(self):
-        # TODO log !!!
-        # TODO on devrait mettre une annotation sur tous les appels de type "capacites"
+        # TODO(#26) log !!!
+        # TODO(#26) annoter tous les appels de type "capacites"
         LOGGER.debug(f"Greffon : {self.cle}||{self.identifiant} - debut appel")

--- a/src/automatheque/automatheque/log.py
+++ b/src/automatheque/automatheque/log.py
@@ -77,7 +77,7 @@ def recup_logger(name="automatheque"):
     # Si la configuration a déjà été chargée alors logging est déjà paramétré
     # et charge_configuration() ne fait rien.
     charge_configuration()
-    # TODO pour gagner en perf on peut aussi garder un attribut "deja_joue" par
+    # TODO(#26) pour gagner en perf on peut aussi garder un attribut "deja_joue" par
     # exemple pour éviter d'appeler charge_configuration à chaque fois.
 
     lg = logging.getLogger(name)

--- a/src/automatheque/automatheque/suivi/adaptateurs/repertoire.py
+++ b/src/automatheque/automatheque/suivi/adaptateurs/repertoire.py
@@ -10,11 +10,10 @@ class StockageRepertoire(StockageAbstraite):
     repertoire: Path = attr.ib(default=Path("/tmp"))
 
     def __attrs_post_init__(self):
-        # TODO >= py3.5
         self.repertoire.mkdir(parents=True, exist_ok=True)
 
     def existe(self, reference: str):
-        # TODO mutex pour thread safety
+        # TODO(#25) mutex pour thread safety
         fichier = self.repertoire / reference
         return fichier.exists()
 

--- a/src/automatheque/automatheque/suivi/journal.py
+++ b/src/automatheque/automatheque/suivi/journal.py
@@ -33,7 +33,7 @@ class JournalSuivi:
         Il faut donner en entrée le nom du paramètre qui contient la référence, et la
         decoration sauvegardera "nom_fonction_reference".
 
-        TODO ajouter option pour date.
+        TODO(#27) ajouter option pour date.
         """
         pass
 

--- a/src/automatheque/automatheque/util/dependances_externes.py
+++ b/src/automatheque/automatheque/util/dependances_externes.py
@@ -57,10 +57,7 @@ def verifie_dependance(cle_dependance):
 
 
 def charge_dependance(cle, executable, executable_complet, erreur="", verifie=True):
-    """Charge la dépendance donnée, dans le registre.
-
-    TODO: voir s'il faut utiliser une fabrique et/ou un constructeur ...
-    """
+    """Charge la dépendance donnée, dans le registre."""
     executable = recup_executable(executable, executable_complet)
     executant = Executant(executable)
 
@@ -86,7 +83,7 @@ def recup_executable(nom, chemin_complet):
     :returns: str ou False
     """
     path = shutil.which(nom)
-    # TODO : il faut aussi tester l'execution sans args pour voir si ç march non ?
+    # TODO(#25) : il faut aussi tester l'execution sans args pour voir si ça marche.
     # Si on ne trouve pas l'exécutable on essaie de forcer un chemin classique :
     if path is None:
         path = chemin_complet

--- a/src/automatheque/automatheque/util/fichier.py
+++ b/src/automatheque/automatheque/util/fichier.py
@@ -8,7 +8,7 @@ def enleve_caracteres_invalides(value):
     https://stackoverflow.com/questions/1033424/how-to-remove-bad-path-characters-in-python
     """
     deletechars = '/\:*?"<>|'
-    # TODO tester la plateforme
+    # TODO(#25) tester la plateforme
     deletechars = "/"  # Linux autorise quasiment tout le reste
     try:
         for c in deletechars:

--- a/src/automatheque/automatheque/util/repertoire.py
+++ b/src/automatheque/automatheque/util/repertoire.py
@@ -20,7 +20,7 @@ def mkdir_p(path):
 
     Renvoie une erreur si la cible existe et n'est pas un répertoire.
 
-    TODO déprécier pour Path.mkdir()
+    TODO(#24) déprécier pour Path.mkdir()
     """
     try:
         os.makedirs(path)
@@ -29,10 +29,6 @@ def mkdir_p(path):
             pass
         else:
             raise
-
-
-# Fonction supplémentaire à ajouter :
-# TODO https://peterlyons.com/problog/2009/04/zip-dir-python
 
 
 def supprime(repertoire, force=False):

--- a/src/automatheque/automatheque/util/script.py
+++ b/src/automatheque/automatheque/util/script.py
@@ -1,10 +1,8 @@
 # -*- coding:utf-8 -*-
 """Utilitaire pour faciliter la création de scripts basés sur automatheque.
 
-TODO cookiecutter : ? https://github.com/LucasRGoes/ports-adapters-sample/blob/master/app/settings.py
-
 Il faut pouvoir l'utiliser aussi dans les modules, pas juste dans les scripts.
-TODO !!
+TODO(#24)
 
 Le format que l'on souhaite est le suivant :
 ```
@@ -91,7 +89,7 @@ class ScriptAutomatheque(object):
         self._logger = None
 
     def __repr__(self):
-        """TODO utiliser attrs."""
+        """TODO(#24) utiliser attrs."""
         return "<ScriptAutomatheque {} {} {}>".format(
             self.nom, self.arguments, self.config
         )
@@ -138,7 +136,7 @@ class ScriptAutomatheque(object):
                 self.config = charge_configuration(ecraser=True, recharger=True)
         except KeyError:
             self.config = charge_configuration(ecraser=True, recharger=True)
-        # TODO ici on pourrait aussi merger la conf et les arguments ...
+        # TODO(#27) ici on pourrait aussi merger la conf et les arguments ...
         # dans self.parametres ?
         """
         def merge(dict_1, dict_2):


### PR DESCRIPTION
## Contexte

Dernier item de #17 : tri des ~31 `TODO`/`FIXME` du code. Clôture l'issue.

## Démarche

Les 31 marqueurs (hors tests) ont été classés en 3 catégories :

### 🅰️ Supprimés (4) — obsolètes / bruit
- `suivi/adaptateurs/repertoire.py` — `# TODO >= py3.5` (obsolète, `requires-python >=3.8`)
- `util/dependances_externes.py` — divagation design « fabrique/constructeur ? »
- `util/repertoire.py` — lien blog mort (zip-dir, 2009)
- `util/script.py` — lien cookiecutter spéculatif

### 🅱️ Convertis en `TODO(#NN)` (22) — vraie dette, regroupée en 4 issues
| Issue | Thème | Nb |
|---|---|---|
| #24 | Modernisation (pathlib, attrs, usage hors scripts) | 5 |
| #25 | Robustesse & portabilité (plateforme, deps, thread-safety, timezones) | 4 |
| #26 | Erreurs, exceptions custom & journalisation | 6 |
| #27 | factrice : fonctionnalités & configuration d'envoi | 7 |

Chaque `TODO` du code pointe désormais vers son issue (`TODO(#24)` … `TODO(#27)`), traçable et actionnable.

### 🅲 Conservés (5) — notes utiles
Limites mypy/typing documentées avec liens amont (`greffon/registre.py`), gestion YAML 1.2 (`log.py`), note locale `locate`/`importlib` (`greffon/__init__.py`).

## Vérification
- `ruff` : **aucune erreur introduite** (43 = 43 sur les fichiers touchés).
- `pytest` : **11 passed**.
- Modifications limitées à des commentaires/docstrings (aucun changement de comportement).

Closes #17.