### PR TITLE
feat(util): décorateur de réessais reessaye (#7)

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `util.reessaye` : décorateur de réessais avec attente croissante
+  (multiplicateur, gigue optionnelle, exceptions ciblées) — cf. #7
+
 ### Changed
 
 ### Removed

--- a/src/automatheque/automatheque/util/__init__.py
+++ b/src/automatheque/automatheque/util/__init__.py
@@ -3,6 +3,9 @@
 # Imports depuis fichier
 from .fichier import enleve_caracteres_invalides
 
+# Imports depuis reessaye
+from .reessaye import reessaye
+
 # Imports depuis repertoire
 from .repertoire import mkdir_p
 
@@ -12,6 +15,8 @@ from .structures_python import dict_merge
 __all__ = [
     # .fichier
     "enleve_caracteres_invalides",
+    # .reessaye
+    "reessaye",
     # .repertoire
     "mkdir_p",
     # .structures_python

--- a/src/automatheque/automatheque/util/reessaye.py
+++ b/src/automatheque/automatheque/util/reessaye.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Décorateur de réessais avec attente croissante.
+
+Besoin récurrent des scripts qui parlent au réseau : réessayer une opération
+instable en patientant de plus en plus longtemps entre les tentatives.
+
+Exemple ::
+
+    @reessaye(tentatives=4, delai=2, multiplicateur=2, exceptions=(ConnectionError,))
+    def appel_api():
+        ...
+
+Avec ces paramètres, ``appel_api`` est tentée jusqu'à 4 fois, avec des pauses
+de 2s, 4s puis 8s entre les essais. Si les 4 essais échouent, la dernière
+exception est relevée telle quelle.
+"""
+
+import functools
+import random
+import time
+
+from automatheque.log import recup_logger
+
+LOGGER = recup_logger(__name__)
+
+
+def reessaye(tentatives=4, delai=2, multiplicateur=2, exceptions=(Exception,), gigue=0):
+    """Décore une fonction pour la réessayer lorsqu'elle lève une exception.
+
+    :param tentatives: nombre total d'essais (>= 1). Si tous échouent, la
+        dernière exception rencontrée est relevée.
+    :param delai: délai initial en secondes avant le premier réessai.
+    :param multiplicateur: facteur appliqué au délai après chaque échec
+        (l'attente croît donc géométriquement).
+    :param exceptions: type d'exception, ou tuple de types, qui déclenche un
+        réessai. Toute autre exception est propagée immédiatement, sans réessai.
+    :param gigue: ajout aléatoire maximal (en secondes) à chaque délai, pour
+        désynchroniser des réessais simultanés. ``0`` (défaut) la désactive.
+    :raise ValueError: si ``tentatives`` < 1, ou si ``delai`` /
+        ``multiplicateur`` / ``gigue`` sont négatifs.
+    """
+    if tentatives < 1:
+        raise ValueError("tentatives doit être >= 1")
+    if delai < 0 or multiplicateur < 0 or gigue < 0:
+        raise ValueError("delai, multiplicateur et gigue doivent être positifs")
+    if not isinstance(exceptions, tuple):
+        exceptions = (exceptions,)
+
+    def decorateur(fonction):
+        # `functools.partial` et autres callables n'ont pas toujours __name__.
+        nom = getattr(fonction, "__name__", repr(fonction))
+
+        @functools.wraps(fonction)
+        def enveloppe(*args, **kwargs):
+            attente = delai
+            for essai in range(1, tentatives + 1):
+                try:
+                    return fonction(*args, **kwargs)
+                except exceptions as exc:
+                    # Dernier essai : on ne patiente plus, on relève l'erreur.
+                    if essai >= tentatives:
+                        LOGGER.warning(
+                            "{} a échoué après {} tentative(s) : {}".format(
+                                nom, tentatives, exc
+                            )
+                        )
+                        raise
+                    pause = attente + (random.uniform(0, gigue) if gigue else 0)
+                    LOGGER.debug(
+                        "{} a échoué (essai {}/{}) : {}. "
+                        "Nouvel essai dans {:.2f}s".format(
+                            nom, essai, tentatives, exc, pause
+                        )
+                    )
+                    time.sleep(pause)
+                    attente *= multiplicateur
+
+        return enveloppe
+
+    return decorateur

--- a/src/automatheque/automatheque/util/reessaye.py
+++ b/src/automatheque/automatheque/util/reessaye.py
@@ -17,8 +17,8 @@ exception est relevée telle quelle.
 """
 
 import functools
-import random
-import time
+from random import uniform
+from time import sleep
 
 from automatheque.log import recup_logger
 
@@ -66,14 +66,14 @@ def reessaye(tentatives=4, delai=2, multiplicateur=2, exceptions=(Exception,), g
                             )
                         )
                         raise
-                    pause = attente + (random.uniform(0, gigue) if gigue else 0)
+                    pause = attente + (uniform(0, gigue) if gigue else 0)
                     LOGGER.debug(
                         "{} a échoué (essai {}/{}) : {}. "
                         "Nouvel essai dans {:.2f}s".format(
                             nom, essai, tentatives, exc, pause
                         )
                     )
-                    time.sleep(pause)
+                    sleep(pause)
                     attente *= multiplicateur
 
         return enveloppe

--- a/src/automatheque/tests/util/test_reessaye.py
+++ b/src/automatheque/tests/util/test_reessaye.py
@@ -1,10 +1,18 @@
 # -*- coding: utf-8 -*-
 """Tests du décorateur de réessais (util/reessaye.py)."""
 
+import importlib
 from unittest.mock import Mock, call, patch
 
 import pytest
 from automatheque.util.reessaye import reessaye
+
+# On patche `sleep`/`uniform` sur l'objet *module* obtenu via importlib :
+# `automatheque.util` réexporte la fonction `reessaye`, qui masque le sous-module
+# du même nom — une cible de patch en chaîne ("automatheque.util.reessaye.sleep")
+# se résout alors vers la fonction (et casse selon la version de Python). Passer
+# par le module explicite est sans ambiguïté sur toutes les versions.
+reessaye_mod = importlib.import_module("automatheque.util.reessaye")
 
 
 def test_reussite_premier_essai_sans_attente():
@@ -12,7 +20,7 @@ def test_reussite_premier_essai_sans_attente():
     fonction = Mock(return_value="ok")
     decoree = reessaye()(fonction)
 
-    with patch("automatheque.util.reessaye.sleep") as sleep:
+    with patch.object(reessaye_mod, "sleep") as sleep:
         assert decoree("a", b=2) == "ok"
 
     fonction.assert_called_once_with("a", b=2)
@@ -26,7 +34,7 @@ def test_reessaie_puis_reussit_avec_delais_croissants():
         tentatives=4, delai=2, multiplicateur=2, exceptions=(ConnectionError,)
     )(fonction)
 
-    with patch("automatheque.util.reessaye.sleep") as sleep:
+    with patch.object(reessaye_mod, "sleep") as sleep:
         assert decoree() == "ok"
 
     assert fonction.call_count == 3
@@ -39,7 +47,7 @@ def test_epuise_les_tentatives_et_releve_la_derniere_exception():
     fonction = Mock(side_effect=[ValueError("boom-1"), ValueError("boom-2"), derniere])
     decoree = reessaye(tentatives=3, delai=1, exceptions=(ValueError,))(fonction)
 
-    with patch("automatheque.util.reessaye.sleep") as sleep:
+    with patch.object(reessaye_mod, "sleep") as sleep:
         with pytest.raises(ValueError) as info:
             decoree()
 
@@ -54,7 +62,7 @@ def test_exception_non_ciblee_se_propage_sans_reessai():
     fonction = Mock(side_effect=KeyError("absente"))
     decoree = reessaye(tentatives=5, exceptions=(ValueError,))(fonction)
 
-    with patch("automatheque.util.reessaye.sleep") as sleep:
+    with patch.object(reessaye_mod, "sleep") as sleep:
         with pytest.raises(KeyError):
             decoree()
 
@@ -67,7 +75,7 @@ def test_accepte_une_exception_unique_hors_tuple():
     fonction = Mock(side_effect=[TimeoutError(), "ok"])
     decoree = reessaye(tentatives=2, delai=1, exceptions=TimeoutError)(fonction)
 
-    with patch("automatheque.util.reessaye.sleep"):
+    with patch.object(reessaye_mod, "sleep"):
         assert decoree() == "ok"
 
     assert fonction.call_count == 2
@@ -80,9 +88,8 @@ def test_gigue_ajoute_au_delai():
         fonction
     )
 
