### PR TITLE
docs: convention de fermeture d'issues (mots-clés) + gabarit PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!--
+Merci pour la PR ! Quelques rappels (cf. CONTRIBUTING.md) :
+- Commits signés + `Signed-off-by` (DCO) : `git commit -s`.
+- Entrée CHANGELOG sous `[Unreleased]` du paquet concerné.
+- Tests verts (`pytest src`) et `ruff` propre.
+-->
+
+## Description
+
+<!-- Que fait cette PR, et pourquoi ? (français bienvenu) -->
+
+## Issues liées
+
+<!--
+OBLIGATOIRE si la PR termine une ou plusieurs issues : un mot-clé ANGLAIS
+reconnu par GitHub PAR issue, sinon l'issue NE se ferme PAS au merge.
+« Résout #N » / « cf. #N » ne ferment rien.
+-->
+
+Closes #
+
+<!-- Références sans fermeture (facultatif) : cf. #N -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,3 +83,28 @@ By making a contribution to this project, I certify that:
 * Les messages de commit et le journal suivent
   [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) : pensez à ajouter
   une entrée dans le `CHANGELOG` du paquet concerné, sous `[Unreleased]`.
+
+## Lier et fermer les issues
+
+Une PR qui **termine** une issue doit la **fermer automatiquement au merge**.
+Pour cela, la description de la PR **doit** contenir un des mots-clés reconnus
+par GitHub, en **anglais**, suivi du numéro :
+
+```
+Closes #42
+Fixes #42
+Resolves #42
+```
+
+⚠️ **Les périphrases françaises ne ferment rien.** « Résout #42 », « Corrige
+#42 », « cf. #42 » sont ignorées par GitHub : l'issue **reste ouverte** et il
+faut la fermer à la main. On peut tout à fait rédiger le reste de la description
+en français — mais le mot-clé de fermeture, lui, est en anglais.
+
+* Une PR peut fermer plusieurs issues : un mot-clé **par** issue
+  (`Closes #4\nCloses #39`), pas `Closes #4, #39`.
+* Pour seulement **référencer** une issue sans la fermer, citer `#42` sans
+  mot-clé (ou « cf. #42 »).
+
+Le gabarit [`.github/pull_request_template.md`](.github/pull_request_template.md)
+pré-remplit ce champ pour ne pas l'oublier.


### PR DESCRIPTION
Inscrit **dans le dépôt** la règle « une PR qui termine une issue la ferme au
merge » — pour ne plus dépendre d'une bonne volonté et arrêter les fermetures
manuelles à répétition.

## Ce que ça ajoute

- **`CONTRIBUTING.md`** → section *« Lier et fermer les issues »* : les mots-clés
  **anglais** (`Closes` / `Fixes` / `Resolves #N`) sont **obligatoires** pour
  fermer une issue ; les périphrases françaises (« Résout #N », « cf. #N »)
  n'ont **aucun effet** côté GitHub. Un mot-clé **par** issue.
- **`.github/pull_request_template.md`** → gabarit pré-remplissant un champ
  `Closes #` (section « Issues liées »), pour que le mot-clé soit sous les yeux
  à chaque création de PR.

## Portée

Documentation / process uniquement, aucun code touché.

_(Cette PR n'a pas de mot-clé de fermeture : elle ne clôt aucune issue existante,
elle établit la convention.)_