### PR TITLE
release: coupe 0.12.0 (automatheque + factrice)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.11.0"
+version = "0.12.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-15
+
 ### Changed
 
 * Licence : passage de GPLv3 à **LGPLv3** (`LGPL-3.0-or-later`) — copyleft

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.factrice"
-version = "0.11.0"
+version = "0.12.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-15
+
 ### Added
 
 * `log.configure_logging_defaut()` : active explicitement le logging console
@@ -168,6 +170,7 @@ Nouvel utilitaire, pour gérer les dépendances externes.
 
 * Corrige lien entre media et photo
 
-[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.11.0...HEAD
+[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.12.0...HEAD
+[0.12.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.12.0
 [0.11.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.11.0
 [0.8.10]: https://github.com/jaegerbobomb/automatheque/releases/tag/v0.8.10

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.11.0"
+version = "0.12.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
Prépare la **0.12.0**. À merger sur `main` **avant** de poser le tag `0.12.0`
(qui déclenche la publication PyPI).

## Périmètre du bump

| Paquet | 0.11.0 → | Raison |
|--------|----------|--------|
| `automatheque` | **0.12.0** | vrais changements (voir ci-dessous) |
| `automatheque.factrice` | **0.12.0** | relicence LGPL |
| `automatheque.schema` | *inchangé (0.9.7)* | métadonnées seulement, publication différée (décision) |

Invariant monas respecté : `version` monas == max des versions paquets == `0.12.0`.

## Contenu 0.12.0

- **#45** logging non-intrusif (NullHandler à l'import, `configure_logging_defaut()` opt-in) + config de log **inline** dans `[log]` du `.ini` (JSON/YAML externe toujours possible, fin de la magie `log.json` au `cwd`).
- **#46** harness de test `automatheque.essai` pour les scripts `@script_automatheque`.
- **#2** configuration **en couches** (`automatheque/config.ini` partagé → `<nom_court>/config.ini` → `--config` → CLI) + `$XDG_CONFIG_HOME`.
- **#20** relicence **LGPL-3.0-or-later** (SPDX valide + classifier trove + DCO).
- **#4/#39** borne `docopt>=0.6,<1`.

## Changements de fichiers

- `pyproject.toml` (monas) + `automatheque` + `factrice` → `0.12.0`.
- CHANGELOG `automatheque` & `factrice` : section `[0.12.0] - 2026-07-15`, `[Unreleased]` vidé, liens de comparaison mis à jour.

## Après merge

Poser le tag **`0.12.0`** (sans préfixe `v`) sur `main` → le workflow *release* publie `automatheque` et `automatheque.factrice` (schema en 0.9.7 ne matche pas le tag et est ignoré).