### PR TITLE
chore: réaligne le monorepo sur monas (v0.11.0) + CI de publication PyPI

### DIFF
--- a/.claude/hooks/git-identity.sh
+++ b/.claude/hooks/git-identity.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Hook SessionStart : restaure l'identité git et la signature SSH de dwwm93
+# dans les sessions Claude Code (web/remote), à CHAQUE démarrage ou reprise.
+#
+# Pourquoi ce hook existe
+# -----------------------
+# Le conteneur cloud est éphémère et un hook « launcher » de la plateforme
+# (hors dépôt) réécrit l'identité git GLOBALE en « Claude <noreply@anthropic.com> »
+# à chaque (re)démarrage de session. On ne peut pas garantir l'ordre d'exécution
+# des hooks ; on écrit donc la configuration au niveau LOCAL du dépôt
+# (.git/config), qui prime toujours sur --global. L'identité dwwm93 gagne donc
+# quel que soit l'ordre.
+#
+# Sûreté pour les autres
+# ----------------------
+# No-op si SIGNING_SSH_KEY est absent (clé fournie uniquement via la config
+# d'environnement de dwwm93). Pour tout autre contributeur, ou en session
+# locale, ce hook ne fait donc rien.
+set -uo pipefail
+
+# Rien à faire si la clé de signature n'est pas dans l'environnement.
+[ -n "${SIGNING_SSH_KEY:-}" ] || exit 0
+command -v ssh-keygen >/dev/null 2>&1 || exit 0
+
+REPO="${CLAUDE_PROJECT_DIR:-$PWD}"
+cd "$REPO" 2>/dev/null || exit 0
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+EMAIL="74361568+dwwm93@users.noreply.github.com"
+NAME="dwwm93"
+SSH_DIR="$HOME/.ssh"
+KEY="$SSH_DIR/commit_signing_key"
+PUB="$KEY.pub"
+ALLOWED="$SSH_DIR/allowed_signers"
+
+# (Re)matérialise la clé privée + publique + allowed_signers depuis l'env.
+umask 077
+mkdir -p "$SSH_DIR"
+chmod 700 "$SSH_DIR"
+printf '%s\n' "$SIGNING_SSH_KEY" >"$KEY"
+ssh-keygen -y -P "" -f "$KEY" >"$PUB" 2>/dev/null || exit 0
+printf '%s %s\n' "$EMAIL" "$(cat "$PUB")" >"$ALLOWED"
+chmod 600 "$KEY"
+chmod 644 "$PUB" "$ALLOWED"
+
+# Config LOCALE au dépôt : prime sur le --global réécrit par la plateforme,
+# indépendamment de l'ordre des hooks SessionStart.
+git config --local user.name "$NAME"
+git config --local user.email "$EMAIL"
+git config --local commit.gpgsign true
+git config --local gpg.format ssh
+git config --local gpg.ssh.program ssh-keygen
+git config --local user.signingkey "$PUB"
+git config --local gpg.ssh.allowedSignersFile "$ALLOWED"
+
+echo "[git-identity] identité+signature dwwm93 rétablies (config locale du dépôt)" >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,33 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  // Empêche l'ajout du lien de session claude.ai (trailer "Claude-Session"
-  // dans les commits + lien dans le corps des PR) en session web/remote.
+
+  // --- Attribution ---------------------------------------------------------
+  // includeCoAuthoredBy=false : supprime la byline "Co-Authored-By: Claude"
+  // dans les commits ET la ligne "🤖 Generated with Claude Code" en bas des PR.
+  // attribution.sessionUrl=false : supprime le trailer "Claude-Session" dans
+  // les commits et le lien de session claude.ai en bas du corps des PR.
   // Réf. doc : https://code.claude.com/docs/en/claude-code-on-the-web
