### PR TITLE
chore(packaging): aligne la baseline Python sur >=3.9 (#32)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,18 @@
 [tool.monas]
 packages = ["src/*"]
 version = "0.11.0"
+# Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
+# pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
+# 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.
+# ruff/mypy ciblent volontairement 3.9 (le plancher) pour détecter toute
+# incompatibilité avec la plus ancienne version supportée. Cf. #32.
 python-version = "3.11"
 
 # --- Outillage qualité (cf. issue #16) ---
 
 [tool.ruff]
+# Cible le plancher supporté (cf. requires-python = ">=3.9") afin de repérer
+# l'usage de syntaxe trop récente pour 3.9.
 target-version = "py39"
 # Les setup.py sont générés par monas, on ne les lint/formate pas.
 extend-exclude = ["**/setup.py"]

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -4,8 +4,15 @@ version = "0.11.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "GPLv3.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
+classifiers = [
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = [
     "automatheque>=0.9.6",
     # 0.9.6 est la plus ancienne version publiée d'automatheque.schema ; le

--- a/src/automatheque.schema/pyproject.toml
+++ b/src/automatheque.schema/pyproject.toml
@@ -4,8 +4,15 @@ version = "0.9.7"
 description = "Domaine pour des classes courantes et partagées"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "GPLv3.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
+classifiers = [
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = [
     "attrs",
 ]

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Packaging : `requires-python` passe à `>=3.9` (3.8 est en fin de vie et
+  n'était plus testé) et ajout des classifiers trove `Python :: 3.9..3.12`,
+  pour une baseline Python unique et cohérente — cf. #32
+
 ### Removed
 
 ## [0.11.0] - 2026-06-23

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -6,8 +6,15 @@ authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },
 ]
 license = { text = "GPLv3.0" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
+classifiers = [
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = [
     "docopt",
     "pytz",


### PR DESCRIPTION
Closes #32.

## Problème

Le dépôt déclarait **quatre** baselines Python divergentes : la promesse `requires-python>=3.8` n'était ni testée (la matrice CI démarre à 3.9) ni cohérente avec l'outillage, et 3.8 est en fin de vie depuis octobre 2024.

| Endroit | Avant | Après |
|---|---|---|
| `src/*/pyproject.toml` → `requires-python` (×3) | `>=3.8` | **`>=3.9`** |
| `[tool.ruff].target-version` | `py39` | `py39` (inchangé) |
| `[tool.mypy].python_version` | `3.9` | `3.9` (inchangé) |
| `[tool.monas].python-version` | `3.11` | `3.11` (inchangé, **documenté**) |
| classifiers trove `Python :: 3.x` | absents | **ajoutés (3.9 → 3.12)** |

## Décision

Baseline unique retenue : **`>=3.9`** (plus basse version non-EOL, déjà ciblée par ruff/mypy et la matrice CI → aucun churn, aucune perte d'utilisateur réel). **Montée à 3.11 remise à plus tard.**

## Détail

- `requires-python` aligné à `>=3.9` dans les 3 paquets.
- Classifiers trove `Programming Language :: Python :: 3.9..3.12` (+ `3 :: Only`) ajoutés aux 3 paquets — utile pour PyPI. *(Le champ `license`/SPDX reste hors scope : cf. #20.)*
- `ruff (py39)` et `mypy (3.9)` ciblent **volontairement le plancher** pour détecter toute syntaxe trop récente pour 3.9 — inchangés mais désormais commentés.
- `[tool.monas].python-version=3.11` documenté comme **interpréteur de dev**, distinct du plancher supporté.

## Vérification

- Parsing TOML des 4 fichiers OK ; `requires-python` identique (`>=3.9`) dans les 3 paquets ; 5 classifiers chacun.
- Suite de tests `automatheque` : **16/16**.
- Compatibilité 3.9 déjà prouvée : `main` passe la CI sur 3.9 → 3.12 (aucun code Python modifié ici).