### PR TITLE
feat(util): Executant.exec accepte cwd/timeout/env/check/text (#66)

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `util.dependances_externes.Executant.exec` accepte les options `subprocess`
+  explicites **`cwd`**, **`env`**, **`timeout`** (+ `TimeoutExpired` propagé,
+  garde-fou anti-blocage), **`check`**, **`text`**/**`encoding`**. Tout
+  `**kwargs` restant est transmis à `subprocess.run`. — cf. #66
+
+### Changed
+
+* **`Executant.exec` (comportement)** — cf. #66 :
+  * `stdin` par défaut est désormais **héritée** du parent (`None`) au lieu d'un
+    `PIPE` ouvert jamais alimenté (qui pouvait bloquer un lecteur d'entrée) ;
+  * les `**kwargs` ne sont **plus convertis en arguments CLI** (mécanisme retiré,
+    inutilisé) ; passer les arguments du programme en **positionnel** via `args`,
+    les `kwargs` vont maintenant à `subprocess.run`.
+
 ## [0.13.1] - 2026-07-17
 
 ### Fixed

--- a/src/automatheque/automatheque/util/dependances_externes.py
+++ b/src/automatheque/automatheque/util/dependances_externes.py
@@ -102,24 +102,58 @@ class Executant(object):
 
     executable = attr.ib()
 
-    def exec(self, *args, stdin=None, **kwargs) -> subprocess.CompletedProcess:
-        """Execute le programme donné en dépendances avec les arguments en paramètres.
+    def exec(
+        self,
+        *args,
+        stdin=None,
+        cwd=None,
+        env=None,
+        timeout=None,
+        check=False,
+        text=False,
+        encoding=None,
+        **kwargs,
+    ) -> subprocess.CompletedProcess:
+        """Execute l'exécutable de la dépendance avec ``args`` comme arguments CLI.
 
-        Renvoie un objet CompletedProcess (https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess)
+        Renvoie un `CompletedProcess
+        <https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess>`_.
+        ``stdout`` et ``stderr`` sont **toujours capturés** (``PIPE``).
 
-        L'idéal est de donner une instance de cette classe à un wrapper pour l'action souhaitée
-        qui se charge d'appeler `self.executant.exec` par ex.
+        Options ``subprocess`` transmises telles quelles :
+
+        :param stdin:    entrée standard (objet fichier, ``PIPE``, ``DEVNULL``…).
+            Défaut ``None`` = **héritée** du processus parent (#66 : auparavant
+            un ``PIPE`` ouvert jamais alimenté, source de blocage).
+        :param cwd:      répertoire de travail du sous-processus.
+        :param env:      environnement (dict) du sous-processus.
+        :param timeout:  délai max en secondes ; à l'expiration, ``subprocess``
+            tue le processus et lève ``subprocess.TimeoutExpired`` (propagé).
+        :param check:    si vrai, lève ``CalledProcessError`` sur code non nul.
+        :param text:     si vrai, ``stdout``/``stderr`` sont décodés en ``str``
+            (défaut ``False`` = ``bytes``, comportement historique).
+        :param encoding: encodage utilisé quand ``text`` (ou ``encoding``) est
+            fourni.
+
+        Tout ``**kwargs`` restant est transmis à ``subprocess.run`` (échappatoire
+        pour les options non listées). ⚠️ Contrairement aux versions ≤ 0.13, les
+        ``kwargs`` ne sont **plus** convertis en arguments CLI : passer les
+        arguments du programme en positionnel via ``args``.
         """
         procargs = [self.executable, *args]
-        for k, v in kwargs.items():
-            procargs += [k, v]
 
         msg_redir = " < 'stdin'" if stdin is not None else ""
-        LOGGER.debug(f"Executant.exec : procargs={procargs}" + msg_redir )
-        pipes = subprocess.run(
+        LOGGER.debug("Executant.exec : procargs=%s%s", procargs, msg_redir)
+        return subprocess.run(
             procargs,
-            stdin=stdin if stdin is not None else subprocess.PIPE,
+            stdin=stdin,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            cwd=cwd,
+            env=env,
+            timeout=timeout,
+            check=check,
+            text=text,
+            encoding=encoding,
+            **kwargs,
         )
-        return pipes

--- a/src/automatheque/tests/test_dependances_externes.py
+++ b/src/automatheque/tests/test_dependances_externes.py
@@ -1,0 +1,74 @@
+"""Tests de ``Executant.exec`` (options subprocess explicites, #66)."""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+from automatheque.util.dependances_externes import Executant
+
+
+def _exec(*args, **kwargs):
+    """Exécute avec ``subprocess.run`` mocké et renvoie le mock pour inspection."""
+    with patch("automatheque.util.dependances_externes.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0)
+        Executant("/bin/truc").exec(*args, **kwargs)
+    return run
+
+
+def test_exec_construit_la_commande():
+    """``args`` positionnels → tokens CLI, précédés de l'exécutable."""
+    run = _exec("--action", "valeur")
+    assert run.call_args.args[0] == ["/bin/truc", "--action", "valeur"]
+
+
+def test_exec_capture_toujours_stdout_stderr():
+    run = _exec()
+    assert run.call_args.kwargs["stdout"] == subprocess.PIPE
+    assert run.call_args.kwargs["stderr"] == subprocess.PIPE
+
+
+def test_exec_propage_cwd_env_timeout():
+    env = {"A": "1"}
+    run = _exec(cwd="/tmp", env=env, timeout=5)
+    kw = run.call_args.kwargs
+    assert kw["cwd"] == "/tmp"
+    assert kw["env"] == env
+    assert kw["timeout"] == 5
+
+
+def test_exec_stdin_herite_par_defaut():
+    """#66 : par défaut, stdin est héritée (None), plus un PIPE jamais alimenté."""
+    run = _exec()
+    assert run.call_args.kwargs["stdin"] is None
+
+
+def test_exec_stdin_explicite_transmis():
+    sentinelle = object()
+    run = _exec(stdin=sentinelle)
+    assert run.call_args.kwargs["stdin"] is sentinelle
+
+
+def test_exec_text_et_encoding():
+    run = _exec(text=True, encoding="utf-8")
+    kw = run.call_args.kwargs
+    assert kw["text"] is True
+    assert kw["encoding"] == "utf-8"
+
+
+def test_exec_check_defaut_false():
+    assert _exec().call_args.kwargs["check"] is False
+
+
+def test_exec_kwargs_transmis_a_subprocess_pas_en_cli():
+    """Les kwargs vont à subprocess.run (échappatoire), plus en arguments CLI."""
+    run = _exec("arg", start_new_session=True)
+    assert run.call_args.args[0] == ["/bin/truc", "arg"]  # aucun token en plus
+    assert run.call_args.kwargs["start_new_session"] is True
+
+
+def test_exec_timeout_propage_timeoutexpired():
+    """À l'expiration, subprocess.TimeoutExpired remonte à l'appelant."""
+    with patch("automatheque.util.dependances_externes.subprocess.run") as run:
+        run.side_effect = subprocess.TimeoutExpired(cmd="truc", timeout=1)
+        with pytest.raises(subprocess.TimeoutExpired):
+            Executant("/bin/truc").exec(timeout=1)


### PR DESCRIPTION
Débloque l'adoption d'`Executant` côté consommateurs (retour « tuyauteur ») :
`exec()` ne transmettait aucune option `subprocess`.

Closes #66

## Ajouts

Paramètres nommés explicites, réservés **avant** `**kwargs` :

- **`cwd`** — répertoire de travail (indispensable flatpak & co).
- **`timeout`** — garde-fou anti-blocage (S007) ; `subprocess.TimeoutExpired`
  propagé. Défaut `None` (comportement préservé).
- **`env`**, **`check`**, **`text`**/**`encoding`**.
- Tout `**kwargs` restant est transmis à `subprocess.run` (échappatoire).

## Changements de comportement (pré-1.0, assumés)

- **`stdin` par défaut héritée** (`None`) au lieu d'un `PIPE` ouvert jamais
  alimenté (source de blocage si le binaire lit son entrée).
- **Les `kwargs` ne sont plus convertis en tokens CLI** (mécanisme retiré —
  inutilisé dans le dépôt, et illisible : `exec(foo="bar")` → `[exe,"foo","bar"]`).
  Passer les arguments du programme en **positionnel** via `args`.

`stdout`/`stderr` restent toujours capturés (`PIPE`) — contrat inchangé. Les 2
appels internes (`factrice.expedition`) n'utilisent que `*args` / `stdin=f` →
non-régression.

## Tests

Nouveau `test_dependances_externes.py` (`subprocess.run` mocké) : construction de
la commande, propagation `cwd`/`env`/`timeout`, `TimeoutExpired`, `text`/
`encoding`, `stdin` héritée/explicite, `kwargs`→`run`. **63 passed**, cœur ruff
clean (les E501 restants du fichier sont préexistants, dette #17).

## Hors périmètre

Le point « `recup_executable` teste aussi le lancement du binaire » reste tracé
dans **#25**.

## Livraison

Nouvelle fonctionnalité + changement de défaut → **mineur 0.14.0** (à confirmer).