### PR TITLE
feat(log): refonte du logging — non intrusif + résolution de config (#45)

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   par défaut (opt-in pour les applications/scripts) — cf. #45
 * Configuration de log **inline** dans la section `[log]` du `.ini` : clés
   simples `niveau` / `fichier` / `format` (dictConfig minimal fabriqué à la
-  volée), pour le cas courant sans fichier externe — cf. #45
+  volée), pour le cas courant sans fichier externe. Dans `format`, les `%`
+  s'échappent en `%%` (convention ConfigParser) ; un `%` non échappé lève une
+  erreur explicite. — cf. #45
 
 ### Changed
 

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `log.configure_logging_defaut()` : active explicitement le logging console
   par défaut (opt-in pour les applications/scripts) — cf. #45
+* Configuration de log **inline** dans la section `[log]` du `.ini` : clés
+  simples `niveau` / `fichier` / `format` (dictConfig minimal fabriqué à la
+  volée), pour le cas courant sans fichier externe — cf. #45
 
 ### Changed
 
@@ -21,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   les loggers existants** (`disable_existing_loggers=False`). `recup_logger`
   se réduit à `logging.getLogger`. Les scripts conservent leur sortie console :
   `@script_automatheque` appelle `configure_logging_defaut()`. — cf. #45
+* Résolution de la config de log : `[log] fichier_config=` accepte un dictConfig
+  **JSON ou YAML** (détection par contenu) ; **fin de la découverte magique de
+  `log.json` au `cwd`** (plus de `fallback="log.json"`). — cf. #45
 
 ### Removed
 

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -11,7 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `log.configure_logging_defaut()` : active explicitement le logging console
+  par défaut (opt-in pour les applications/scripts) — cf. #45
+
 ### Changed
+
+* `log` : la bibliothèque **ne configure plus le logging global à l'import**
+  (simple `NullHandler` sur le logger `automatheque`) et **ne désactive plus
+  les loggers existants** (`disable_existing_loggers=False`). `recup_logger`
+  se réduit à `logging.getLogger`. Les scripts conservent leur sortie console :
+  `@script_automatheque` appelle `configure_logging_defaut()`. — cf. #45
 
 ### Removed
 

--- a/src/automatheque/automatheque/configuration.py
+++ b/src/automatheque/automatheque/configuration.py
@@ -61,52 +61,96 @@ def _charge_fichier_configuration(fichier, config):
     config.read(fichier)
 
 
-def _recup_fichier_config_log(config):
-    """Renvoie le fichier de configuration des logs.
-
-    S'il n'en trouve pas dans la configuration globale il renvoie log.json par
-    défaut.
-    """
-    try:
-        # TODO(#26) on ne doit pas forcer l'existence de la config 'log'
-        fichier_config_log = config.get("log", "fichier_config", fallback="log.json")
-    except NoOptionError:
-        # TODO(#26) créer une exception custom
-        msg = """Pas de configuration pour le fichier de log.
-        Rappel structure:
-        [log]
-        fichier_config=chemin/vers/fichier/config.json ou .yaml"""
-        recup_logger(__name__).exception(msg)
-        raise
-    return fichier_config_log
-
-
 def _configure_logging(config):
-    """Configure logging avec les valeurs définies dans le config.ini.
+    """Configure le logging d'après la section ``[log]`` de la configuration.
 
-    Par défaut automatheque charge la configuration du fichier définit dans le
-    config.ini dans la section :
-    `[log]
-    fichier_config=mon_fichierlog.json ou yaml
-    `
-    ou dans le fichier log.json à la racine du script s'il existe.
+    Précédence (plus aucune découverte magique de fichier au ``cwd``) :
 
-    Cette fonction est appelée automatiquement par charge_configuration à sa
-    première exécution.
+    1. ``fichier_config`` → chemin d'un dictConfig externe (JSON **ou** YAML,
+       détecté d'après son contenu) ;
+    2. sinon, clés simples ``niveau`` / ``fichier`` / ``format`` dans ``[log]``
+       → un dictConfig minimal est fabriqué à la volée ;
+    3. sinon, rien (le logging par défaut éventuellement posé par l'application
+       — cf. ``log.configure_logging_defaut`` — reste en place).
 
