### PR TITLE
docs(changelog): prépare la release 0.11.0 (replie Unreleased)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,13 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-* Corrige le plancher de dépendance `automatheque.schema` (`>=0.9.5` →
-  `>=0.9.6`, plus ancienne version réellement publiée) et ajoute un job CI
-  « tests-plancher » qui éprouve factrice contre ses versions planchers — cf. #33
-
-## [0.11.0] - 2026-06-23
+## [0.11.0] - 2026-06-29
 
 Réalignement sur la version globale du monorepo gérée par monas.
 
@@ -32,6 +26,11 @@ Réalignement sur la version globale du monorepo gérée par monas.
 * `expedition.py` : repli (`fallback`) sur `ConfigParser`, exception SMTP
   ciblée à la place d'un `except` trop large, suppression de code mort
 * Nettoyage qualité (typage, `except` ciblés, argument par défaut mutable)
+* Packaging : `requires-python` passe à `>=3.9` + classifiers trove
+  `Python :: 3.9..3.12` — cf. #32
+* Corrige le plancher de dépendance `automatheque.schema` (`>=0.9.5` →
+  `>=0.9.6`, plus ancienne version réellement publiée) et ajoute un job CI
+  « tests-plancher » qui éprouve factrice contre ses versions planchers — cf. #33
 
 ## [0.10.1] - 2023-11-02
 

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Packaging : `requires-python` passe à `>=3.9` + classifiers trove
+  `Python :: 3.9..3.12` — cf. #32. (Changement de métadonnées non encore
+  publié : sera embarqué au prochain bump de `schema`.)
+
 ### Removed
 
 ## [0.9.7] - 2023-10-31

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -11,20 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* `util.reessaye` : décorateur de réessais avec attente croissante
-  (multiplicateur, gigue optionnelle, exceptions ciblées) — cf. #7
-* `util.script` : alias court `script` pour `script_automatheque`
-  (`@script(__doc__, __version__)`), le nom canonique restant disponible.
-
 ### Changed
-
-* Packaging : `requires-python` passe à `>=3.9` (3.8 est en fin de vie et
-  n'était plus testé) et ajout des classifiers trove `Python :: 3.9..3.12`,
-  pour une baseline Python unique et cohérente — cf. #32
 
 ### Removed
 
-## [0.11.0] - 2026-06-23
+## [0.11.0] - 2026-06-29
 
 Réalignement du monorepo sur la version globale gérée par monas. Les packages
 qui ont réellement changé depuis leur dernière version passent à 0.11.0
@@ -34,11 +25,18 @@ sautera à la version globale lors de sa prochaine modification.
 
 ### Added
 
+* `util.reessaye` : décorateur de réessais avec attente croissante
+  (multiplicateur, gigue optionnelle, exceptions ciblées) — cf. #7
+* `util.script` : alias court `script` pour `script_automatheque`
+  (`@script(__doc__, __version__)`), le nom canonique restant disponible.
 * CI : socle d'intégration continue (tests multi-versions, lint/format/types)
 * CI : publication PyPI via tag (trusted publishing OIDC)
 
 ### Changed
 
+* Packaging : `requires-python` passe à `>=3.9` (3.8 est en fin de vie et
+  n'était plus testé) et ajout des classifiers trove `Python :: 3.9..3.12`,
+  pour une baseline Python unique et cohérente — cf. #32
 * Feat: Modifie la gestion des Capacites des Greffons
 * Feat: Ajoute du typing dans le module greffon
 * Feat: Ajoute GreffonAbstrait pour les Greffons qui nécessitent une contrainte d'abstraction


### PR DESCRIPTION
Prépare le tag `0.11.0` : le HEAD de `main` reflétera exactement l'état 0.11.0, plus besoin de chercher « le bon commit ».

## Changements

- **automatheque `[0.11.0]`** ← replie l'`[Unreleased]` : `reessaye` (#7), alias `script` (#40), `requires-python>=3.9` + classifiers (#32), en plus du réalignement et de la CI déjà listés. Date → **2026-06-29**.
- **factrice `[0.11.0]`** ← replie : `requires-python>=3.9` (#32) + correctif de plancher `schema` (#33). Date → **2026-06-29**.
- **schema** : **inchangé en 0.9.7** (le tag `0.11.0` le saute, il est déjà sur PyPI). Le changement de métadonnées #32 (`requires-python>=3.9`) est noté en **`[Unreleased]`** — il sera publié au prochain bump de `schema`.

## ⚠️ Décision en attente — `schema`

`schema` a reçu une modif de **métadonnées** via #32 (`requires-python` `>=3.8`→`>=3.9`) **sans bump de version**. Conséquence : le `0.9.7` de `main` diffère du `0.9.7` publié sur PyPI, et le tag `0.11.0` ne le republiera pas.

Deux options (à toi) :
1. **Laisser tel quel** (recommandé si tu veux release vite) : la modif part au prochain bump de `schema`. Divergence bénigne.
2. **Bump `schema` → 0.11.0** : aligne les 3 paquets sur la globale (cohérent avec la logique monas « paquet modifié → version globale ») et le tag `0.11.0` publiera **aussi** `schema`. Je replie alors son `[Unreleased]` dans un `[0.11.0]`.

Dis-moi si tu veux l'option 2 et je l'ajoute à cette PR.

## Après merge

```bash
git checkout main && git pull
git tag -a 0.11.0 -m "0.11.0"   # sans préfixe v : le workflow matche [0-9]*
git push origin 0.11.0
```