-    cible = "automatheque.util.reessaye.uniform"
-    with patch(cible, return_value=0.5) as uniform:
-        with patch("automatheque.util.reessaye.sleep") as sleep:
+    with patch.object(reessaye_mod, "uniform", return_value=0.5) as uniform:
+        with patch.object(reessaye_mod, "sleep") as sleep:
             assert decoree() == "ok"
 
     uniform.assert_called_once_with(0, 1)

--- a/src/automatheque/tests/util/test_reessaye.py
+++ b/src/automatheque/tests/util/test_reessaye.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Tests du décorateur de réessais (util/reessaye.py)."""
+
+from unittest.mock import Mock, call, patch
+
+import pytest
+from automatheque.util.reessaye import reessaye
+
+
+def test_reussite_premier_essai_sans_attente():
+    """Si la fonction réussit du premier coup, aucune attente n'a lieu."""
+    fonction = Mock(return_value="ok")
+    decoree = reessaye()(fonction)
+
+    with patch("automatheque.util.reessaye.time.sleep") as sleep:
+        assert decoree("a", b=2) == "ok"
+
+    fonction.assert_called_once_with("a", b=2)
+    sleep.assert_not_called()
+
+
+def test_reessaie_puis_reussit_avec_delais_croissants():
+    """Échoue 2 fois puis réussit : 3 appels, pauses 2s puis 4s (multiplicateur=2)."""
+    fonction = Mock(side_effect=[ConnectionError(), ConnectionError(), "ok"])
+    decoree = reessaye(
+        tentatives=4, delai=2, multiplicateur=2, exceptions=(ConnectionError,)
+    )(fonction)
+
+    with patch("automatheque.util.reessaye.time.sleep") as sleep:
+        assert decoree() == "ok"
+
+    assert fonction.call_count == 3
+    assert sleep.call_args_list == [call(2), call(4)]
+
+
+def test_epuise_les_tentatives_et_releve_la_derniere_exception():
+    """Si tous les essais échouent, la dernière exception est relevée."""
+    derniere = ValueError("boom-3")
+    fonction = Mock(side_effect=[ValueError("boom-1"), ValueError("boom-2"), derniere])
+    decoree = reessaye(tentatives=3, delai=1, exceptions=(ValueError,))(fonction)
+
+    with patch("automatheque.util.reessaye.time.sleep") as sleep:
+        with pytest.raises(ValueError) as info:
+            decoree()
+
+    assert info.value is derniere
+    assert fonction.call_count == 3
+    # 3 tentatives => 2 attentes entre les essais.
+    assert sleep.call_count == 2
+
+
+def test_exception_non_ciblee_se_propage_sans_reessai():
+    """Une exception hors de la liste ciblée n'est pas réessayée."""
+    fonction = Mock(side_effect=KeyError("absente"))
+    decoree = reessaye(tentatives=5, exceptions=(ValueError,))(fonction)
+
+    with patch("automatheque.util.reessaye.time.sleep") as sleep:
+        with pytest.raises(KeyError):
+            decoree()
+
+    fonction.assert_called_once()
+    sleep.assert_not_called()
+
+
+def test_accepte_une_exception_unique_hors_tuple():
+    """`exceptions` peut être une classe seule (pas forcément un tuple)."""
+    fonction = Mock(side_effect=[TimeoutError(), "ok"])
+    decoree = reessaye(tentatives=2, delai=1, exceptions=TimeoutError)(fonction)
+
+    with patch("automatheque.util.reessaye.time.sleep"):
+        assert decoree() == "ok"
+
+    assert fonction.call_count == 2
+
+
+def test_gigue_ajoute_au_delai():
+    """La gigue ajoute une part aléatoire bornée au délai de base."""
+    fonction = Mock(side_effect=[ConnectionError(), "ok"])
+    decoree = reessaye(tentatives=2, delai=3, gigue=1, exceptions=(ConnectionError,))(
+        fonction
+    )
+
+    cible = "automatheque.util.reessaye.random.uniform"
+    with patch(cible, return_value=0.5) as uniform:
+        with patch("automatheque.util.reessaye.time.sleep") as sleep:
+            assert decoree() == "ok"
+
+    uniform.assert_called_once_with(0, 1)
+    sleep.assert_called_once_with(3.5)
+
+
+def test_tentatives_invalides_leve_valueerror():
+    """Une configuration aberrante est rejetée à la décoration."""
+    with pytest.raises(ValueError):
+        reessaye(tentatives=0)
+
+    with pytest.raises(ValueError):
+        reessaye(delai=-1)
+
+
+def test_preserve_les_metadonnees_de_la_fonction():
+    """functools.wraps : nom et docstring de la fonction d'origine conservés."""
+
+    @reessaye()
+    def appel_api():
+        """Docstring d'origine."""
+        return 42
+
+    assert appel_api.__name__ == "appel_api"
+    assert appel_api.__doc__ == "Docstring d'origine."
+    assert appel_api() == 42

