### PR TITLE
release: coupe 0.13.1 (automatheque)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.13.0"
+version = "0.13.1"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-07-17
+
 ### Fixed
 
 * **Logging (régression #45)** : la section `[log]` d'un script configure
@@ -228,7 +230,8 @@ Nouvel utilitaire, pour gérer les dépendances externes.
 
 * Corrige lien entre media et photo
 
-[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.13.0...HEAD
+[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.13.1...HEAD
+[0.13.1]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.13.1
 [0.13.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.13.0
 [0.12.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.12.0
 [0.11.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.11.0

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.13.0"
+version = "0.13.1"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
Patch **0.13.1**. À merger sur `main` **avant** de poser le tag `0.13.1`.

## Contenu

Correctif de la régression logging **#63** (mergé via #64) : la section `[log]`
d'un script configure désormais la **racine** — `getLogger(__name__)` et les
dépendances sont couverts ; ajout de `names` (niveaux par logger) ; suppression
de `recup_logger` ; exemple canonique `log.yaml.dist`.

## Périmètre (règle monas : on ne bumpe que ce qui change)

| Paquet | → | |
|--------|---|--|
| `automatheque` | **0.13.1** | correctif #63 |
| `automatheque.factrice` | *0.12.0* | inchangé |
| `automatheque.schema` | *0.9.7* | inchangé |

Invariant monas respecté (`version` monas == max == `0.13.1`).

## Après merge

Tag **`0.13.1`** (sans `v`) sur `main` → publie **uniquement `automatheque`**.

_(PR de release : ne ferme pas d'issue — #63 a déjà été fermée par le `Closes` de #64.)_