### PR TITLE
docs(script): exemple de sous-commandes dans le README paquet

### DIFF
--- a/src/automatheque/README.md
+++ b/src/automatheque/README.md
@@ -34,3 +34,38 @@ if __name__ == '__main__':
 > L'API a été promue de `automatheque.util.script` vers `automatheque.script`
 > (#41). L'ancien chemin reste importable (shim) mais émet un
 > `DeprecationWarning` : migrez vers `from automatheque.script import script`.
+
+Le décorateur câble automatiquement, si le script les déclare dans son usage :
+`--dry-run` (via `_script.dry_run`), la verbosité `-v`/`-q` (niveau de log), une
+sortie propre sur `Ctrl-C` (code 130), et la durée d'exécution.
+
+### Sous-commandes (via commandopt)
+
+On déclare des fonctions-commandes avec `@commande([...])` (alias de
+`commandopt.commandopt`) et on aiguille avec `_script.execute_commande()`. Les
+options internes d'automatheque (`--config`, `--dry-run`, `-v`/`-q`) sont
+exclues de la sélection, mais restent transmises à la commande.
+
+```python
+"""Mon script
+
+Usage:
+  mon_script.py (--ajouter | --supprimer) [--config=<f>] [-v]
+"""
+from automatheque.script import script, commande
+
+@commande(["--ajouter"])
+def ajouter(arguments):
+    ...
+
+@commande(["--supprimer"])
+def supprimer(arguments):
+    ...
+
+@script(__doc__, __version__)
+def main(_script):
+    return _script.execute_commande()
+
+if __name__ == '__main__':
+    main()
+```


### PR DESCRIPTION
Complète la doc de #39 (dispatch commandopt, mergé via #59).

L'exemple de sous-commandes (`@commande([...])` + `_script.execute_commande()`)
n'existait que dans la **docstring du module** `automatheque.script` ; le **README
du paquet** — plus visible — ne le montrait pas. Ce commit l'y ajoute, avec un
rappel des commodités câblées (`--dry-run`, `-v`/`-q`, Ctrl-C→130, durée).

Doc uniquement, aucun changement de code.