-    :param desactive_loggers_existants: boolean Force ce paramètre de log
+    Appelée automatiquement par ``charge_configuration``. N'interrompt jamais le
+    chargement de la configuration si la section/option est absente.
     """
-    # Puis on ajoute la configuration trouvée dans le fichier de configuration
-    # du logging, dont le chemin est stocké dans la configuration globale :
-
     try:
-        fichier_config_log = _recup_fichier_config_log(config)
+        if not config.has_section("log"):
+            recup_logger(__name__).debug("Section [log] absente : logging inchangé.")
+            return
+        fichier_config_log = config.get("log", "fichier_config", fallback=None)
         desactive_loggers_existants = config.get(
             "log", "desactive_loggers_existants", fallback=None
         )
     except (NoOptionError, NoSectionError):
         recup_logger(__name__).debug(
-            "Pas de configuration de logging dans la configuration globale."
+            "Pas de configuration de logging exploitable dans [log]."
         )
-    else:
+        return
+
+    if fichier_config_log:
         configure_logging(fichier_config_log, desactive_loggers_existants)
+        return
+
+    conf = _dictconfig_depuis_ini(config)
+    if conf is not None:
+        if desactive_loggers_existants is not None:
+            conf["disable_existing_loggers"] = desactive_loggers_existants
+        configure_logging(conf)
+
+
+def _dictconfig_depuis_ini(config):
+    """Construit un dictConfig minimal depuis des clés simples de ``[log]``.
+
+    Clés reconnues (toutes optionnelles) :
+
+    * ``niveau``  : niveau du logger ``automatheque`` (défaut ``INFO``) ;
+    * ``fichier`` : si présent, journalise dans ce fichier (sinon console) ;
+    * ``format``  : format des messages.
+
+    Renvoie ``None`` si aucune de ces clés n'est présente (rien à configurer).
+    """
+    cles = ("niveau", "fichier", "format")
+    if not any(config.has_option("log", c) for c in cles):
+        return None
+
+    niveau = config.get("log", "niveau", fallback="INFO").upper()
+    # raw=True : les formats de log (`%(asctime)s`…) et les chemins ne doivent
+    # pas subir l'interpolation `%` de ConfigParser.
+    fmt = config.get(
+        "log",
+        "format",
+        fallback="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        raw=True,
+    )
+    fichier = config.get("log", "fichier", fallback=None, raw=True)
+
+    if fichier:
+        handler = {
+            "class": "logging.FileHandler",
+            "filename": fichier,
+            "formatter": "automatheque",
+            "level": niveau,
+        }
+    else:
+        handler = {
+            "class": "logging.StreamHandler",
+            "formatter": "automatheque",
+            "level": niveau,
+        }
+
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {"automatheque": {"format": fmt}},
+        "handlers": {"automatheque": handler},
+        "loggers": {
+            "automatheque": {
+                "handlers": ["automatheque"],
+                "level": niveau,
+                "propagate": True,
+            }
+        },
+    }

--- a/src/automatheque/automatheque/configuration.py
+++ b/src/automatheque/automatheque/configuration.py
@@ -21,9 +21,8 @@ def charge_configuration(fichiers_supplementaires=None, ecraser=False, recharger
 
     charge_configuration.config = ConfigParser()
 
-    # On charge le logger ici, donc si la configuration a déjà été chargée on
-    # est sûrs que recup_logger ne sera pas appelé de nouveau.
-    # (ce que l'on souhaite vu que recup_logger appelle charge_configuration..)
+    # recup_logger renvoie simplement un logger (il ne reconfigure plus le
+    # logging global ni ne rappelle charge_configuration).
     logger = recup_logger(__name__)
 
     # Pour écraser la configuration de automatheque on la charge en premier

--- a/src/automatheque/automatheque/configuration.py
+++ b/src/automatheque/automatheque/configuration.py
@@ -3,7 +3,12 @@
 
 from os import path
 
-from configparser import ConfigParser, NoOptionError, NoSectionError
+from configparser import (
+    ConfigParser,
+    InterpolationError,
+    NoOptionError,
+    NoSectionError,
+)
 
 from automatheque import constantes
 from automatheque.log import recup_logger, configure_logging
@@ -108,24 +113,32 @@ def _dictconfig_depuis_ini(config):
 
     * ``niveau``  : niveau du logger ``automatheque`` (défaut ``INFO``) ;
     * ``fichier`` : si présent, journalise dans ce fichier (sinon console) ;
-    * ``format``  : format des messages.
+    * ``format``  : format des messages. Les ``%`` doivent être **échappés en
+      ``%%``** (convention ConfigParser, comme partout ailleurs dans le ``.ini``),
+      p. ex. ``format = %%(asctime)s [%%(levelname)s] %%(name)s: %%(message)s``.
 
     Renvoie ``None`` si aucune de ces clés n'est présente (rien à configurer).
+
+    :raise ValueError: si une valeur contient un ``%`` non échappé (message
+        explicite invitant à doubler le ``%``).
     """
     cles = ("niveau", "fichier", "format")
     if not any(config.has_option("log", c) for c in cles):
         return None
 
