### PR TITLE
chore(packaging): SPDX licence valide + bornage docopt&lt;1 (#20, #4/#39)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,13 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-* Corrige le plancher de dépendance `automatheque.schema` (`>=0.9.5` →
-  `>=0.9.6`, plus ancienne version réellement publiée) et ajoute un job CI
-  « tests-plancher » qui éprouve factrice contre ses versions planchers — cf. #33
-
-## [0.11.0] - 2026-06-23
+## [0.11.0] - 2026-06-29
 
 Réalignement sur la version globale du monorepo gérée par monas.
 
@@ -32,6 +26,11 @@ Réalignement sur la version globale du monorepo gérée par monas.
 * `expedition.py` : repli (`fallback`) sur `ConfigParser`, exception SMTP
   ciblée à la place d'un `except` trop large, suppression de code mort
 * Nettoyage qualité (typage, `except` ciblés, argument par défaut mutable)
+* Packaging : `requires-python` passe à `>=3.9` + classifiers trove
+  `Python :: 3.9..3.12` — cf. #32
+* Corrige le plancher de dépendance `automatheque.schema` (`>=0.9.5` →
+  `>=0.9.6`, plus ancienne version réellement publiée) et ajoute un job CI
+  « tests-plancher » qui éprouve factrice contre ses versions planchers — cf. #33
 
 ## [0.10.1] - 2023-11-02
 

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Packaging : identifiant de licence corrigé en SPDX valide
+  `GPL-3.0-or-later` (était `GPLv3.0`) — cf. #20
+
 ## [0.11.0] - 2026-06-29
 
 Réalignement sur la version globale du monorepo gérée par monas.

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -3,7 +3,7 @@ name = "automatheque.factrice"
 version = "0.11.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
-license = {text = "GPLv3.0"}
+license = {text = "GPL-3.0-or-later"}
 requires-python = ">=3.9"
 readme = "README.md"
 classifiers = [

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Packaging : `requires-python` passe à `>=3.9` + classifiers trove
   `Python :: 3.9..3.12` — cf. #32. (Changement de métadonnées non encore
   publié : sera embarqué au prochain bump de `schema`.)
+* Packaging : identifiant de licence corrigé en SPDX valide
+  `GPL-3.0-or-later` (était `GPLv3.0`) — cf. #20
 
 ### Removed
 

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Packaging : `requires-python` passe à `>=3.9` + classifiers trove
+  `Python :: 3.9..3.12` — cf. #32. (Changement de métadonnées non encore
+  publié : sera embarqué au prochain bump de `schema`.)
+
 ### Removed
 
 ## [0.9.7] - 2023-10-31

--- a/src/automatheque.schema/pyproject.toml
+++ b/src/automatheque.schema/pyproject.toml
@@ -3,7 +3,7 @@ name = "automatheque.schema"
 version = "0.9.7"
 description = "Domaine pour des classes courantes et partagées"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
-license = {text = "GPLv3.0"}
+license = {text = "GPL-3.0-or-later"}
 requires-python = ">=3.9"
 readme = "README.md"
 classifiers = [

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -11,20 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* `util.reessaye` : décorateur de réessais avec attente croissante
-  (multiplicateur, gigue optionnelle, exceptions ciblées) — cf. #7
-* `util.script` : alias court `script` pour `script_automatheque`
-  (`@script(__doc__, __version__)`), le nom canonique restant disponible.
-
 ### Changed
-
-* Packaging : `requires-python` passe à `>=3.9` (3.8 est en fin de vie et
-  n'était plus testé) et ajout des classifiers trove `Python :: 3.9..3.12`,
-  pour une baseline Python unique et cohérente — cf. #32
 
 ### Removed
 
-## [0.11.0] - 2026-06-23
+## [0.11.0] - 2026-06-29
 
 Réalignement du monorepo sur la version globale gérée par monas. Les packages
 qui ont réellement changé depuis leur dernière version passent à 0.11.0
@@ -34,11 +25,18 @@ sautera à la version globale lors de sa prochaine modification.
 
 ### Added
 
+* `util.reessaye` : décorateur de réessais avec attente croissante
+  (multiplicateur, gigue optionnelle, exceptions ciblées) — cf. #7
+* `util.script` : alias court `script` pour `script_automatheque`
+  (`@script(__doc__, __version__)`), le nom canonique restant disponible.
 * CI : socle d'intégration continue (tests multi-versions, lint/format/types)
 * CI : publication PyPI via tag (trusted publishing OIDC)
 
 ### Changed
 
+* Packaging : `requires-python` passe à `>=3.9` (3.8 est en fin de vie et
+  n'était plus testé) et ajout des classifiers trove `Python :: 3.9..3.12`,
+  pour une baseline Python unique et cohérente — cf. #32
 * Feat: Modifie la gestion des Capacites des Greffons
 * Feat: Ajoute du typing dans le module greffon
 * Feat: Ajoute GreffonAbstrait pour les Greffons qui nécessitent une contrainte d'abstraction

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Packaging : identifiant de licence corrigé en SPDX valide
+  `GPL-3.0-or-later` (était `GPLv3.0`) — cf. #20
+* Packaging : dépendance `docopt` bornée `>=0.6,<1` (garde-fou breaking
+  changes) — cf. #4/#39
+
 ### Removed
 
 ## [0.11.0] - 2026-06-29

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -5,7 +5,7 @@ description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },
 ]
-license = { text = "GPLv3.0" }
+license = { text = "GPL-3.0-or-later" }
 requires-python = ">=3.9"
 readme = "README.md"
 classifiers = [
@@ -16,7 +16,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "docopt",
+    # Borné < 1 : garde-fou contre une éventuelle 1.0 à breaking changes
+    # (migration suivie dans #4 / #39).
+    "docopt>=0.6,<1",
     "pytz",
     "pyyaml",
     "attrs>=19.2",


### PR DESCRIPTION
Deux quick wins de métadonnées (aucun code modifié).

## 1. Identifiant de licence SPDX valide (volet de #20)

`license = "GPLv3.0"` n'est **pas un identifiant SPDX valide** → corrigé en **`GPL-3.0-or-later`** dans les **3 paquets**. Forme `{text = ...}` conservée (compatible `setuptools>=61`).

> Périmètre volontairement réduit à l'**identifiant**. Le reste de #20 (choix éventuel d'une autre licence, fichier `LICENSE`, classifier trove `License ::`, `CONTRIBUTING`/DCO) **reste ouvert**.

## 2. Bornage de `docopt` (garde-fou de #4/#39)

`automatheque` : `"docopt"` (non borné) → **`"docopt>=0.6,<1"`**. Protège d'une éventuelle 1.0 à breaking changes tirée involontairement, en attendant la migration (docopt-ng / commandopt) suivie dans #4 et #39.

## Vérification

- Parsing TOML des 4 fichiers OK ; `license` = `GPL-3.0-or-later` partout ; `docopt>=0.6,<1`.
- Suite `automatheque` : **16/16**. Métadonnées uniquement.