### PR TITLE
refactor(script): promeut script_automatheque hors de util (#41)

### DIFF
--- a/src/automatheque.factrice/automatheque/factrice/app/__init__.py
+++ b/src/automatheque.factrice/automatheque/factrice/app/__init__.py
@@ -18,7 +18,7 @@ Options:
 import subprocess
 
 from automatheque.schema.texte.courriel import Courriel
-from automatheque.util.script import script_automatheque, ScriptAutomatheque
+from automatheque.script import script_automatheque, ScriptAutomatheque
 
 from automatheque.factrice.expedition import ExpeditriceEsmtp, ExpeditriceSmtp
 

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* `script_automatheque` / `script` / `ScriptAutomatheque` sont promus de
+  `automatheque.util.script` vers **`automatheque.script`** : c'est l'API phare
+  du projet, pas un utilitaire bas niveau. `automatheque.util.script` reste
+  importable (shim) mais émet un `DeprecationWarning` et sera supprimé
+  ultérieurement. Nouveau chemin : `from automatheque.script import script`.
+  — cf. #41
+
 ## [0.12.0] - 2026-07-15
 
 ### Added

--- a/src/automatheque/README.md
+++ b/src/automatheque/README.md
@@ -21,15 +21,16 @@ pip install automatheque
 ## Usage : Utilitaire pour script
 
 ```python
-from automatheque.util.script import script_automatheque
+from automatheque.script import script  # alias court de script_automatheque
 
-# préparation de l'annotation en haut du fichier :
-script_automatheque = script_automatheque(__doc__, __version__)
-
-@script_automatheque
+@script(__doc__, __version__)
 def main(_script):
     print(_script.config)
 
 if __name__ == '__main__':
     main()
 ```
+
+> L'API a été promue de `automatheque.util.script` vers `automatheque.script`
+> (#41). L'ancien chemin reste importable (shim) mais émet un
+> `DeprecationWarning` : migrez vers `from automatheque.script import script`.

--- a/src/automatheque/automatheque/essai.py
+++ b/src/automatheque/automatheque/essai.py
@@ -4,7 +4,7 @@
 Tester un script décoré demanderait sinon de bricoler ``sys.argv``, la
 configuration et le logger à la main. Ce module permet d'exécuter un script
 décoré avec un ``argv`` contrôlé et d'inspecter l'objet
-:class:`~automatheque.util.script.ScriptAutomatheque` produit (arguments parsés,
+:class:`~automatheque.script.ScriptAutomatheque` produit (arguments parsés,
 configuration chargée) ainsi que la valeur de retour.
 
 Exemple ::
@@ -34,7 +34,7 @@ from collections import namedtuple
 from pathlib import Path
 
 from automatheque.configuration import charge_configuration
-from automatheque.util.script import script_automatheque
+from automatheque.script import script_automatheque
 
 __all__ = [
     "ResultatScript",
@@ -79,7 +79,7 @@ def execute_script(doc, fonction, argv=None, version=None, reinitialise=True):
         l'exécution, pour isoler les tests les uns des autres.
     :return: un :class:`ResultatScript` ``(resultat, script)`` où ``resultat`` est
         la valeur renvoyée par ``fonction`` et ``script`` l'objet
-        :class:`~automatheque.util.script.ScriptAutomatheque` (``.arguments``,
+        :class:`~automatheque.script.ScriptAutomatheque` (``.arguments``,
         ``.config``…).
     """
     if reinitialise:

--- a/src/automatheque/automatheque/script.py
+++ b/src/automatheque/automatheque/script.py
@@ -1,0 +1,195 @@
+# -*- coding:utf-8 -*-
+"""API phare d'automatheque : faciliter la création de scripts.
+
+Il faut pouvoir l'utiliser aussi dans les modules, pas juste dans les scripts.
+TODO(#24)
+
+Le format que l'on souhaite est le suivant :
+```
+'''Mon script
+
+Usage:
+  mon_script.py [--action] [--config=<fichier_config>]
+
+Options:
+  --action  Action realisée
+  --config=<fichier_config>  Fichier de configuration supplémentaire (ponctuel)
+'''
+__version__ = '0.1a'  # ou importer depuis mon_package.__version__
+
+# La configuration est chargée en couches, sans rien déclarer ici :
+#   ~/.config/automatheque/config.ini   (partagé entre scripts)
+#   ~/.config/<mon_script>/config.ini   (propre à ce script ; surcharge)
+#   --config <fichier>                  (ponctuel ; surcharge)
+
+from automatheque.script import script  # alias court de script_automatheque
+
+@script(__doc__, __version__)
+def main(..., _script=None):
+    # code à exécuter
+    # _script est un objet `ScriptAutomatheque`
+    print(_script)
+
+if __name__ == '__main__':
+    main(...)
+```
+Cela déclenche les logs de début, de fin, parse les arguments etc.
+
+``script`` est un alias court de ``script_automatheque`` : les deux noms sont
+équivalents et exportés depuis ``automatheque.script``.
+
+.. note::
+   Historiquement ce module vivait dans ``automatheque.util.script``. Il a été
+   promu au premier niveau (:mod:`automatheque.script`) car c'est l'API centrale
+   du projet, pas un utilitaire bas niveau (#41). L'ancien emplacement reste
+   importable via un shim qui émet un ``DeprecationWarning``.
+"""
+
+import sys
+import os
+import re
+import datetime
+from functools import wraps
+
+import docopt
+
+from automatheque import constantes
+from automatheque.configuration import charge_configuration, NoOptionError
+from automatheque.log import configure_logging_defaut, recup_logger, logger_existe
+
+
+def script_automatheque(chaine_docopt, version=None):
+    """Decorateur pour ScriptAutomatheque.
+
+    - signale le début et la fin du traitement
+    - passe un objet ScriptAutomatheque à la fonction appelante
+    """
+    s = ScriptAutomatheque(
+        nom=sys.argv[0], chaine_docopt=chaine_docopt, version=version
+    )
+    s.initialise()
+
+    def decorateur(fonction):
+        @wraps(fonction)
+        def init_script(*args, **kwds):
+            try:
+                s.joli_titre()
+                s.signale_debut_traitement()
+                return fonction(_script=s, *args, **kwds)
+            finally:
+                s.signale_fin_traitement()
+
+        return init_script
+
+    return decorateur
+
+
+class ScriptAutomatheque(object):
+    """Objet ScriptAutomatheque qui automatise la creation de scripts.
+
+    Cet objet contient :
+    - self.arguments : les arguments récupérés par docopt
+    - self.config : automatiquement extraite de l'argument --config si présent
+                    mergée avec la configuration d'automatheque
+    - self.parametres : merge de arguments avec config
+    - self.logger : logger pour les appels internes de ScriptAutomatheque
+
+    """
+
+    def __init__(self, nom, chaine_docopt, version=None):
+        self.nom = nom
+        self.nom_court = re.sub(r"\.py$", "", os.path.basename(nom))
+        self.chaine_docopt = chaine_docopt
+        self.version = version
+        self.arguments = None
+        self.config = None
+        self._logger = None
+
+    def __repr__(self):
+        """TODO(#24) utiliser attrs."""
+        return "<ScriptAutomatheque {} {} {}>".format(
+            self.nom, self.arguments, self.config
+        )
+
+    @property
+    def logger(self):
+        """Loggeur pour le script_automatheque.
+
+        Permet de charger par défaut la configuration du logger stockée dans
+        le fichier de configuration, et de logger certaines actions de l'objet
+        :class:`ScriptAutomatheque` (alors ces logs sont écrits en utilisant
+        la configuration de `nom_du_script.main`)
+
+        L'ideal est ensuite de gérer les loggers avec `logging.getLogger()` ou
+        son wrapper `automatheque.log.recup_logger()` même si self.logger est
+        quand même accessible dans la fonction wrappée.
+
+        Si le logger pour le script n'a pas été déclaré, alors on utilise le
+        logger automatheque.
+        """
+        if not self._logger:
+            if not logger_existe(self.nom_court):
+                self._logger = recup_logger()
+                self._logger.warning("Aucun logger pour '{}'.".format(self.nom_court))
+                self._logger.warning("Utilisation du logger automatheque par défault.")
+            else:
+                self._logger = recup_logger(self.nom_court)
+        return self._logger
+
+    def joli_titre(self):
+        self.logger.info("********** {} {} *********".format(self.nom, self.version))
+
+    def initialise(self):
+        # Un script EST une application : c'est le bon endroit pour activer le
+        # logging console par défaut (la lib, elle, ne configure rien à l'import).
+        configure_logging_defaut()
+        self.arguments = docopt.docopt(self.chaine_docopt, version=self.version)
+        # Configuration en couches, de la plus générale à la plus spécifique
+        # (chaque couche surcharge la précédente) :
+        #   1. config.ini partagé d'automatheque  (chargé par ecraser=True)
+        #   2. <racine>/<nom_court>/config.ini     (propre au script)
+        #   3. --config <fichier>                  (explicite, ponctuel)
+        fichiers = [
+            os.path.join(
+                constantes.repertoire_config_script(self.nom_court), "config.ini"
+            )
+        ]
+        config_cli = self.arguments.get("--config")
+        if config_cli:
+            fichiers.append(config_cli)
+        self.config = charge_configuration(fichiers, ecraser=True, recharger=True)
+        # TODO(#27) ici on pourrait aussi merger la conf et les arguments ...
+        # dans self.parametres ?
+        """
+        def merge(dict_1, dict_2):
+            ""Merge two dictionaries.
+            Values that evaluate to true take priority over falsy values.
+            `dict_1` takes priority over `dict_2`.
+            ""
+            return dict((str(key), dict_1.get(key) or dict_2.get(key))
+        for key in set(dict_2) | set(dict_1))
+        """
+
+    def signale_debut_traitement(self):
+        """Signale que le traitement a debuté.
+
+        On pourrait aussi initialiser un logger et s'en servir.
+        """
+        self.logger.info(
+            "{}|{}| Début du traitement".format(
+                self.nom, datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%s")
+            )
+        )
+
+    def signale_fin_traitement(self):
+        """Signale que le traitement est terminé."""
+        self.logger.info(
+            "{}|{}| Fin du traitement".format(
+                self.nom, datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%s")
+            )
+        )
+
+
+# Alias court : `@script(...)` se lit mieux que `@script_automatheque(...)`.
+# Le nom canonique reste disponible (rétrocompatibilité).
+script = script_automatheque

--- a/src/automatheque/automatheque/util/script.py
+++ b/src/automatheque/automatheque/util/script.py
@@ -1,189 +1,34 @@
 # -*- coding:utf-8 -*-
-"""Utilitaire pour faciliter la création de scripts basés sur automatheque.
+"""Shim de rétrocompatibilité — l'API a déménagé vers :mod:`automatheque.script`.
 
-Il faut pouvoir l'utiliser aussi dans les modules, pas juste dans les scripts.
-TODO(#24)
+``script_automatheque`` (son alias court ``script``) et ``ScriptAutomatheque``
+vivent désormais dans :mod:`automatheque.script` (#41) : c'est l'API phare du
+projet (« se faciliter le scripting »), elle n'a plus sa place parmi les
+utilitaires bas niveau de ``util`` (``fichier``, ``reessaye``, ``repertoire``…).
 
-Le format que l'on souhaite est le suivant :
-```
-'''Mon script
+Ce module reste importable pour ne pas casser le code existant, mais émet un
+``DeprecationWarning`` à l'import. Migrez vos imports :
 
-Usage:
-  mon_script.py [--action] [--config=<fichier_config>]
+    - from automatheque.util.script import script      # déprécié
+    + from automatheque.script import script
 
-Options:
-  --action  Action realisée
-  --config=<fichier_config>  Fichier de configuration supplémentaire (ponctuel)
-'''
-__version__ = '0.1a'  # ou importer depuis mon_package.__version__
-
-# La configuration est chargée en couches, sans rien déclarer ici :
-#   ~/.config/automatheque/config.ini   (partagé entre scripts)
-#   ~/.config/<mon_script>/config.ini   (propre à ce script ; surcharge)
-#   --config <fichier>                  (ponctuel ; surcharge)
-
-from automatheque.util.script import script  # alias court de script_automatheque
-
-@script(__doc__, __version__)
-def main(..., _script=None):
-    # code à exécuter
-    # _script est un objet `ScriptAutomatheque`
-    print(_script)
-
-if __name__ == '__main__':
-    main(...)
-```
-Cela déclenche les logs de début, de fin, parse les arguments etc.
-
-``script`` est un alias court de ``script_automatheque`` : les deux noms sont
-équivalents et exportés depuis ``automatheque.util.script``.
+Le shim sera supprimé dans une version ultérieure.
 """
 
-import sys
-import os
-import re
-import datetime
-from functools import wraps
+import warnings
 
-import docopt
+from automatheque.script import (  # noqa: F401  (ré-exports voulus)
+    ScriptAutomatheque,
+    script,
+    script_automatheque,
+)
 
-from automatheque import constantes
-from automatheque.configuration import charge_configuration, NoOptionError
-from automatheque.log import configure_logging_defaut, recup_logger, logger_existe
+warnings.warn(
+    "automatheque.util.script est déprécié : importez depuis "
+    "automatheque.script (« from automatheque.script import script »). "
+    "Ce shim sera supprimé dans une version ultérieure.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-
-def script_automatheque(chaine_docopt, version=None):
-    """Decorateur pour ScriptAutomatheque.
-
-    - signale le début et la fin du traitement
-    - passe un objet ScriptAutomatheque à la fonction appelante
-    """
-    s = ScriptAutomatheque(
-        nom=sys.argv[0], chaine_docopt=chaine_docopt, version=version
-    )
-    s.initialise()
-
-    def decorateur(fonction):
-        @wraps(fonction)
-        def init_script(*args, **kwds):
-            try:
-                s.joli_titre()
-                s.signale_debut_traitement()
-                return fonction(_script=s, *args, **kwds)
-            finally:
-                s.signale_fin_traitement()
-
-        return init_script
-
-    return decorateur
-
-
-class ScriptAutomatheque(object):
-    """Objet ScriptAutomatheque qui automatise la creation de scripts.
-
-    Cet objet contient :
-    - self.arguments : les arguments récupérés par docopt
-    - self.config : automatiquement extraite de l'argument --config si présent
-                    mergée avec la configuration d'automatheque
-    - self.parametres : merge de arguments avec config
-    - self.logger : logger pour les appels internes de ScriptAutomatheque
-
-    """
-
-    def __init__(self, nom, chaine_docopt, version=None):
-        self.nom = nom
-        self.nom_court = re.sub(r"\.py$", "", os.path.basename(nom))
-        self.chaine_docopt = chaine_docopt
-        self.version = version
-        self.arguments = None
-        self.config = None
-        self._logger = None
-
-    def __repr__(self):
-        """TODO(#24) utiliser attrs."""
-        return "<ScriptAutomatheque {} {} {}>".format(
-            self.nom, self.arguments, self.config
-        )
-
-    @property
-    def logger(self):
-        """Loggeur pour le script_automatheque.
-
-        Permet de charger par défaut la configuration du logger stockée dans
-        le fichier de configuration, et de logger certaines actions de l'objet
-        :class:`ScriptAutomatheque` (alors ces logs sont écrits en utilisant
-        la configuration de `nom_du_script.main`)
-
-        L'ideal est ensuite de gérer les loggers avec `logging.getLogger()` ou
-        son wrapper `automatheque.log.recup_logger()` même si self.logger est
-        quand même accessible dans la fonction wrappée.
-
-        Si le logger pour le script n'a pas été déclaré, alors on utilise le
-        logger automatheque.
-        """
-        if not self._logger:
-            if not logger_existe(self.nom_court):
-                self._logger = recup_logger()
-                self._logger.warning("Aucun logger pour '{}'.".format(self.nom_court))
-                self._logger.warning("Utilisation du logger automatheque par défault.")
-            else:
-                self._logger = recup_logger(self.nom_court)
-        return self._logger
-
-    def joli_titre(self):
-        self.logger.info("********** {} {} *********".format(self.nom, self.version))
-
-    def initialise(self):
-        # Un script EST une application : c'est le bon endroit pour activer le
-        # logging console par défaut (la lib, elle, ne configure rien à l'import).
-        configure_logging_defaut()
-        self.arguments = docopt.docopt(self.chaine_docopt, version=self.version)
-        # Configuration en couches, de la plus générale à la plus spécifique
-        # (chaque couche surcharge la précédente) :
-        #   1. config.ini partagé d'automatheque  (chargé par ecraser=True)
-        #   2. <racine>/<nom_court>/config.ini     (propre au script)
-        #   3. --config <fichier>                  (explicite, ponctuel)
-        fichiers = [
-            os.path.join(
-                constantes.repertoire_config_script(self.nom_court), "config.ini"
-            )
-        ]
-        config_cli = self.arguments.get("--config")
-        if config_cli:
-            fichiers.append(config_cli)
-        self.config = charge_configuration(fichiers, ecraser=True, recharger=True)
-        # TODO(#27) ici on pourrait aussi merger la conf et les arguments ...
-        # dans self.parametres ?
-        """
-        def merge(dict_1, dict_2):
-            ""Merge two dictionaries.
-            Values that evaluate to true take priority over falsy values.
-            `dict_1` takes priority over `dict_2`.
-            ""
-            return dict((str(key), dict_1.get(key) or dict_2.get(key))
-        for key in set(dict_2) | set(dict_1))
-        """
-
-    def signale_debut_traitement(self):
-        """Signale que le traitement a debuté.
-
-        On pourrait aussi initialiser un logger et s'en servir.
-        """
-        self.logger.info(
-            "{}|{}| Début du traitement".format(
-                self.nom, datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%s")
-            )
-        )
-
-    def signale_fin_traitement(self):
-        """Signale que le traitement est terminé."""
-        self.logger.info(
-            "{}|{}| Fin du traitement".format(
-                self.nom, datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%s")
-            )
-        )
-
-
-# Alias court : `@script(...)` se lit mieux que `@script_automatheque(...)`.
-# Le nom canonique reste disponible (rétrocompatibilité).
-script = script_automatheque
+__all__ = ["script_automatheque", "ScriptAutomatheque", "script"]

--- a/src/automatheque/tests/test_essai.py
+++ b/src/automatheque/tests/test_essai.py
@@ -7,7 +7,7 @@ from automatheque.essai import (
     execute_script,
     reinitialise_configuration,
 )
-from automatheque.util.script import ScriptAutomatheque
+from automatheque.script import ScriptAutomatheque
 
 DOC = """Script de démonstration.
 

--- a/src/automatheque/tests/test_script.py
+++ b/src/automatheque/tests/test_script.py
@@ -1,0 +1,54 @@
+"""Tests de la promotion de l'API script (#41).
+
+`script_automatheque` / `script` / `ScriptAutomatheque` vivent désormais dans
+`automatheque.script`. `automatheque.util.script` reste un shim de
+rétrocompatibilité qui ré-exporte les mêmes objets et émet un
+`DeprecationWarning` à l'import.
+"""
+
+import importlib
+import warnings
+
+
+def test_import_depuis_le_nouvel_emplacement():
+    """Le nouvel emplacement expose bien l'API et son alias court."""
+    from automatheque.script import (
+        ScriptAutomatheque,
+        script,
+        script_automatheque,
+    )
+
+    assert script is script_automatheque
+    assert callable(script_automatheque)
+    assert isinstance(ScriptAutomatheque, type)
+
+
+def test_shim_util_script_emet_un_deprecationwarning():
+    """L'ancien chemin reste importable mais prévient de la dépréciation.
+
+    On recharge le module pour que l'avertissement soit ré-émis même si un
+    autre test (ou import) l'a déjà chargé auparavant.
+    """
+    import automatheque.util.script as ancien
+
+    with warnings.catch_warnings(record=True) as captures:
+        warnings.simplefilter("always")
+        importlib.reload(ancien)
+
+    assert any(
+        issubclass(c.category, DeprecationWarning)
+        and "automatheque.script" in str(c.message)
+        for c in captures
+    )
+
+
+def test_shim_reexporte_les_memes_objets():
+    """Le shim pointe vers les objets canoniques, pas des copies."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        import automatheque.script as nouveau
+        import automatheque.util.script as ancien
+
+    assert ancien.script_automatheque is nouveau.script_automatheque
+    assert ancien.ScriptAutomatheque is nouveau.ScriptAutomatheque
+    assert ancien.script is nouveau.script


### PR DESCRIPTION
Première étape du **Jalon A**. Promeut l'API phare du projet au premier niveau.

Résout #41.

## Pourquoi

`script_automatheque` (+ alias `script`) et `ScriptAutomatheque` sont **le cœur
de l'expérience** (« se faciliter le scripting »), mais vivaient dans
`automatheque.util.script`, noyés parmi les utilitaires bas niveau (`fichier`,
`reessaye`, `repertoire`…). Import verbeux, API sous-vendue.

## Changements

- **Nouveau module dédié `automatheque/script.py`** → `from automatheque.script import script`.
  - Volontairement **pas** exposé via le `__init__` du paquet : sinon `import
    automatheque` tirerait `docopt` + `configuration` à chaque fois (garde-fou du #41).
- **`automatheque/util/script.py` → shim** : ré-exporte `script_automatheque`,
  `script`, `ScriptAutomatheque` depuis le nouvel emplacement et émet un
  `DeprecationWarning` à l'import. Suppression prévue à terme.
- **Imports internes migrés** : `automatheque.essai`, `automatheque.factrice.app`,
  tests.
- **README** (paquet) : nouvel import + alias court `script` + note de dépréciation.

## Tests

- `test_script.py` : import depuis le nouveau chemin, le shim émet bien le
  `DeprecationWarning`, et les ré-exports pointent vers **les mêmes objets**.
- Suite complète : **39 passed** (`pytest src`, install éditable des 3 paquets
  comme en CI), `factrice` non régressé.

## Rétrocompat

Pré-1.0, mais le shim assure la transition douce : le code existant
(`from automatheque.util.script import …`) continue de fonctionner, avec un
avertissement invitant à migrer.

## Suite

#5 (enrichir `@script_automatheque` : `--dry-run`, `-v/-q`, codes de sortie)
viendra se poser sur ce nouvel emplacement.