### PR TITLE
release: coupe 0.13.0 (automatheque)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.12.0"
+version = "0.13.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-16
+
 ### Added
 
 * Dispatch de **sous-commandes** via **commandopt 1.0** dans
@@ -201,7 +203,8 @@ Nouvel utilitaire, pour gérer les dépendances externes.
 
 * Corrige lien entre media et photo
 
-[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.12.0...HEAD
+[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.13.0...HEAD
+[0.13.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.13.0
 [0.12.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.12.0
 [0.11.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.11.0
 [0.8.10]: https://github.com/jaegerbobomb/automatheque/releases/tag/v0.8.10

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.12.0"
+version = "0.13.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
Prépare la **0.13.0**. À merger sur `main` **avant** de poser le tag `0.13.0`
(qui déclenche la publication PyPI).

## Périmètre du bump (règle monas : on ne bumpe que ce qui change)

| Paquet | → | Raison |
|--------|---|--------|
| `automatheque` | **0.13.0** | Jalon A : #41 + #5 + #39 + #4 |
| `automatheque.factrice` | *inchangé (0.12.0)* | aucun changement depuis 0.12.0 |
| `automatheque.schema` | *inchangé (0.9.7)* | idem |

Invariant monas respecté : `version` monas == max des versions == `0.13.0`.

## Contenu 0.13.0

- **#41** — promotion de l'API phare vers `automatheque.script` (+ shim déprécié sur `util.script`).
- **#5** — `@script_automatheque` enrichi : `--dry-run`, verbosité `-v`/`-q`, sortie propre sur `Ctrl-C` (130) + exceptions journalisées, durée d'exécution.
- **#39** — dispatch de sous-commandes via **commandopt 1.0** (`@commande` + `_script.execute_commande()`, options internes exclues de la sélection).
- **#4** — passage de `docopt` à **`docopt-ng`** (aligné avec commandopt).

## Changements de fichiers

- `pyproject.toml` (monas) + `automatheque` → `0.13.0`.
- CHANGELOG `automatheque` : section `[0.13.0] - 2026-07-16`, `[Unreleased]` vidé, liens de comparaison mis à jour.

## Après merge

Poser le tag **`0.13.0`** (sans préfixe `v`) sur `main` → le workflow *release*
publie **uniquement `automatheque`** (factrice et schema ne matchent pas le tag).