### PR TITLE
feat(script): dispatch commandopt 1.0 + passage à docopt-ng (#39, #4)

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Parseur CLI : passage de `docopt` à **`docopt-ng`** (`docopt-ng>=0.9,<1`) —
+  fork maintenu, même module importable `docopt` (aucun changement de code),
+  aligné avec commandopt qui s'appuie sur le même parseur. — cf. #4
 * `script_automatheque` / `script` / `ScriptAutomatheque` sont promus de
   `automatheque.util.script` vers **`automatheque.script`** : c'est l'API phare
   du projet, pas un utilitaire bas niveau. `automatheque.util.script` reste

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Dispatch de **sous-commandes** via **commandopt 1.0** dans
+  `@script_automatheque` (#39) : on déclare des fonctions-commandes avec
+  `@commande([...])` (alias de `commandopt.commandopt`, ré-exporté par
+  `automatheque.script`) et on aiguille avec `_script.execute_commande()`. Les
+  options internes d'automatheque (`--config`, `--dry-run`, `-v`/`-q`, cf.
+  `OPTIONS_INTERNES`) sont **exclues de la sélection**. Nouvelle dépendance
+  `commandopt>=1.0.0rc1,<2` — automatheque sert de banc de validation à la 1.0.
 * `@script_automatheque` — commodités câblées automatiquement quand le script
   les déclare dans son usage docopt (#5) :
   * `--dry-run` exposé via `_script.dry_run` (au script d'en tenir compte) ;

--- a/src/automatheque/automatheque/script.py
+++ b/src/automatheque/automatheque/script.py
@@ -47,6 +47,29 @@ propre (code 130) et toute exception non gérée est journalisée avant de remon
 ``script`` est un alias court de ``script_automatheque`` : les deux noms sont
 équivalents et exportés depuis ``automatheque.script``.
 
+Sous-commandes (via ``commandopt``) : on déclare des fonctions-commandes avec
+``@commande([...])`` et on aiguille avec ``_script.execute_commande()``. Les
+options internes d'automatheque (``--config``, ``--dry-run``, ``-v``/``-q``)
+sont exclues de la sélection.
+```
+'''Usage:
+  mon_script.py (--ajouter | --supprimer) [--config=<f>] [-v]
+'''
+from automatheque.script import script, commande
+
+@commande(["--ajouter"])
+def ajouter(arguments):
+    ...
+
+@commande(["--supprimer"])
+def supprimer(arguments):
+    ...
+
+@script(__doc__, __version__)
+def main(_script):
+    return _script.execute_commande()
+```
+
 .. note::
    Historiquement ce module vivait dans ``automatheque.util.script``. Il a été
    promu au premier niveau (:mod:`automatheque.script`) car c'est l'API centrale
@@ -54,18 +77,39 @@ propre (code 130) et toute exception non gérée est journalisée avant de remon
    importable via un shim qui émet un ``DeprecationWarning``.
 """
 
-import sys
+import datetime
+import logging
 import os
 import re
-import logging
-import datetime
+import sys
 from functools import wraps
 
 import docopt
 
+# Ré-exportés pour offrir une seule surface d'import aux scripts
+# (`from automatheque.script import commande, Registry, NoCommandFoundError`).
+from commandopt import (  # noqa: F401
+    Command,
+    NoCommandFoundError,
+    Registry,
+    commandopt,
+)
+
 from automatheque import constantes
-from automatheque.configuration import charge_configuration, NoOptionError
-from automatheque.log import configure_logging_defaut, recup_logger, logger_existe
+from automatheque.configuration import charge_configuration
+from automatheque.log import configure_logging_defaut, logger_existe, recup_logger
+
+#: Options « internes » à automatheque : elles configurent le script (logging,
+#: emplacement de config, simulation), elles ne le **routent** pas. On les
+#: exclut donc de la sélection de commande commandopt (#39), sinon un
+#: ``--config`` ou un ``-v`` ferait échouer l'appariement d'une commande.
+OPTIONS_INTERNES = frozenset(
+    {"--config", "--dry-run", "-v", "--verbose", "-q", "--quiet"}
+)
+
+#: Alias ergonomique de :func:`commandopt.commandopt` : ``@commande([...])`` se
+#: lit mieux dans un script. Le nom d'origine reste disponible via commandopt.
+commande = commandopt
 
 
 def script_automatheque(chaine_docopt, version=None):
@@ -203,6 +247,24 @@ class ScriptAutomatheque(object):
             return dict((str(key), dict_1.get(key) or dict_2.get(key))
         for key in set(dict_2) | set(dict_1))
         """
+
+    def execute_commande(self, registry=None):
+        """Aiguille vers la commande commandopt correspondant aux arguments.
+
+        Les commandes sont déclarées avec ``@commande([...])`` (alias de
+        :func:`commandopt.commandopt`) ; ``execute_commande`` sélectionne celle
+        dont les options obligatoires sont présentes dans ``self.arguments`` et
+        l'exécute, en lui passant le dict d'arguments complet.
+
+        Les :data:`OPTIONS_INTERNES` d'automatheque (``--config``, ``-v``…) sont
+        **exclues de la sélection** : elles paramètrent le script sans le router.
+
+        :param registry: :class:`commandopt.Registry` à interroger ; par défaut
+            le registre global (façade :class:`commandopt.Command`).
+        :raises commandopt.NoCommandFoundError: si aucune commande ne correspond.
+        """
+        cible = Command if registry is None else registry
+        return cible.run(self.arguments, ignore=OPTIONS_INTERNES)
 
     def _niveau_journal_demande(self):
         """Traduit ``-v``/``-vv``/``-q`` en niveau de log, ou ``None``.

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -18,8 +18,12 @@ classifiers = [
 ]
 dependencies = [
     # Borné < 1 : garde-fou contre une éventuelle 1.0 à breaking changes
-    # (migration suivie dans #4 / #39).
+    # (migration vers docopt-ng suivie dans #4).
     "docopt>=0.6,<1",
+    # Dispatch de sous-commandes dans @script_automatheque (#39). La borne
+    # >=1.0.0rc1 embarque volontairement la RC : automatheque sert de banc de
+    # validation à la 1.0 de commandopt. <2 : garde-fou contre une 2.0.
+    "commandopt>=1.0.0rc1,<2",
     "pytz",
     "pyyaml",
     "attrs>=19.2",

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -17,9 +17,10 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    # Borné < 1 : garde-fou contre une éventuelle 1.0 à breaking changes
-    # (migration vers docopt-ng suivie dans #4).
-    "docopt>=0.6,<1",
+    # docopt-ng : fork maintenu de docopt, même module importable `docopt`
+    # (drop-in). Aligné avec commandopt, qui s'appuie lui aussi sur docopt-ng
+    # (#4). Borné < 1 : garde-fou contre une 1.0 à breaking changes.
+    "docopt-ng>=0.9,<1",
     # Dispatch de sous-commandes dans @script_automatheque (#39). La borne
     # >=1.0.0rc1 embarque volontairement la RC : automatheque sert de banc de
     # validation à la 1.0 de commandopt. <2 : garde-fou contre une 2.0.

--- a/src/automatheque/tests/test_script.py
+++ b/src/automatheque/tests/test_script.py
@@ -10,10 +10,11 @@ import importlib
 import logging
 import warnings
 
+import commandopt
 import pytest
-
 from automatheque.essai import execute_script
-
+from automatheque.script import OPTIONS_INTERNES, commande
+from commandopt import NoCommandFoundError, Registry
 
 #: Usage docopt déclarant les commodités câblées par #5.
 DOC_OPTIONS = """Script de démonstration des options.
@@ -133,3 +134,90 @@ def test_duree_mesuree_a_la_fin():
     """La fin de traitement dispose d'un horodatage de début pour la durée."""
     res = execute_script(DOC_OPTIONS, _noop, argv=[])
     assert res.script._debut is not None
+
+
+# --- #39 : intégration commandopt (dispatch de sous-commandes) -----------------
+
+
+#: Usage docopt déclarant deux sous-commandes + des options internes.
+DOC_COMMANDES = """Script de démonstration des sous-commandes.
+
+Usage:
+  demo [--ajouter] [--supprimer] [--config=<f>] [-v] [--dry-run]
+
+Options:
+  --ajouter     Ajoute.
+  --supprimer   Supprime.
+  -v            Bavard.
+  --dry-run     Simulation.
+  --config=<f>  Configuration ponctuelle.
+"""
+
+
+def test_commande_est_l_alias_de_commandopt():
+    """`commande` est exactement le décorateur `commandopt.commandopt`."""
+    assert commande is commandopt.commandopt
+
+
+def test_execute_commande_aiguille_vers_la_bonne_commande():
+    """`execute_commande` sélectionne la commande selon les options présentes."""
+    reg = Registry()
+
+    @commande(["--ajouter"], registry=reg)
+    def ajouter(arguments):
+        return "AJOUT"
+
+    @commande(["--supprimer"], registry=reg)
+    def supprimer(arguments):
+        return "SUPPR"
+
+    def main(_script=None):
+        return _script.execute_commande(registry=reg)
+
+    assert execute_script(DOC_COMMANDES, main, argv=["--ajouter"]).resultat == "AJOUT"
+    assert execute_script(DOC_COMMANDES, main, argv=["--supprimer"]).resultat == "SUPPR"
+
+
+def test_execute_commande_ignore_les_options_internes():
+    """`--config`/`-v`/`--dry-run` n'entrent pas dans la sélection, mais restent
+    transmises à la commande."""
+    reg = Registry()
+
+    @commande(["--ajouter"], registry=reg)
+    def ajouter(arguments):
+        return arguments  # on renvoie le dict complet pour l'inspecter
+
+    def main(_script=None):
+        return _script.execute_commande(registry=reg)
+
+    args = execute_script(
+        DOC_COMMANDES,
+        main,
+        argv=["--ajouter", "--config", "c.ini", "-v", "--dry-run"],
+    ).resultat
+
+    # La sélection a réussi malgré les options internes…
+    assert args["--ajouter"] is True
+    # … et la commande reçoit bien le dict complet, options internes incluses.
+    assert args["--config"] == "c.ini"
+
+
+def test_execute_commande_sans_correspondance_leve():
+    """Aucune option de commande présente → NoCommandFoundError (propagée)."""
+    reg = Registry()
+
+    @commande(["--ajouter"], registry=reg)
+    def ajouter(arguments):
+        return "AJOUT"
+
+    def main(_script=None):
+        return _script.execute_commande(registry=reg)
+
+    with pytest.raises(NoCommandFoundError):
+        execute_script(DOC_COMMANDES, main, argv=["--config", "c.ini"])
+
+
+def test_options_internes_couvrent_les_commodites():
+    """Le jeu d'options ignorées couvre config + dry-run + verbosité."""
+    attendues = {"--config", "--dry-run", "-v", "--verbose", "-q", "--quiet"}
+    assert attendues <= OPTIONS_INTERNES

--- a/src/automatheque/tests/test_script.py
+++ b/src/automatheque/tests/test_script.py
@@ -221,3 +221,14 @@ def test_options_internes_couvrent_les_commodites():
     """Le jeu d'options ignorées couvre config + dry-run + verbosité."""
     attendues = {"--config", "--dry-run", "-v", "--verbose", "-q", "--quiet"}
     assert attendues <= OPTIONS_INTERNES
+
+
+# --- #4 : migration docopt -> docopt-ng ----------------------------------------
+
+
+def test_parseur_est_docopt_ng():
+    """#4 : le module `docopt` importé est fourni par docopt-ng (dépendance
+    déclarée), aligné avec commandopt qui s'appuie sur le même parseur."""
+    import importlib.metadata as md
+
+    assert md.version("docopt-ng")  # lève PackageNotFoundError si absent


### PR DESCRIPTION
Aligne automatheque sur **docopt-ng** et y intègre le **dispatch de
sous-commandes de commandopt 1.0**. Résout **#39** et **#4** (traités ensemble
car commandopt s'appuie sur docopt-ng : un seul parseur partout).

## #4 — docopt → docopt-ng

docopt-ng est le fork maintenu de docopt, exposant le **même module importable
`docopt`** : `docopt.docopt(usage, version=…)` est inchangé → **aucune
modification de code**, seulement la dépendance.

- `docopt>=0.6,<1` → **`docopt-ng>=0.9,<1`** (`>=0.9` = plancher de commandopt ;
  `<1` garde-fou breaking changes).
- Test verrouillant la migration.

## #39 — dispatch commandopt 1.0

Après enquête sur la RC (`1.0.0rc1`, PyPI), l'API est un **dispatcher de
sous-commandes** : on enregistre des fonctions indexées par les options docopt
« vraies », et `Registry.run(arguments, ignore=…)` sélectionne+exécute la bonne.

- **`@commande([...])`** — alias de `commandopt.commandopt`, ré-exporté par
  `automatheque.script` (avec `Command`, `Registry`, `NoCommandFoundError`).
- **`_script.execute_commande(registry=None)`** — aiguille selon `self.arguments`
  en passant `ignore=OPTIONS_INTERNES`.
- **`OPTIONS_INTERNES`** = `{--config, --dry-run, -v, --verbose, -q, --quiet}` :
  ces options **paramètrent** le script, elles ne le **routent** pas → exclues
  de la sélection (sinon un `--config` casserait l'appariement). La commande
  reçoit malgré tout le **dict complet**.
- Dépendance **`commandopt>=1.0.0rc1,<2`** : embarque volontairement la RC —
  automatheque sert de **banc de validation** à la 1.0 de commandopt.

## Validation

Prototype + suite `pytest src` : **51 passed**, **ruff clean**. Tourne sur
docopt-ng (parsing, groupes `( | )`, dispatch, `ignore`, `NoCommandFoundError`).

## Suite

- Une fois la 1.0 de commandopt figée : remonter la borne à `>=1,<2`.
- Le `[Unreleased]` d'automatheque (#41 + #5 + #39 + #4) est mûr pour une
  **0.13.0**.