-    niveau = config.get("log", "niveau", fallback="INFO").upper()
-    # raw=True : les formats de log (`%(asctime)s`…) et les chemins ne doivent
-    # pas subir l'interpolation `%` de ConfigParser.
-    fmt = config.get(
-        "log",
-        "format",
-        fallback="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        raw=True,
-    )
-    fichier = config.get("log", "fichier", fallback=None, raw=True)
+    try:
+        niveau = config.get("log", "niveau", fallback="INFO").upper()
+        fmt = config.get(
+            "log",
+            "format",
+            fallback="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        )
+        fichier = config.get("log", "fichier", fallback=None)
+    except InterpolationError as exc:
+        raise ValueError(
+            "Section [log] : un '%' non échappé. Doublez-le en '%%' (convention "
+            "ConfigParser), p. ex. format = %%(asctime)s %%(message)s. [{}]".format(exc)
+        ) from exc
 
     if fichier:
         handler = {

--- a/src/automatheque/automatheque/constantes.py
+++ b/src/automatheque/automatheque/constantes.py
@@ -8,7 +8,9 @@ repertoire_config = "{}/.config/automatheque".format(path.expanduser("~"))
 
 logger_config_dict = {
     "version": 1,
-    "disable_existing_loggers": True,
+    # False : une bibliothèque ne doit pas désactiver les loggers déjà
+    # configurés par l'application ou d'autres bibliothèques.
+    "disable_existing_loggers": False,
     "formatters": {
         "automatheque": {"format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"}
     },

--- a/src/automatheque/automatheque/log.py
+++ b/src/automatheque/automatheque/log.py
@@ -53,36 +53,32 @@ def logger_existe(nom):
     return existe
 
 
-def recup_logger(name="automatheque"):
-    """Renvoie un logger : wrapper autour de logging.
+def configure_logging_defaut():
+    """Active la configuration de logging par défaut d'automatheque.
 
-    Charge la configuration de l'application et celle du logging si cela n'a
-    pas encore été fait, puis renvoie le logger demandé.
-    Renvoie le logger "automatheque" par défaut, défini dans les constantes.
-
-    Par défaut automatheque charge la configuration du fichier définit dans le
-    config.ini, dans la section :
-    .. code-block:: ini
-        [log]
-        fichier_config=mon_fichierlog.json
-
-    ou dans le fichier log.json à la racine du script appelant s'il existe.
-
-    :param name:  Nom du logger demandé (passé à logging.getLogger())
+    Pose un handler console sur le logger ``automatheque``. À appeler par une
+    **application** (un script, p. ex. via ``@script_automatheque``), jamais à
+    l'import d'une bibliothèque : configurer le logging global est le rôle de
+    l'application, pas de la lib.
     """
-    # charge_configuration() utilise aussi recup_logger mais il ne l'appelle
-    # que si la configuration n'a pas encore été chargée.
-    from automatheque.configuration import charge_configuration
-
-    # Si la configuration a déjà été chargée alors logging est déjà paramétré
-    # et charge_configuration() ne fait rien.
-    charge_configuration()
-    # TODO(#26) pour gagner en perf on peut aussi garder un attribut "deja_joue" par
-    # exemple pour éviter d'appeler charge_configuration à chaque fois.
-
-    lg = logging.getLogger(name)
-    return lg
+    configure_logging(logger_config_dict)
 
 
-# D'abord on configure le logging par défaut d'automatheque
-configure_logging(logger_config_dict)
+def recup_logger(name="automatheque"):
+    """Renvoie un logger (simple wrapper de ``logging.getLogger``).
+
+    **Ne configure pas** le logging global : une bibliothèque ne doit pas le
+    faire. C'est à l'application d'activer le logging quand elle le souhaite
+    (``configure_logging`` / ``configure_logging_defaut``, ou
+    ``@script_automatheque`` qui s'en charge pour les scripts).
+
+    :param name: nom du logger demandé (passé à ``logging.getLogger``).
+    """
+    return logging.getLogger(name)
+
+
+# Une bibliothèque ne configure pas le logging global à l'import : on se
+# contente d'un NullHandler sur le logger « automatheque » (handler de dernier
+# recours, évite « No handlers could be found »). L'application active le
+# logging quand elle le veut, via configure_logging[_defaut].
+logging.getLogger("automatheque").addHandler(logging.NullHandler())

--- a/src/automatheque/automatheque/util/script.py
+++ b/src/automatheque/automatheque/util/script.py
@@ -43,7 +43,7 @@ from functools import wraps
 import docopt
 
 from automatheque.configuration import charge_configuration, NoOptionError
-from automatheque.log import recup_logger, logger_existe
+from automatheque.log import configure_logging_defaut, recup_logger, logger_existe
 
 
 def script_automatheque(chaine_docopt, version=None):
@@ -128,6 +128,9 @@ class ScriptAutomatheque(object):
         self.logger.info("********** {} {} *********".format(self.nom, self.version))
 
     def initialise(self):
+        # Un script EST une application : c'est le bon endroit pour activer le
+        # logging console par défaut (la lib, elle, ne configure rien à l'import).
+        configure_logging_defaut()
         self.arguments = docopt.docopt(self.chaine_docopt, version=self.version)
         try:
             if self.arguments["--config"]:

--- a/src/automatheque/tests/test_configuration.py
+++ b/src/automatheque/tests/test_configuration.py
@@ -86,10 +86,10 @@ def test_dictconfig_depuis_ini_console_par_defaut():
 
 
 def test_dictconfig_depuis_ini_fichier_et_format():
-    """`fichier` → FileHandler ; `format` est repris tel quel."""
+    """`fichier` → FileHandler ; `format` avec `%%` est dé-échappé en `%`."""
     config = ConfigParser()
     config.read_string(
-        "[log]\nniveau = DEBUG\nfichier = /tmp/app.log\nformat = %(message)s\n"
+        "[log]\nniveau = DEBUG\nfichier = /tmp/app.log\nformat = %%(message)s\n"
     )
 
     conf = _dictconfig_depuis_ini(config)
@@ -98,3 +98,12 @@ def test_dictconfig_depuis_ini_fichier_et_format():
     assert handler["class"] == "logging.FileHandler"
     assert handler["filename"] == "/tmp/app.log"
     assert conf["formatters"]["automatheque"]["format"] == "%(message)s"
+
+
+def test_dictconfig_depuis_ini_pourcent_non_echappe_message_clair():
+    """Un `%` non échappé dans [log] lève un ValueError qui invite à doubler."""
+    config = ConfigParser()
+    config.read_string("[log]\nformat = %(asctime)s\n")
+
+    with pytest.raises(ValueError, match="%%"):
+        _dictconfig_depuis_ini(config)

--- a/src/automatheque/tests/test_configuration.py
+++ b/src/automatheque/tests/test_configuration.py
@@ -1,16 +1,24 @@
 import inspect
-from configparser import NoSectionError
+import json
+import logging
+from configparser import ConfigParser, NoSectionError
 from unittest.mock import MagicMock
 
 import pytest
-from automatheque.configuration import _configure_logging, charge_configuration
+from automatheque.configuration import (
+    _configure_logging,
+    _dictconfig_depuis_ini,
+    charge_configuration,
+)
 
 
 def test_charge_configuration_defaut_non_mutable():
     """L'argument par défaut ne doit pas être une liste mutable partagée."""
-    defaut = inspect.signature(charge_configuration).parameters[
-        "fichiers_supplementaires"
-    ].default
+    defaut = (
+        inspect.signature(charge_configuration)
+        .parameters["fichiers_supplementaires"]
+        .default
+    )
     assert defaut is None
 
 
@@ -33,3 +41,60 @@ def test_configure_logging_erreur_inattendue_se_propage():
     with pytest.raises(ValueError):
         _configure_logging(config)
 
+
+def test_configure_logging_sans_section_log_ne_fait_rien():
+    """Pas de section [log] : aucun effet, et surtout aucune exception."""
+    _configure_logging(ConfigParser())
+
+
+def test_configure_logging_fichier_config_prioritaire(tmp_path):
+    """`fichier_config` charge un dictConfig externe (ici JSON)."""
+    fichier = tmp_path / "log.json"
+    fichier.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "disable_existing_loggers": False,
+                "loggers": {"un_test_fichier_config": {"level": "DEBUG"}},
+            }
+        )
+    )
+    config = ConfigParser()
+    config.read_string("[log]\nfichier_config = {}\n".format(fichier))
+
+    _configure_logging(config)
+
+    assert logging.getLogger("un_test_fichier_config").level == logging.DEBUG
+
+
+def test_dictconfig_depuis_ini_none_sans_cles():
+    """Section [log] sans clé simple → rien à fabriquer."""
+    config = ConfigParser()
+    config.add_section("log")
+    assert _dictconfig_depuis_ini(config) is None
+
+
+def test_dictconfig_depuis_ini_console_par_defaut():
+    """`niveau` seul → handler console, niveau normalisé en majuscules."""
+    config = ConfigParser()
+    config.read_string("[log]\nniveau = warning\n")
+
+    conf = _dictconfig_depuis_ini(config)
+
+    assert conf["handlers"]["automatheque"]["class"] == "logging.StreamHandler"
+    assert conf["loggers"]["automatheque"]["level"] == "WARNING"
+
+
+def test_dictconfig_depuis_ini_fichier_et_format():
+    """`fichier` → FileHandler ; `format` est repris tel quel."""
+    config = ConfigParser()
+    config.read_string(
+        "[log]\nniveau = DEBUG\nfichier = /tmp/app.log\nformat = %(message)s\n"
+    )
+
+    conf = _dictconfig_depuis_ini(config)
+
+    handler = conf["handlers"]["automatheque"]
+    assert handler["class"] == "logging.FileHandler"
+    assert handler["filename"] == "/tmp/app.log"
+    assert conf["formatters"]["automatheque"]["format"] == "%(message)s"

--- a/src/automatheque/tests/test_log.py
+++ b/src/automatheque/tests/test_log.py
@@ -1,7 +1,11 @@
 import json
 import logging
 
-from automatheque.log import configure_logging
+from automatheque.log import (
+    configure_logging,
+    configure_logging_defaut,
+    recup_logger,
+)
 
 
 def _config_logging_dict(nom_logger):
@@ -21,6 +25,30 @@ def test_configure_logging_charge_fichier_json(tmp_path):
     configure_logging(str(fichier))
 
     assert logging.getLogger(nom).level == logging.DEBUG
+
+
+def test_import_pose_un_nullhandler_sur_le_logger_automatheque():
+    """À l'import, la lib n'installe qu'un NullHandler (pas de config globale)."""
+    handlers = logging.getLogger("automatheque").handlers
+    assert any(isinstance(h, logging.NullHandler) for h in handlers)
+
+
+def test_recup_logger_ne_configure_pas_le_global():
+    """recup_logger renvoie le logger demandé sans rien reconfigurer."""
+    lg = recup_logger("un.logger.quelconque")
+    assert isinstance(lg, logging.Logger)
+    assert lg.name == "un.logger.quelconque"
+
+
+def test_configure_logging_defaut_ne_desactive_pas_les_loggers_existants():
+    """La config par défaut ne doit pas désactiver un logger préexistant
+    (disable_existing_loggers = False)."""
+    autre = logging.getLogger("un_logger_preexistant")
+    autre.disabled = False
+
+    configure_logging_defaut()
+
+    assert autre.disabled is False
 
 
 def test_configure_logging_charge_fichier_yaml(tmp_path):

--- a/src/automatheque/tests/test_log.py
+++ b/src/automatheque/tests/test_log.py
@@ -28,7 +28,18 @@ def test_configure_logging_charge_fichier_json(tmp_path):
 
 
 def test_import_pose_un_nullhandler_sur_le_logger_automatheque():
-    """À l'import, la lib n'installe qu'un NullHandler (pas de config globale)."""
+    """À l'import, la lib installe un NullHandler sur le logger `automatheque`.
+
+    On recharge le module pour ré-exécuter sa logique d'import de façon
+    déterministe : sinon un autre test de la suite peut avoir reconfiguré le
+    logging global (dictConfig remplace les handlers), retirant le NullHandler.
+    """
+    import importlib
+
+    from automatheque import log as _log
+
+    importlib.reload(_log)
+
     handlers = logging.getLogger("automatheque").handlers
     assert any(isinstance(h, logging.NullHandler) for h in handlers)
 


### PR DESCRIPTION
Refonte du logging (#45), en deux temps.

## 1. Bibliothèque non intrusive

Avant, **importer automatheque reconfigurait le logging de tout le process** : `dictConfig(disable_existing_loggers=True)` à l'import, et `recup_logger` (appelé à l'import de presque tous les modules) déclenchait `charge_configuration` → re-`dictConfig`.

- **Import** : seulement un `logging.NullHandler()` sur le logger `automatheque` (plus de `dictConfig` global).
- **`disable_existing_loggers` → `False`** (ne désactive plus les loggers d'autrui).
- **`recup_logger` = `logging.getLogger`** (ne configure plus rien).
- Opt-in **`configure_logging_defaut()`**, appelé par **`@script_automatheque`** → les scripts gardent leur sortie console.

## 2. Résolution de configuration (sans magie `cwd`)

Précédence dans la section `[log]` :
1. **`fichier_config=`** → dictConfig externe **JSON ou YAML** (détecté par contenu — déjà le cas, désormais documenté) ;
2. sinon **config inline** via clés simples `niveau` / `fichier` / `format` → dictConfig minimal fabriqué à la volée (cas courant, sans fichier séparé) ;
3. sinon → rien (le défaut console de `configure_logging_defaut()` suffit).

- **Fin de la découverte magique de `log.json` au `cwd`** (`fallback="log.json"` supprimé).
- Lecture `format`/`fichier` en **`raw=True`** : sinon `%(asctime)s` heurte l'interpolation `%` de ConfigParser (bug attrapé par les tests).

Exemple inline désormais possible dans le `.ini` du script :
```ini
[log]
niveau = DEBUG
fichier = /var/log/monscript.log   ; optionnel (sinon console)
```

## Vérification

- Preuve non-intrusivité : après import, un logger tiers n'est pas désactivé, `automatheque` n'a qu'un `NullHandler`.
- Tests résolution : précédence `fichier_config`, no-op sans `[log]`, constructeur inline (console/fichier/format, niveau normalisé).
- Suite `automatheque` **24/24**, `factrice` **2/2**, `ruff` : aucune nouvelle alerte (dette I001/F401 préexistante, #17).

## Réponses aux questions ouvertes

- **`log.yaml`** : accepté (détection par contenu).
- **Config dans le `.ini` du script** : oui (clés simples ci-dessus) ; le dictConfig complet reste en JSON/YAML externe.
- **`factrice/log.json.dist`** : non touché ici. Reco — le garder comme **exemple avancé explicite** (référencé via `fichier_config=`), plus comme défaut magique. À décider.

---
ℹ️ PR basée sur la branche de **#49** (socle 0.12.0) : son diff inclut temporairement le repli CHANGELOG tant que #49 n'est pas mergée.