### PR TITLE
docs(changelog): CHANGELOG pour factrice et schema (#34)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -1,0 +1,46 @@
+# Changelog — automatheque.factrice
+
+<!-- markdownlint-disable MD024 -->
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> Ce journal a été introduit avec la version 0.11.0 (cf. #34). Les entrées des
+> versions antérieures sont reconstituées depuis l'historique git et peuvent
+> donc être moins détaillées.
+
+## [Unreleased]
+
+### Changed
+
+* Corrige le plancher de dépendance `automatheque.schema` (`>=0.9.5` →
+  `>=0.9.6`, plus ancienne version réellement publiée) et ajoute un job CI
+  « tests-plancher » qui éprouve factrice contre ses versions planchers — cf. #33
+
+## [0.11.0] - 2026-06-23
+
+Réalignement sur la version globale du monorepo gérée par monas.
+
+### Added
+
+* Tests de `expedition`
+
+### Changed
+
+* `expedition.py` : repli (`fallback`) sur `ConfigParser`, exception SMTP
+  ciblée à la place d'un `except` trop large, suppression de code mort
+* Nettoyage qualité (typage, `except` ciblés, argument par défaut mutable)
+
+## [0.10.1] - 2023-11-02
+
+### Added
+
+* Gestion de l'envoi via ESMTP (`ExpeditriceEsmtp`)
+
+## [0.10.0] - 2023-10-31
+
+### Added
+
+* Première version fonctionnelle d'envoi de mail simple (`ExpeditriceSmtp`)

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -1,0 +1,37 @@
+# Changelog — automatheque.schema
+
+<!-- markdownlint-disable MD024 -->
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> Ce journal a été introduit a posteriori (cf. #34). Les entrées sont
+> reconstituées depuis l'historique git et peuvent donc être moins détaillées.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Removed
+
+## [0.9.7] - 2023-10-31
+
+### Changed
+
+* `courriel` : l'émetteur devient facultatif dans le constructeur de `Courriel`
+  (il est récupéré par défaut lors de l'envoi via `factrice`)
+
+## [0.9.6] - 2023-10-31
+
+### Added
+
+* `courriel` : date par défaut
+* Marqueur `py.typed` (PEP 561) empaqueté via `MANIFEST.in`
+
+### Changed
+
+* `courriel` : renommage d'une propriété


### PR DESCRIPTION
Closes #34.

## Contexte

Seul `automatheque` avait un CHANGELOG ; `factrice` et `schema` n'en avaient pas, alors qu'ils sont publiables et que `factrice` a été bumpé en 0.11.0 avec de vrais changements.

## Choix

**Un CHANGELOG par paquet** (cohérent avec le versioning indépendant de monas), au format *Keep a Changelog* déjà utilisé par `automatheque`.

L'historique est **reconstitué depuis git** (commits de bump + features), avec une note de transparence en tête de chaque fichier puisqu'il est rédigé a posteriori.

- `src/automatheque.factrice/CHANGELOG` : `0.10.0` → `0.10.1` → `0.11.0`, plus `Unreleased` (correctif de plancher `schema` de #33).
- `src/automatheque.schema/CHANGELOG` : `0.9.6`, `0.9.7`, plus `Unreleased`.

## Hors scope

- Format/dates des versions antérieures : reconstitués au mieux depuis git (dates des commits de bump).
- Documentation du process de tenue du CHANGELOG (point optionnel de #34) : non traité ici.
- `requires-python>=3.9` (#32) : volontairement non mentionné, c'est l'objet de la PR #37.

## Vérification

Les deux fichiers suivent le format de `automatheque/CHANGELOG` ; chaque paquet publiable a désormais un journal reflétant au moins sa version courante. Aucun code modifié.