-  // (réglage "attribution.sessionUrl", requiert Claude Code >= 2.1.182).
+  // (sessionUrl requiert Claude Code >= 2.1.182).
+  "includeCoAuthoredBy": false,
   "attribution": {
     "sessionUrl": false
+  },
+
+  // --- Identité / signature des commits (sessions web/remote) --------------
+  // Hook SessionStart commité dans le dépôt : seul type de hook qui s'exécute
+  // en session cloud, à chaque démarrage/reprise. Il rétablit l'identité git
+  // et la signature SSH de dwwm93 (no-op si SIGNING_SSH_KEY est absent, donc
+  // sans effet pour les autres contributeurs ou en local).
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/git-identity.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+# Publie sur PyPI lors du push d'un tag de version (ex. `0.11.0`), tel que
+# créé par `monas bump`. Conforme à la sémantique de `monas publish` : seuls
+# les packages dont la version == tag sont publiés (les packages non bumpés
+# gardent leur ancienne version et sont ignorés ici).
+
+on:
+  push:
+    tags:
+      - "[0-9]*"
+
+jobs:
+  publish:
+    name: Publie ${{ matrix.package }} sur PyPI
+    runs-on: ubuntu-latest
+    # Trusted Publishing (OIDC) : aucun secret, GitHub s'authentifie auprès de
+    # PyPI. Chaque projet PyPI doit déclarer un « trusted publisher » pointant
+    # vers ce dépôt et ce workflow (release.yml).
+    # Pour durcir, on peut ajouter `environment: pypi` ici ET côté PyPI.
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - automatheque
+          - automatheque.schema
+          - automatheque.factrice
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installe Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Détermine la version du package
+        id: ver
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('src/${{ matrix.package }}/pyproject.toml','rb'))['project']['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$VERSION" = "${{ github.ref_name }}" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${{ matrix.package }} est en $VERSION (pas ${{ github.ref_name }}) — non publié pour cette release."
+          fi
+
+      - name: Construit le package
+        if: steps.ver.outputs.publish == 'true'
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --outdir dist "src/${{ matrix.package }}"
+
+      - name: Publie sur PyPI (trusted publishing)
+        if: steps.ver.outputs.publish == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.9.9"
+version = "0.11.0"
 python-version = "3.11"
 
 # --- Outillage qualité (cf. issue #16) ---

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.factrice"
-version = "0.10.1"
+version = "0.11.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "GPLv3.0"}

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -13,10 +13,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Removed
+
+## [0.11.0] - 2026-06-23
+
+Réalignement du monorepo sur la version globale gérée par monas. Les packages
+qui ont réellement changé depuis leur dernière version passent à 0.11.0
+(`automatheque` depuis 0.9.9, `automatheque.factrice` depuis 0.10.1).
+`automatheque.schema` reste en 0.9.7 (aucun changement de code depuis) et
+sautera à la version globale lors de sa prochaine modification.
+
+### Added
+
+* CI : socle d'intégration continue (tests multi-versions, lint/format/types)
+* CI : publication PyPI via tag (trusted publishing OIDC)
+
+### Changed
+
 * Feat: Modifie la gestion des Capacites des Greffons
 * Feat: Ajoute du typing dans le module greffon
 * Feat: Ajoute GreffonAbstrait pour les Greffons qui nécessitent une contrainte d'abstraction
 * Feat: Déclare (à tort) être correctement typé - Travail en cours
+* Nettoyage qualité (typage, excepts ciblés, argument mutable, code mort)
 
 ### Removed
 
@@ -111,5 +129,6 @@ Nouvel utilitaire, pour gérer les dépendances externes.
 
 * Corrige lien entre media et photo
 
-[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/v0.8.10...HEAD
+[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.11.0...HEAD
+[0.11.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.11.0
 [0.8.10]: https://github.com/jaegerbobomb/automatheque/releases/tag/v0.8.10

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.9.9"
+version = "0.11.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
## Contexte

Le dépôt avait dérivé du modèle de versions de **monas** : des bumps manuels avaient
cassé l'invariant `[tool.monas].version == max(versions des packages)` (`factrice`
était passé à 0.10.1 sans mise à jour de la version globale, restée à 0.9.9).

Cette PR réaligne le monorepo sur le fonctionnement natif de monas et ajoute la CI
de publication PyPI (aujourd'hui faite à la main).

## Réalignement des versions

Seuls les packages **réellement modifiés depuis leur dernière version** sont bumpés,
conformément au modèle monas (les autres conservent leur version et sauteront à la
globale lors de leur prochaine modification) :

| Package | Avant | Après | Raison |
|---|---|---|---|
| `automatheque` | 0.9.9 | **0.11.0** | code réel (greffon, configuration, log, util) + tests |
| `automatheque.factrice` | 0.10.1 | **0.11.0** | code réel (`fallback` ConfigParser, exception SMTP ciblée, code mort supprimé) + tests |
| `automatheque.schema` | 0.9.7 | **0.9.7** (inchangé) | uniquement un commentaire modifié → pas de release |
| `[tool.monas].version` | 0.9.9 | **0.11.0** | invariant restauré (globale == max) |

La globale 0.11.0 (minor) est cohérente : `automatheque` apporte des fonctionnalités,
et 0.11.0 > max actuel (0.10.1).

## CI de publication PyPI (`.github/workflows/release.yml`)

- **Déclencheur** : push d'un tag de version (ex. `0.11.0`), tel que créé par `monas bump`.
- **Auth** : Trusted Publishing (OIDC) — aucun secret stocké.
- **Sémantique** : conforme à `monas publish` — seuls les packages dont la version == tag
  sont publiés. Pour cette release, `automatheque` et `automatheque.factrice` seraient
  publiés, `automatheque.schema` (0.9.7) serait ignoré.

## Configuration Claude Code (sessions web)

- `.claude/hooks/git-identity.sh` (hook SessionStart) : rétablit l'identité git et la
  signature SSH de dwwm93 à chaque démarrage/reprise de session cloud, via la config
  **locale** du dépôt (qui prime sur le `--global` réécrit par la plateforme). No-op
  si `SIGNING_SSH_KEY` est absent (sans effet pour les autres contributeurs/local).
- `.claude/settings.json` : `includeCoAuthoredBy:false` + `attribution.sessionUrl:false`.

## ⚠️ À faire avant la première release (hors de cette PR)

La release n'est **pas** déclenchée par cette PR (aucun tag poussé). Quand vous serez prêt :

1. Configurer un *trusted publisher* sur PyPI pour `automatheque` et `automatheque.factrice`
   (owner `jaegerbobomb`, repo `automatheque`, workflow `release.yml`, environment vide).
2. Créer et pousser le tag sur `main` :
   ```bash
   git checkout main && git pull
   git tag -a 0.11.0 -m "0.11.0"
   git push origin 0.11.0
   ```