### PR TITLE
ci(factrice): lower-bound testing des planchers intra-dépôt (#33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,65 @@ jobs:
       - name: Lance les tests avec couverture
         run: pytest src --cov=automatheque --cov-report=term-missing
 
+  tests-plancher:
+    # Lower-bound testing : le job « tests » ci-dessus installe les paquets
+    # intra-dépôt en editable, donc les planchers de version déclarés par
+    # factrice (ex. `automatheque>=0.9.6`) ne sont jamais réellement éprouvés.
+    # Ici on installe explicitement ces planchers depuis PyPI puis on lance les
+    # tests de factrice : on garantit ainsi que les planchers sont *vrais*
+    # (pas de régression à la version minimale annoncée), au lieu d'une simple
+    # affirmation. Cf. #33.
+    name: Tests factrice contre les versions planchers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installe Python 3.9 (plus basse version supportée par la CI)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Installe les planchers déclarés par factrice (depuis PyPI)
+        # Les planchers sont *dérivés* du pyproject de factrice (et non codés en
+        # dur ici) : si un plancher est relevé, ou s'il référence une version
+        # non publiée, ce job suit automatiquement / casse — ce qui est le but.
+        run: |
+          python -m pip install --upgrade pip tomli
+          python - <<'PY'
+          import re
+          import subprocess
+          import sys
+
+          try:
+              import tomllib
+          except ModuleNotFoundError:  # Python < 3.11
+              import tomli as tomllib
+
+          chemin = "src/automatheque.factrice/pyproject.toml"
+          with open(chemin, "rb") as f:
+              data = tomllib.load(f)
+
+          pins = []
+          for dep in data["project"]["dependencies"]:
+              # On ne traite que les dépendances intra-dépôt (préfixe automatheque).
+              if not re.match(r"\s*automatheque", dep):
+                  continue
+              m = re.match(r"\s*([A-Za-z0-9_.\-]+)\s*>=\s*([0-9][^,;\s]*)", dep)
+              assert m, "Dépendance intra-dépôt sans plancher '>=' : {!r}".format(dep)
+              pins.append("{}=={}".format(m.group(1), m.group(2)))
+
+          print("Planchers installés depuis PyPI :", pins)
+          subprocess.check_call([sys.executable, "-m", "pip", "install", *pins])
+          PY
+
+      - name: Installe factrice depuis les sources (sans toucher aux planchers)
+        run: |
+          pip install --no-deps ./src/automatheque.factrice
+          pip install pytest
+
+      - name: Tests factrice contre les planchers
+        run: pytest src/automatheque.factrice/tests -q
+
   qualite:
     name: Qualité (lint, format, types) — rapport
     runs-on: ubuntu-latest

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -8,7 +8,11 @@ requires-python = ">=3.8"
 readme = "README.md"
 dependencies = [
     "automatheque>=0.9.6",
-    "automatheque.schema>=0.9.5",
+    # 0.9.6 est la plus ancienne version publiée d'automatheque.schema ; le
+    # plancher précédent (>=0.9.5) référençait une version jamais publiée. Le
+    # job CI « tests-plancher » valide que factrice fonctionne contre ces
+    # planchers.
+    "automatheque.schema>=0.9.6",
 ]
 
 [project.urls]


### PR DESCRIPTION
Closes #33.

## Contexte

Le job CI `tests` installe les paquets du monorepo en `editable` (version courante 0.11.0). Les **planchers de version** déclarés par factrice (`automatheque>=0.9.6`, `automatheque.schema>=…`) ne sont donc **jamais réellement éprouvés** : ils restent une affirmation, pas une garantie.

> Note de recadrage (cf. #33) : un plancher **sous** la version courante est normal et sain (c'est la version minimale compatible, pas la dernière). L'objectif n'est pas de monter les planchers, mais de **prouver** qu'ils sont vrais.

## Ce que fait cette PR

**1. Corrige un plancher invalide** révélé par la démarche :
`automatheque.schema>=0.9.5` référençait une version **jamais publiée** (la plus ancienne sur PyPI est `0.9.6`). Corrigé en `>=0.9.6`.

**2. Ajoute le job CI `tests-plancher`** (*lower-bound testing*) :
- **dérive** les planchers du `pyproject` de factrice (pas de valeurs codées en dur → si un plancher bouge ou pointe une version non publiée, le job suit / casse, ce qui est le but) ;
- installe ces planchers **depuis PyPI** ;
- installe factrice **depuis les sources** avec `--no-deps` (sans remonter les planchers) ;
- lance les tests de factrice contre ces versions minimales.

## Vérification

Simulé localement (env isolé `uv`) : `automatheque==0.9.6` + `automatheque.schema==0.9.6` depuis PyPI + factrice depuis les sources → **tests factrice verts (2/2)**. La logique de dérivation produit bien `['automatheque==0.9.6', 'automatheque.schema==0.9.6']`, et le YAML est valide.

## Hors scope (notés dans #33)

Lower-bound testing des dépendances **externes** non bornées (`docopt`, `pytz`, `pyyaml`, `attrs`) ; synchronisation éventuelle des planchers via `monas`.