### PR TITLE
feat(script): enrichit @script_automatheque (dry-run, verbosité, sortie propre) (#5)

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `@script_automatheque` — commodités câblées automatiquement quand le script
+  les déclare dans son usage docopt (#5) :
+  * `--dry-run` exposé via `_script.dry_run` (au script d'en tenir compte) ;
+  * `-v`/`--verbose` (DEBUG) et `-q`/`--quiet` (WARNING) ajustent le niveau de
+    log sans code ;
+  * `Ctrl-C` (KeyboardInterrupt) → sortie propre (code POSIX 130) au lieu d'une
+    traceback ; toute exception non gérée est journalisée (avec sa traceback)
+    avant de remonter ;
+  * la fin de traitement journalise la **durée** d'exécution.
+
 ### Changed
 
 * `script_automatheque` / `script` / `ScriptAutomatheque` sont promus de

--- a/src/automatheque/automatheque/script.py
+++ b/src/automatheque/automatheque/script.py
@@ -9,10 +9,13 @@ Le format que l'on souhaite est le suivant :
 '''Mon script
 
 Usage:
-  mon_script.py [--action] [--config=<fichier_config>]
+  mon_script.py [--action] [--dry-run] [-v | -q] [--config=<fichier_config>]
 
 Options:
   --action  Action realisée
+  --dry-run  N'effectue aucune action définitive
+  -v --verbose  Journalisation plus bavarde (DEBUG) ; répétable
+  -q --quiet  Journalisation plus discrète (WARNING)
   --config=<fichier_config>  Fichier de configuration supplémentaire (ponctuel)
 '''
 __version__ = '0.1a'  # ou importer depuis mon_package.__version__
@@ -28,12 +31,18 @@ from automatheque.script import script  # alias court de script_automatheque
 def main(..., _script=None):
     # code à exécuter
     # _script est un objet `ScriptAutomatheque`
+    if _script.dry_run:
+        return  # rien de définitif en dry-run
     print(_script)
 
 if __name__ == '__main__':
     main(...)
 ```
-Cela déclenche les logs de début, de fin, parse les arguments etc.
+Cela déclenche les logs de début, de fin, parse les arguments etc. Si le script
+déclare ``--dry-run``, ``-v``/``-q`` dans son usage, ils sont **câblés
+automatiquement** : ``_script.dry_run`` et le niveau de log sont ajustés sans
+code supplémentaire. Une interruption clavier (Ctrl-C) se solde par une sortie
+propre (code 130) et toute exception non gérée est journalisée avant de remonter.
 
 ``script`` est un alias court de ``script_automatheque`` : les deux noms sont
 équivalents et exportés depuis ``automatheque.script``.
@@ -48,6 +57,7 @@ Cela déclenche les logs de début, de fin, parse les arguments etc.
 import sys
 import os
 import re
+import logging
 import datetime
 from functools import wraps
 
@@ -75,7 +85,22 @@ def script_automatheque(chaine_docopt, version=None):
             try:
                 s.joli_titre()
                 s.signale_debut_traitement()
+                if s.dry_run:
+                    s.logger.info(
+                        "Mode --dry-run actif : aucune action définitive "
+                        "ne devrait être effectuée."
+                    )
                 return fonction(_script=s, *args, **kwds)
+            except KeyboardInterrupt:
+                # Ctrl-C : sortie propre (code POSIX 130) plutôt qu'une
+                # traceback. N'arrive jamais dans les tests (pas d'interruption).
+                s.logger.warning("Interruption clavier (Ctrl-C) — arrêt.")
+                raise SystemExit(130)
+            except Exception:
+                # On journalise l'erreur (avec sa traceback) puis on la laisse
+                # remonter : code de sortie non nul + testabilité préservée.
+                s.logger.exception("Le script s'est terminé sur une erreur.")
+                raise
             finally:
                 s.signale_fin_traitement()
 
@@ -103,6 +128,11 @@ class ScriptAutomatheque(object):
         self.version = version
         self.arguments = None
         self.config = None
+        #: Vrai si le script a été appelé avec ``--dry-run`` (câblé
+        #: automatiquement si l'option figure dans l'usage docopt). Au script
+        #: d'en tenir compte pour ne rien modifier de définitif.
+        self.dry_run = False
+        self._debut = None
         self._logger = None
 
     def __repr__(self):
@@ -158,6 +188,10 @@ class ScriptAutomatheque(object):
         if config_cli:
             fichiers.append(config_cli)
         self.config = charge_configuration(fichiers, ecraser=True, recharger=True)
+        # Commodités câblées automatiquement si le script les déclare dans son
+        # usage docopt (sinon `.get` renvoie None → comportement par défaut).
+        self.dry_run = bool(self.arguments.get("--dry-run"))
+        self._applique_verbosite()
         # TODO(#27) ici on pourrait aussi merger la conf et les arguments ...
         # dans self.parametres ?
         """
@@ -170,22 +204,63 @@ class ScriptAutomatheque(object):
         for key in set(dict_2) | set(dict_1))
         """
 
+    def _niveau_journal_demande(self):
+        """Traduit ``-v``/``-vv``/``-q`` en niveau de log, ou ``None``.
+
+        ``None`` = ne rien changer (on garde le niveau INFO par défaut).
+        ``--quiet``/``-q`` masque les INFO (WARNING) ; ``--verbose``/``-v``
+        (répétable) descend en DEBUG.
+        """
+        args = self.arguments or {}
+        if args.get("--quiet") or args.get("-q"):
+            return logging.WARNING
+        v = args.get("--verbose")
+        if v is None:
+            v = args.get("-v")
+        try:
+            v = int(v or 0)
+        except (TypeError, ValueError):
+            v = 1 if v else 0
+        if v >= 1:
+            return logging.DEBUG
+        return None
+
+    def _applique_verbosite(self):
+        """Aligne le logger et le handler ``automatheque`` sur ``-v``/``-q``.
+
+        Il faut baisser le niveau du **handler** (INFO par défaut, cf.
+        ``constantes.logger_config_dict``), sinon les DEBUG restent filtrés.
+        """
+        niveau = self._niveau_journal_demande()
+        if niveau is None:
+            return
+        lg = logging.getLogger("automatheque")
+        lg.setLevel(niveau)
+        for handler in lg.handlers:
+            handler.setLevel(niveau)
+
     def signale_debut_traitement(self):
         """Signale que le traitement a debuté.
 
         On pourrait aussi initialiser un logger et s'en servir.
         """
+        self._debut = datetime.datetime.now()
         self.logger.info(
             "{}|{}| Début du traitement".format(
-                self.nom, datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%s")
+                self.nom, self._debut.strftime("%Y-%m-%d %H:%M:%S")
             )
         )
 
     def signale_fin_traitement(self):
-        """Signale que le traitement est terminé."""
+        """Signale que le traitement est terminé (avec la durée si connue)."""
+        fin = datetime.datetime.now()
+        if self._debut is not None:
+            duree = "{:.3f}s".format((fin - self._debut).total_seconds())
+        else:
+            duree = "?"
         self.logger.info(
-            "{}|{}| Fin du traitement".format(
-                self.nom, datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%s")
+            "{}|{}| Fin du traitement (durée : {})".format(
+                self.nom, fin.strftime("%Y-%m-%d %H:%M:%S"), duree
             )
         )
 

--- a/src/automatheque/tests/test_script.py
+++ b/src/automatheque/tests/test_script.py
@@ -7,7 +7,29 @@ rétrocompatibilité qui ré-exporte les mêmes objets et émet un
 """
 
 import importlib
+import logging
 import warnings
+
+import pytest
+
+from automatheque.essai import execute_script
+
+
+#: Usage docopt déclarant les commodités câblées par #5.
+DOC_OPTIONS = """Script de démonstration des options.
+
+Usage:
+  demo [--dry-run] [-v | -q]
+
+Options:
+  --dry-run     N'effectue aucune action définitive.
+  -v --verbose  Journalisation DEBUG.
+  -q --quiet    Journalisation WARNING.
+"""
+
+
+def _noop(_script=None):
+    return "ok"
 
 
 def test_import_depuis_le_nouvel_emplacement():
@@ -52,3 +74,62 @@ def test_shim_reexporte_les_memes_objets():
     assert ancien.script_automatheque is nouveau.script_automatheque
     assert ancien.ScriptAutomatheque is nouveau.ScriptAutomatheque
     assert ancien.script is nouveau.script
+
+
+# --- #5 : enrichissement de @script_automatheque -------------------------------
+
+
+def test_dry_run_cable_automatiquement():
+    """`--dry-run` déclaré dans l'usage → `_script.dry_run` reflète l'argument."""
+    avec = execute_script(DOC_OPTIONS, _noop, argv=["--dry-run"])
+    sans = execute_script(DOC_OPTIONS, _noop, argv=[])
+
+    assert avec.script.dry_run is True
+    assert sans.script.dry_run is False
+
+
+def test_verbosite_v_descend_en_debug():
+    """`-v` abaisse le logger ET le handler `automatheque` en DEBUG."""
+    execute_script(DOC_OPTIONS, _noop, argv=["-v"])
+
+    lg = logging.getLogger("automatheque")
+    assert lg.level == logging.DEBUG
+    assert all(h.level == logging.DEBUG for h in lg.handlers)
+
+
+def test_verbosite_q_remonte_en_warning():
+    """`-q` masque les INFO en passant le logger `automatheque` en WARNING."""
+    execute_script(DOC_OPTIONS, _noop, argv=["-q"])
+
+    assert logging.getLogger("automatheque").level == logging.WARNING
+
+
+def test_interruption_clavier_sort_proprement_130():
+    """Un Ctrl-C (KeyboardInterrupt) se traduit en `SystemExit(130)`."""
+
+    def interrompt(_script=None):
+        raise KeyboardInterrupt
+
+    with pytest.raises(SystemExit) as exc:
+        execute_script(DOC_OPTIONS, interrompt, argv=[])
+
+    assert exc.value.code == 130
+
+
+def test_exception_journalisee_et_propagee(caplog):
+    """Une exception non gérée est journalisée (avec traceback) puis remonte."""
+
+    def echoue(_script=None):
+        raise ValueError("boom")
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match="boom"):
+            execute_script(DOC_OPTIONS, echoue, argv=[])
+
+    assert any("erreur" in r.message.lower() for r in caplog.records)
+
+
+def test_duree_mesuree_a_la_fin():
+    """La fin de traitement dispose d'un horodatage de début pour la durée."""
+    res = execute_script(DOC_OPTIONS, _noop, argv=[])
+    assert res.script._debut is not None


### PR DESCRIPTION
Deuxième étape du **Jalon A**, posée sur la promotion de #41 (PR #57).
Résout #5.

## Objectif

Doter `@script_automatheque` des commodités attendues d'un framework de scripts,
**câblées automatiquement** dès que le script les déclare dans son usage docopt
(sinon : comportement par défaut inchangé).

## Ajouts

- **`--dry-run`** → exposé via `_script.dry_run` (au script d'en tenir compte ;
  un message le rappelle dans les logs).
- **Verbosité** : `-v`/`--verbose` → DEBUG, `-q`/`--quiet` → WARNING. Ajuste le
  niveau du **logger *et* du handler** `automatheque` (handler à INFO par défaut,
  sinon les DEBUG resteraient filtrés).
- **Sortie propre** :
  - `Ctrl-C` (`KeyboardInterrupt`) → `SystemExit(130)` (code POSIX) au lieu d'une
    traceback ;
  - toute exception non gérée est **journalisée** (avec sa traceback) avant de
    remonter.
- **Durée** d'exécution journalisée en fin de traitement (+ correction au passage
  du `%s` → `%S` dans le format d'horodatage).

## Compatibilité harness (important)

Le harness `essai.execute_script` (#46) capture la **valeur de retour** de la
fonction décorée. L'enrichissement **ne fait aucun `sys.exit` sur le chemin
nominal** : seul un vrai `Ctrl-C` produit `SystemExit(130)` (jamais déclenché
en test), et les exceptions sont journalisées **puis re-levées** (propagation et
testabilité préservées).

## `--config`

Déjà câblé depuis #2/#53 (couche ponctuelle de la config en couches) — rien à
changer ici.

## Tests

Via `essai.execute_script` : `dry_run` on/off, `-v`→DEBUG, `-q`→WARNING,
`Ctrl-C`→130, exception journalisée+propagée, durée mesurée. **45 passed**
(`pytest src`, install éditable comme en CI), robuste au ré-ordonnancement.

## Reste hors périmètre (pour ne pas surcharger)

Le hook `atexit` « résumé d'exécution » avec **compteur d'actions** du #5 n'est
pas inclus (nécessiterait une API de comptage d'actions) — à traiter séparément
si souhaité. La durée, elle, est déjà là.