### PR TITLE
feat(essai): harness de test pour les scripts @script_automatheque (#46)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,13 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-* Corrige le plancher de dépendance `automatheque.schema` (`>=0.9.5` →
-  `>=0.9.6`, plus ancienne version réellement publiée) et ajoute un job CI
-  « tests-plancher » qui éprouve factrice contre ses versions planchers — cf. #33
-
-## [0.11.0] - 2026-06-23
+## [0.11.0] - 2026-06-29
 
 Réalignement sur la version globale du monorepo gérée par monas.
 
@@ -32,6 +26,11 @@ Réalignement sur la version globale du monorepo gérée par monas.
 * `expedition.py` : repli (`fallback`) sur `ConfigParser`, exception SMTP
   ciblée à la place d'un `except` trop large, suppression de code mort
 * Nettoyage qualité (typage, `except` ciblés, argument par défaut mutable)
+* Packaging : `requires-python` passe à `>=3.9` + classifiers trove
+  `Python :: 3.9..3.12` — cf. #32
+* Corrige le plancher de dépendance `automatheque.schema` (`>=0.9.5` →
+  `>=0.9.6`, plus ancienne version réellement publiée) et ajoute un job CI
+  « tests-plancher » qui éprouve factrice contre ses versions planchers — cf. #33
 
 ## [0.10.1] - 2023-11-02
 

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Packaging : `requires-python` passe à `>=3.9` + classifiers trove
+  `Python :: 3.9..3.12` — cf. #32. (Changement de métadonnées non encore
+  publié : sera embarqué au prochain bump de `schema`.)
+
 ### Removed
 
 ## [0.9.7] - 2023-10-31

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `automatheque.essai` : harness de test des scripts `@script_automatheque`
+  (`execute_script`, `ecris_config`, `reinitialise_configuration`) — cf. #46
+
 ### Changed
 
 ### Removed

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -11,20 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* `util.reessaye` : décorateur de réessais avec attente croissante
-  (multiplicateur, gigue optionnelle, exceptions ciblées) — cf. #7
-* `util.script` : alias court `script` pour `script_automatheque`
-  (`@script(__doc__, __version__)`), le nom canonique restant disponible.
-
 ### Changed
