### PR TITLE
release: coupe 0.14.0 (automatheque)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.13.1"
+version = "0.14.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-17
+
 ### Added
 
 * `util.dependances_externes.Executant.exec` accepte les options `subprocess`
@@ -246,7 +248,8 @@ Nouvel utilitaire, pour gérer les dépendances externes.
 
 * Corrige lien entre media et photo
 
-[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.13.1...HEAD
+[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.14.0...HEAD
+[0.14.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.14.0
 [0.13.1]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.13.1
 [0.13.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.13.0
 [0.12.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.12.0

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.13.1"
+version = "0.14.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
Fermée : coupée sur la version erronée de `Executant.exec` (kwargs→CLI retiré à tort). La 0.14.0 sera re-coupée après le merge du correctif #70.