### PR TITLE
docs: documenter le réglage attribution.sessionUrl

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  // Empêche l'ajout du lien de session claude.ai (trailer "Claude-Session"
+  // dans les commits + lien dans le corps des PR) en session web/remote.
+  // Réf. doc : https://code.claude.com/docs/en/claude-code-on-the-web
+  // (réglage "attribution.sessionUrl", requiert Claude Code >= 2.1.182).
   "attribution": {
     "sessionUrl": false
   }


### PR DESCRIPTION
## Objet

Documente le réglage `attribution.sessionUrl: false` déjà présent dans `.claude/settings.json` (ajouté en #23), via un commentaire `//` indiquant son effet et un lien vers la doc officielle.

## Pourquoi
Rendre le fichier auto-explicatif : `sessionUrl: false` supprime le trailer `Claude-Session` des commits et le lien de session claude.ai dans le corps des PR pour les sessions web/remote (requiert Claude Code ≥ 2.1.182).

Aucun changement de comportement — commentaire uniquement.