### PR TITLE
feat(config): configuration en couches + XDG + dossier par script (#2)

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   erreur explicite. — cf. #45
 * `automatheque.essai` : harness de test des scripts `@script_automatheque`
   (`execute_script`, `ecris_config`, `reinitialise_configuration`) — cf. #46
+* Configuration **en couches** : `@script_automatheque` charge automatiquement
+  `<racine>/automatheque/config.ini` (partagé) **puis**
+  `<racine>/<nom_court>/config.ini` (propre au script, surcharge), avant
+  `--config`. `$XDG_CONFIG_HOME` est désormais honoré. — cf. #2
 
 ### Changed
 
@@ -35,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GPL-3.0-or-later` (était `GPLv3.0`) — cf. #20
 * Packaging : dépendance `docopt` bornée `>=0.6,<1` (garde-fou breaking
   changes) — cf. #4/#39
+* `constantes.repertoire_config` et `configuration.fichier_config` deviennent des
+  **fonctions** (résolution `$XDG_CONFIG_HOME` à l'exécution) ; ajout de
+  `constantes.repertoire_config_script(nom_court)`. Plus besoin du
+  `[default: <script>.ini]` docopt pour la config par script. — cf. #2
 
 ### Removed
 

--- a/src/automatheque/automatheque/configuration.py
+++ b/src/automatheque/automatheque/configuration.py
@@ -13,7 +13,9 @@ from configparser import (
 from automatheque import constantes
 from automatheque.log import recup_logger, configure_logging
 
-fichier_config = "{}/config.ini".format(constantes.repertoire_config)
+def fichier_config():
+    """Chemin du ``config.ini`` **partagé** d'automatheque (couche de base)."""
+    return path.join(constantes.repertoire_config(), "config.ini")
 
 
 def charge_configuration(fichiers_supplementaires=None, ecraser=False, recharger=False):
@@ -33,13 +35,13 @@ def charge_configuration(fichiers_supplementaires=None, ecraser=False, recharger
     # Pour écraser la configuration de automatheque on la charge en premier
     # et les fichiers suivants vont prendre la précédence.
     if ecraser:
-        _charge_fichier_configuration(fichier_config, charge_configuration.config)
+        _charge_fichier_configuration(fichier_config(), charge_configuration.config)
 
     # Ajout des autres fichiers s'il y en a :
     for f in fichiers_supplementaires:
         # Si "f" n'est pas un fichier, on regarde s'il existe dans le
-        # répertoire de configuration d'automatheque.
-        paths_a_tester = [f, path.join(constantes.repertoire_config, f)]
+        # répertoire de configuration partagé d'automatheque.
+        paths_a_tester = [f, path.join(constantes.repertoire_config(), f)]
         for fichier in paths_a_tester:
             if not path.isfile(fichier):
                 logger.debug("{} n'est pas un fichier.".format(fichier))
@@ -50,7 +52,7 @@ def charge_configuration(fichiers_supplementaires=None, ecraser=False, recharger
     # Si on veut conserver la configuration de automatheque, alors on charge
     # sa configuration en dernier :
     if not ecraser:
-        _charge_fichier_configuration(fichier_config, charge_configuration.config)
+        _charge_fichier_configuration(fichier_config(), charge_configuration.config)
 
     # Si la configuration que l'on vient d'importer contient des paramètres
     # qui concernent les logs alors on configure le logging :

--- a/src/automatheque/automatheque/constantes.py
+++ b/src/automatheque/automatheque/constantes.py
@@ -1,10 +1,32 @@
 # -*- coding: utf-8 -*-
 """Réglages principaux de Automathèque."""
 
-from os import path
+from os import environ, path
 
-# Répertoire où stocker les principaux réglages de Automathèque.
-repertoire_config = "{}/.config/automatheque".format(path.expanduser("~"))
+
+def _racine_config():
+    """Racine de configuration de l'utilisateur, en honorant ``$XDG_CONFIG_HOME``.
+
+    Renvoie ``$XDG_CONFIG_HOME`` s'il est défini et non vide, sinon ``~/.config``.
+    """
+    return environ.get("XDG_CONFIG_HOME") or path.join(path.expanduser("~"), ".config")
+
+
+def repertoire_config():
+    """Répertoire de configuration **partagé** d'automatheque.
+
+    ``<racine>/automatheque/`` — réglages communs à tous les scripts (p. ex. SMTP).
+    """
+    return path.join(_racine_config(), "automatheque")
+
+
+def repertoire_config_script(nom_court):
+    """Répertoire de configuration **propre à un script** : ``<racine>/<nom_court>/``.
+
+    C'est le foyer naturel du script : son ``config.ini`` et, par convention, son
+    ``log.json``, ses données, son cache…
+    """
+    return path.join(_racine_config(), nom_court)
 
 logger_config_dict = {
     "version": 1,

--- a/src/automatheque/automatheque/util/script.py
+++ b/src/automatheque/automatheque/util/script.py
@@ -13,9 +13,14 @@ Usage:
 
 Options:
   --action  Action realisée
-  --config=<fichier_config>  Fichier de configuration [default: mon_script.ini]
+  --config=<fichier_config>  Fichier de configuration supplémentaire (ponctuel)
 '''
 __version__ = '0.1a'  # ou importer depuis mon_package.__version__
+
+# La configuration est chargée en couches, sans rien déclarer ici :
+#   ~/.config/automatheque/config.ini   (partagé entre scripts)
+#   ~/.config/<mon_script>/config.ini   (propre à ce script ; surcharge)
+#   --config <fichier>                  (ponctuel ; surcharge)
 
 from automatheque.util.script import script  # alias court de script_automatheque
 
@@ -42,6 +47,7 @@ from functools import wraps
 
 import docopt
 
+from automatheque import constantes
 from automatheque.configuration import charge_configuration, NoOptionError
 from automatheque.log import configure_logging_defaut, recup_logger, logger_existe
 
@@ -132,18 +138,20 @@ class ScriptAutomatheque(object):
         # logging console par défaut (la lib, elle, ne configure rien à l'import).
         configure_logging_defaut()
         self.arguments = docopt.docopt(self.chaine_docopt, version=self.version)
-        try:
-            if self.arguments["--config"]:
-                # On écrase les configurations précédentes (par ex si
-                # automatheque a déjà été chargé) car on estime que
-                # l'annotation vient avec des informations supplémentaires.
-                self.config = charge_configuration(
-                    [self.arguments["--config"]], ecraser=True, recharger=True
-                )
-            else:
-                self.config = charge_configuration(ecraser=True, recharger=True)
-        except KeyError:
-            self.config = charge_configuration(ecraser=True, recharger=True)
+        # Configuration en couches, de la plus générale à la plus spécifique
+        # (chaque couche surcharge la précédente) :
+        #   1. config.ini partagé d'automatheque  (chargé par ecraser=True)
+        #   2. <racine>/<nom_court>/config.ini     (propre au script)
+        #   3. --config <fichier>                  (explicite, ponctuel)
+        fichiers = [
+            os.path.join(
+                constantes.repertoire_config_script(self.nom_court), "config.ini"
+            )
+        ]
+        config_cli = self.arguments.get("--config")
+        if config_cli:
+            fichiers.append(config_cli)
+        self.config = charge_configuration(fichiers, ecraser=True, recharger=True)
         # TODO(#27) ici on pourrait aussi merger la conf et les arguments ...
         # dans self.parametres ?
         """

--- a/src/automatheque/tests/test_configuration.py
+++ b/src/automatheque/tests/test_configuration.py
@@ -11,6 +11,8 @@ from automatheque.configuration import (
     charge_configuration,
 )
 
+from automatheque import constantes
+
 
 def test_charge_configuration_defaut_non_mutable():
     """L'argument par défaut ne doit pas être une liste mutable partagée."""
@@ -107,3 +109,41 @@ def test_dictconfig_depuis_ini_pourcent_non_echappe_message_clair():
 
     with pytest.raises(ValueError, match="%%"):
         _dictconfig_depuis_ini(config)
+
+
+def test_racine_config_honore_xdg(monkeypatch, tmp_path):
+    """`$XDG_CONFIG_HOME` est respecté quand il est défini."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert constantes._racine_config() == str(tmp_path)
+
+
+def test_racine_config_defaut_sur_config(monkeypatch):
+    """Sans `$XDG_CONFIG_HOME`, on retombe sur ~/.config."""
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    assert constantes._racine_config().endswith("/.config")
+
+
+def test_repertoire_config_par_script(monkeypatch, tmp_path):
+    """Le répertoire par script est <racine>/<nom_court>/."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert constantes.repertoire_config_script("monscript") == str(
+        tmp_path / "monscript"
+    )
+
+
+def test_charge_configuration_en_couches(monkeypatch, tmp_path):
+    """La couche supplémentaire surcharge la couche partagée, qui sert de base."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    partage = tmp_path / "automatheque"
+    partage.mkdir()
+    (partage / "config.ini").write_text("[demo]\ncle = partagee\nbase = oui\n")
+
+    (tmp_path / "monscript").mkdir()
+    specifique = tmp_path / "monscript" / "config.ini"
+    specifique.write_text("[demo]\ncle = specifique\n")
+
+    cfg = charge_configuration([str(specifique)], ecraser=True, recharger=True)
+
+    assert cfg.get("demo", "cle") == "specifique"  # la couche script surcharge
+    assert cfg.get("demo", "base") == "oui"  # la couche partagée reste la base


### PR DESCRIPTION
Première implémentation du design en couches de #2. **Sans couche de compatibilité** (décision : pré-1.0, on fait propre).

## Comportement

`@script_automatheque` charge la configuration **en couches**, du général au spécifique (chaque couche surcharge la précédente) :

```
~/.config/automatheque/config.ini   (partagé entre scripts : SMTP commun…)   ← base
        ↓
~/.config/<nom_court>/config.ini    (propre au script)
        ↓
--config <fichier>                  (ponctuel)
        ↓
arguments CLI
```

- **`$XDG_CONFIG_HOME` honoré** (lecture manuelle, zéro dépendance).
- Le dossier `~/.config/<nom_court>/` devient le **foyer du script** (config + `log.json` + données…), ce qui résout l'objet initial de #2.
- **Plus besoin du `[default: <script>.ini]` docopt** : la config par script est dérivée du `nom_court`.

## Changements

- `constantes` : `_racine_config()` (XDG), `repertoire_config()` et `repertoire_config_script(nom_court)` (fonctions).
- `configuration` : `fichier_config()` devient une fonction (résolution à l'exécution).
- `script.initialise()` : empile partagé < par-script < `--config` ; exemple d'en-tête mis à jour (suppression du `[default:]`).

## Vérification

- Tests : `$XDG_CONFIG_HOME` honoré / défaut `~/.config`, `repertoire_config_script`, **superposition** partagé < spécifique.
- **Smoke test end-to-end** : avec `XDG_CONFIG_HOME` pointé sur un tmp, un `~/.config/<nom_court>/config.ini` est **chargé automatiquement** par un script décoré.
- Suite `automatheque` **29/29** ; aucune nouvelle alerte `ruff` (dette I001/F401 préexistante).

## Reste de #2 (suite)

Doc utilisateur ; résolution d'un `[log] fichier_config=` relatif dans le dossier du script ; `platformdirs` si multi-OS ; tests d'intégration via le harness #46.

---
ℹ️ PR empilée sur **#52** (logging) → **#49** : son diff inclut temporairement ces commits tant que les bases ne sont pas mergées.