### PR TITLE
feat(script): alias court `script` pour `script_automatheque`

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `util.reessaye` : décorateur de réessais avec attente croissante
   (multiplicateur, gigue optionnelle, exceptions ciblées) — cf. #7
+* `util.script` : alias court `script` pour `script_automatheque`
+  (`@script(__doc__, __version__)`), le nom canonique restant disponible.
 
 ### Changed
 

--- a/src/automatheque/automatheque/util/script.py
+++ b/src/automatheque/automatheque/util/script.py
@@ -17,7 +17,9 @@ Options:
 '''
 __version__ = '0.1a'  # ou importer depuis mon_package.__version__
 
-@script_automatheque(__doc__, __version__)
+from automatheque.util.script import script  # alias court de script_automatheque
+
+@script(__doc__, __version__)
 def main(..., _script=None):
     # code à exécuter
     # _script est un objet `ScriptAutomatheque`
@@ -27,6 +29,9 @@ if __name__ == '__main__':
     main(...)
 ```
 Cela déclenche les logs de début, de fin, parse les arguments etc.
+
+``script`` est un alias court de ``script_automatheque`` : les deux noms sont
+équivalents et exportés depuis ``automatheque.util.script``.
 """
 
 import sys
@@ -166,3 +171,8 @@ class ScriptAutomatheque(object):
                 self.nom, datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%s")
             )
         )
+
+
+# Alias court : `@script(...)` se lit mieux que `@script_automatheque(...)`.
+# Le nom canonique reste disponible (rétrocompatibilité).
+script = script_automatheque


### PR DESCRIPTION
## Quoi

Ajoute un alias court **`script`** pour le décorateur `script_automatheque`, pour un usage plus lisible :

```python
from automatheque.util.script import script

@script(__doc__, __version__)
def main(..., _script=None):
    ...
```

- Le nom canonique `script_automatheque` reste exporté → **100 % rétrocompatible** (`from automatheque.util.script import script_automatheque` continue de marcher, p. ex. dans `factrice`).
- Exemple d'usage en en-tête de `util/script.py` mis à jour + entrée CHANGELOG.

## Choix de nommage

`script` plutôt que `app` : `app` (façon Typer/FastAPI) désignerait un **objet application** auquel on accroche des commandes, alors qu'ici c'est une **fabrique de décorateur** appelée une fois sur `main`. `script` est plus honnête.

## Vérification

- `from automatheque.util.script import script` → `script is script_automatheque` ✅
- Suite `automatheque` : **16/16**.
- `ruff` : aucune nouvelle alerte (les 2 alertes du fichier — `I001`, `NoOptionError` inutilisé — préexistent à l'identique sur `main`, dette #17, laissées intactes pour un diff focalisé).

## Note de design (suite séparée)

L'emplacement de cette API phare sous `util/` mérite réflexion (cf. discussion) : un `automatheque.script` de plus haut niveau serait plus visible. Ce serait un **déplacement avec shim de rétrocompat**, donc hors scope de cette PR — à capturer dans une issue dédiée (recoupe #5).