--- a/src/automatheque/tests/util/test_reessaye.py
+++ b/src/automatheque/tests/util/test_reessaye.py
@@ -12,7 +12,7 @@ def test_reussite_premier_essai_sans_attente():
     fonction = Mock(return_value="ok")
     decoree = reessaye()(fonction)
 
-    with patch("automatheque.util.reessaye.time.sleep") as sleep:
+    with patch("automatheque.util.reessaye.sleep") as sleep:
         assert decoree("a", b=2) == "ok"
 
     fonction.assert_called_once_with("a", b=2)
@@ -26,7 +26,7 @@ def test_reessaie_puis_reussit_avec_delais_croissants():
         tentatives=4, delai=2, multiplicateur=2, exceptions=(ConnectionError,)
     )(fonction)
 
-    with patch("automatheque.util.reessaye.time.sleep") as sleep:
+    with patch("automatheque.util.reessaye.sleep") as sleep:
         assert decoree() == "ok"
 
     assert fonction.call_count == 3
@@ -39,7 +39,7 @@ def test_epuise_les_tentatives_et_releve_la_derniere_exception():
     fonction = Mock(side_effect=[ValueError("boom-1"), ValueError("boom-2"), derniere])
     decoree = reessaye(tentatives=3, delai=1, exceptions=(ValueError,))(fonction)
 