-
-* Packaging : `requires-python` passe à `>=3.9` (3.8 est en fin de vie et
-  n'était plus testé) et ajout des classifiers trove `Python :: 3.9..3.12`,
-  pour une baseline Python unique et cohérente — cf. #32
 
 ### Removed
 
-## [0.11.0] - 2026-06-23
+## [0.11.0] - 2026-06-29
 
 Réalignement du monorepo sur la version globale gérée par monas. Les packages
 qui ont réellement changé depuis leur dernière version passent à 0.11.0
@@ -34,11 +25,18 @@ sautera à la version globale lors de sa prochaine modification.
 
 ### Added
 
+* `util.reessaye` : décorateur de réessais avec attente croissante
+  (multiplicateur, gigue optionnelle, exceptions ciblées) — cf. #7
+* `util.script` : alias court `script` pour `script_automatheque`
+  (`@script(__doc__, __version__)`), le nom canonique restant disponible.
 * CI : socle d'intégration continue (tests multi-versions, lint/format/types)
 * CI : publication PyPI via tag (trusted publishing OIDC)
 
 ### Changed
 
+* Packaging : `requires-python` passe à `>=3.9` (3.8 est en fin de vie et
+  n'était plus testé) et ajout des classifiers trove `Python :: 3.9..3.12`,
+  pour une baseline Python unique et cohérente — cf. #32
 * Feat: Modifie la gestion des Capacites des Greffons
 * Feat: Ajoute du typing dans le module greffon
 * Feat: Ajoute GreffonAbstrait pour les Greffons qui nécessitent une contrainte d'abstraction

--- a/src/automatheque/automatheque/essai.py
+++ b/src/automatheque/automatheque/essai.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Harness de test pour les scripts ``@script_automatheque``.
+
+Tester un script décoré demanderait sinon de bricoler ``sys.argv``, la
+configuration et le logger à la main. Ce module permet d'exécuter un script
+décoré avec un ``argv`` contrôlé et d'inspecter l'objet
+:class:`~automatheque.util.script.ScriptAutomatheque` produit (arguments parsés,
+configuration chargée) ainsi que la valeur de retour.
+
+Exemple ::
+
+    from automatheque.essai import execute_script
+
+    DOC = '''Mon script.
+
+    Usage:
+      prog [--action] [--config=<fichier>]
+
+    Options:
+      --action            Réalise l'action.
+      --config=<fichier>  Fichier de configuration.
+    '''
+
+    def main(_script=None):
+        return _script.arguments["--action"]
+
+    resultat, script = execute_script(DOC, main, argv=["--action"])
+    assert resultat is True
+    assert script.arguments["--action"] is True
+"""
+
+import sys
+from collections import namedtuple
+from pathlib import Path
+
+from automatheque.configuration import charge_configuration
+from automatheque.util.script import script_automatheque
+
+__all__ = [
+    "ResultatScript",
+    "execute_script",
+    "reinitialise_configuration",
+    "ecris_config",
+]
+
+#: Valeur de retour de :func:`execute_script` : ``(resultat, script)``.
+ResultatScript = namedtuple("ResultatScript", ["resultat", "script"])
+
+
+def reinitialise_configuration():
+    """Oublie la configuration globale mise en cache par ``charge_configuration``.
+
+    Utile entre deux tests : ``charge_configuration`` mémorise son résultat dans
+    un attribut de fonction, qui fuiterait sinon d'un test à l'autre.
+    """
+    if hasattr(charge_configuration, "config"):
+        del charge_configuration.config
+
+
+def ecris_config(chemin, contenu):
+    """Écrit ``contenu`` (un ``.ini``) dans ``chemin`` ; renvoie le chemin (str).
+
+    Pratique avec le ``tmp_path`` de pytest pour fabriquer une configuration
+    jetable à passer via ``argv=["--config", chemin]``.
+    """
+    chemin = Path(chemin)
+    chemin.write_text(contenu, encoding="utf-8")
+    return str(chemin)
+
+
+def execute_script(doc, fonction, argv=None, version=None, reinitialise=True):
+    """Décore ``fonction`` avec ``script_automatheque`` et l'exécute avec ``argv``.
+
+    :param doc: la chaîne d'usage docopt (le ``__doc__`` du script).
+    :param fonction: la fonction à décorer ; elle doit accepter ``_script``.
+    :param argv: arguments de ligne de commande (sans le nom du programme).
+    :param version: version éventuelle passée à docopt.
+    :param reinitialise: si vrai (défaut), oublie la configuration en cache avant
+        l'exécution, pour isoler les tests les uns des autres.
+    :return: un :class:`ResultatScript` ``(resultat, script)`` où ``resultat`` est
+        la valeur renvoyée par ``fonction`` et ``script`` l'objet
+        :class:`~automatheque.util.script.ScriptAutomatheque` (``.arguments``,
+        ``.config``…).
+    """
+    if reinitialise:
+        reinitialise_configuration()
+
+    capture = {}
+
+    def fonction_capturante(*args, _script=None, **kwds):
+        capture["script"] = _script
+        return fonction(*args, _script=_script, **kwds)
+
+    # `script_automatheque` lit sys.argv et charge la config dès la décoration,
+    # d'où le pilotage de sys.argv autour de cette ligne.
+    faux_argv = ["script-de-test", *(argv or [])]
+    ancien_argv = sys.argv
+    sys.argv = faux_argv
+    try:
+        decoree = script_automatheque(doc, version)(fonction_capturante)
+        resultat = decoree()
+    finally:
+        sys.argv = ancien_argv
+
+    return ResultatScript(resultat=resultat, script=capture.get("script"))

--- a/src/automatheque/tests/test_essai.py
+++ b/src/automatheque/tests/test_essai.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Tests du harness de test des scripts (essai.py)."""
+
+from automatheque.essai import (
+    ResultatScript,
+    ecris_config,
+    execute_script,
+    reinitialise_configuration,
+)
+from automatheque.util.script import ScriptAutomatheque
+
+DOC = """Script de démonstration.
+
+Usage:
+  prog [--action] [--config=<fichier>]
+
+Options:
+  --action            Réalise l'action.
+  --config=<fichier>  Fichier de configuration.
+"""
+
+
+def test_execute_script_parse_argv_et_renvoie_le_resultat():
+    """L'argv contrôlé est parsé et la valeur de retour est remontée."""
+
+    def main(_script=None):
+        return _script.arguments["--action"]
+
+    res = execute_script(DOC, main, argv=["--action"])
+
+    assert isinstance(res, ResultatScript)
+    assert res.resultat is True
+    assert isinstance(res.script, ScriptAutomatheque)
+    assert res.script.arguments["--action"] is True
+
+
+def test_execute_script_sans_argument():
+    """Sans `--action`, l'argument est faux."""
+    res = execute_script(DOC, lambda _script=None: _script.arguments["--action"])
+    assert res.resultat is False
+
+
+def test_execute_script_charge_la_config_via_option_config(tmp_path):
+    """Un `--config` pointant un .ini jetable peuple `script.config`."""
+    fichier = ecris_config(tmp_path / "conf.ini", "[demo]\ncle = valeur\n")
+
+    res = execute_script(DOC, lambda _script=None: None, argv=["--config", fichier])
+
+    assert res.script.config.get("demo", "cle") == "valeur"
+
+
+def test_reinitialise_configuration_efface_le_cache():
+    """`reinitialise_configuration` oublie le singleton de configuration."""
+    from automatheque.configuration import charge_configuration
+
+    charge_configuration(ecraser=True, recharger=True)
+    assert hasattr(charge_configuration, "config")
+
+    reinitialise_configuration()
+    assert not hasattr(charge_configuration, "config")


### PR DESCRIPTION
Closes #46.

## Quoi

Nouveau module **`automatheque.essai`** pour tester un script `@script_automatheque` sans bricoler `sys.argv`/config à la main.

```python
from automatheque.essai import execute_script

DOC = """Mon script.

Usage:
  prog [--action] [--config=FICHIER]

Options:
  --action          Réalise l'action.
  --config=FICHIER  Fichier de configuration.
"""

def main(_script=None):
    return _script.arguments["--action"]

resultat, script = execute_script(DOC, main, argv=["--action"])
assert resultat is True
assert script.arguments["--action"] is True
```

## API

- **`execute_script(doc, fonction, argv=None, version=None, reinitialise=True)`** → `(resultat, script)` : décore `fonction` avec `script_automatheque` sous un `sys.argv` contrôlé, l'exécute, et renvoie la valeur de retour **et** l'objet `ScriptAutomatheque` (donc `.arguments`, `.config`).
- **`ecris_config(chemin, contenu)`** → `str` : écrit un `.ini` jetable (à coupler au `tmp_path` de pytest) pour tester `--config`.
- **`reinitialise_configuration()`** : oublie le singleton de configuration (`charge_configuration.config`) → isolation entre tests.

## Notes de conception

- `script_automatheque` lit `sys.argv` et charge la config **dès la décoration** : le harness pilote donc `sys.argv` autour de cette étape, puis récupère `_script` via la fonction décorée.
- Module **top-level** (`automatheque.essai`, pas sous `util`) et **sans dépendance runtime à pytest** (helpers composables avec `tmp_path`/`caplog`).
- Limite assumée : capture fine des logs et isolation totale de la config seront plus propres **après #45** (refonte logging) — d'où l'helper `reinitialise_configuration` en attendant.

## Vérification

- `tests/test_essai.py` : argv parsé, valeur de retour, `--config` → `script.config`, réinit du cache. **4/4**.
- Suite complète `automatheque` : **20/20**. `ruff check` OK.

## Suite

Débloque le test du décorateur enrichi (#5) et la montée de couverture (#18).