-    with patch("automatheque.util.reessaye.time.sleep") as sleep:
+    with patch("automatheque.util.reessaye.sleep") as sleep:
         with pytest.raises(ValueError) as info:
             decoree()
 
@@ -54,7 +54,7 @@ def test_exception_non_ciblee_se_propage_sans_reessai():
     fonction = Mock(side_effect=KeyError("absente"))
     decoree = reessaye(tentatives=5, exceptions=(ValueError,))(fonction)
 
-    with patch("automatheque.util.reessaye.time.sleep") as sleep:
+    with patch("automatheque.util.reessaye.sleep") as sleep:
         with pytest.raises(KeyError):
             decoree()
 
@@ -67,7 +67,7 @@ def test_accepte_une_exception_unique_hors_tuple():
     fonction = Mock(side_effect=[TimeoutError(), "ok"])
     decoree = reessaye(tentatives=2, delai=1, exceptions=TimeoutError)(fonction)
 
-    with patch("automatheque.util.reessaye.time.sleep"):
+    with patch("automatheque.util.reessaye.sleep"):
         assert decoree() == "ok"
 
     assert fonction.call_count == 2
@@ -80,9 +80,9 @@ def test_gigue_ajoute_au_delai():
         fonction
     )
 
-    cible = "automatheque.util.reessaye.random.uniform"
+    cible = "automatheque.util.reessaye.uniform"
     with patch(cible, return_value=0.5) as uniform:
-        with patch("automatheque.util.reessaye.time.sleep") as sleep:
+        with patch("automatheque.util.reessaye.sleep") as sleep:
             assert decoree() == "ok"
 
     uniform.assert_called_once_with(0, 1)


### PR DESCRIPTION
Closes #7.

## Quoi

Nouveau module `automatheque.util.reessaye` : un décorateur qui réessaie une fonction lorsqu'elle lève une exception, avec attente croissante.

```python
from automatheque.util import reessaye

@reessaye(tentatives=4, delai=2, multiplicateur=2, exceptions=(ConnectionError,))
def appel_api():
    ...
```

Ici `appel_api` est tentée jusqu'à 4 fois, avec des pauses de 2s, 4s puis 8s. Si les 4 essais échouent, **la dernière exception est relevée telle quelle**.

## API

| Paramètre | Rôle | Défaut |
|---|---|---|
| `tentatives` | nombre total d'essais (≥ 1) | `4` |
| `delai` | délai initial (s) avant le 1ᵉʳ réessai | `2` |
| `multiplicateur` | facteur appliqué au délai après chaque échec | `2` |
| `exceptions` | type(s) d'exception qui déclenchent un réessai ; les autres se propagent immédiatement | `(Exception,)` |
| `gigue` | ajout aléatoire max (s) à chaque délai, pour désynchroniser des réessais simultanés ; `0` la désactive | `0` |

Notes :
- vocabulaire **français** (`multiplicateur`, `gigue`) pour rester cohérent avec le reste du code ;
- valide ses paramètres dès la décoration (`ValueError` si `tentatives < 1` ou valeurs négatives) ;
- `functools.wraps` (nom/docstring préservés) ; robuste aux callables sans `__name__` (ex. `functools.partial`) ;
- exposé dans `util/__init__.py` (`__all__`).

## Tests

8 tests (`temps`/`gigue` mockés, donc instantanés) : réussite immédiate, escalade des délais (`2s, 4s`), épuisement + relevé de la dernière exception, exception non ciblée propagée sans réessai, exception unique hors tuple, gigue, validation des paramètres, préservation des métadonnées.

Suite complète `automatheque` : **16/16 verts**, `ruff check`/`format` OK.

## Suite

À réutiliser ensuite dans `factrice` (envoi SMTP) et le futur client HTTP (#11).