### PR TITLE
fix(util): Executant.exec — restaure la conversion kwargs → arguments CLI

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -15,10 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicites **`cwd`**, **`env`**, **`timeout`** (+ `TimeoutExpired` propagé,
   garde-fou anti-blocage), **`check`**, **`text`**/**`encoding`**. La conversion
   des `**kwargs` en arguments CLI (`exec("build", mode="rapide")` →
-  `[exe, "build", "mode", "rapide"]`) et le `stdin` par défaut (`PIPE`) sont
-  **préservés** : changement purement additif. Seul effet — ces 7 noms
-  (`stdin`, `cwd`, `env`, `timeout`, `check`, `text`, `encoding`) deviennent
-  réservés et ne peuvent plus servir d'option CLI via `kwargs`. — cf. #66
+  `[exe, "build", "mode", "rapide"]`) est **préservée** ; ces nouveaux noms
+  (`cwd`, `env`, `timeout`, `check`, `text`, `encoding`, `stdin`) deviennent
+  simplement réservés (plus utilisables comme option CLI via `kwargs`). — cf. #66
+
+### Changed
+
+* `Executant.exec` : `stdin` par défaut est désormais **héritée** du parent
+  (`None`) au lieu d'un `PIPE` ouvert jamais alimenté (qui pouvait bloquer un
+  binaire lisant son entrée). — cf. #66
 
 ## [0.13.1] - 2026-07-17
 

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -13,17 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `util.dependances_externes.Executant.exec` accepte les options `subprocess`
   explicites **`cwd`**, **`env`**, **`timeout`** (+ `TimeoutExpired` propagé,
-  garde-fou anti-blocage), **`check`**, **`text`**/**`encoding`**. Tout
-  `**kwargs` restant est transmis à `subprocess.run`. — cf. #66
-
-### Changed
-
-* **`Executant.exec` (comportement)** — cf. #66 :
-  * `stdin` par défaut est désormais **héritée** du parent (`None`) au lieu d'un
-    `PIPE` ouvert jamais alimenté (qui pouvait bloquer un lecteur d'entrée) ;
-  * les `**kwargs` ne sont **plus convertis en arguments CLI** (mécanisme retiré,
-    inutilisé) ; passer les arguments du programme en **positionnel** via `args`,
-    les `kwargs` vont maintenant à `subprocess.run`.
+  garde-fou anti-blocage), **`check`**, **`text`**/**`encoding`**. La conversion
+  des `**kwargs` en arguments CLI (`exec("build", mode="rapide")` →
+  `[exe, "build", "mode", "rapide"]`) et le `stdin` par défaut (`PIPE`) sont
+  **préservés** : changement purement additif. Seul effet — ces 7 noms
+  (`stdin`, `cwd`, `env`, `timeout`, `check`, `text`, `encoding`) deviennent
+  réservés et ne peuvent plus servir d'option CLI via `kwargs`. — cf. #66
 
 ## [0.13.1] - 2026-07-17
 

--- a/src/automatheque/automatheque/util/dependances_externes.py
+++ b/src/automatheque/automatheque/util/dependances_externes.py
@@ -130,6 +130,8 @@ class Executant(object):
         comme options CLI via ``kwargs``) :
 
         :param stdin:    entrée standard (objet fichier, ``PIPE``, ``DEVNULL``…).
+            Défaut ``None`` = **héritée** du parent (auparavant un ``PIPE`` ouvert
+            jamais alimenté, source de blocage). Cf. #66.
         :param cwd:      répertoire de travail du sous-processus.
         :param env:      environnement (dict) du sous-processus.
         :param timeout:  délai max en secondes ; à l'expiration, ``subprocess``
@@ -148,7 +150,7 @@ class Executant(object):
         LOGGER.debug("Executant.exec : procargs=%s%s", procargs, msg_redir)
         return subprocess.run(
             procargs,
-            stdin=stdin if stdin is not None else subprocess.PIPE,
+            stdin=stdin,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=cwd,

--- a/src/automatheque/automatheque/util/dependances_externes.py
+++ b/src/automatheque/automatheque/util/dependances_externes.py
@@ -114,17 +114,22 @@ class Executant(object):
         encoding=None,
         **kwargs,
     ) -> subprocess.CompletedProcess:
-        """Execute l'exécutable de la dépendance avec ``args`` comme arguments CLI.
+        """Execute l'exécutable de la dépendance.
 
         Renvoie un `CompletedProcess
         <https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess>`_.
         ``stdout`` et ``stderr`` sont **toujours capturés** (``PIPE``).
 
-        Options ``subprocess`` transmises telles quelles :
+        Arguments de la ligne de commande :
+
+        * les positionnels ``args`` sont ajoutés tels quels ;
+        * les ``**kwargs`` sont ajoutés par **paires clé/valeur** :
+          ``exec("build", mode="rapide")`` → ``[exe, "build", "mode", "rapide"]``.
+
+        Options ``subprocess`` (paramètres nommés **réservés**, donc utilisables
+        comme options CLI via ``kwargs``) :
 
         :param stdin:    entrée standard (objet fichier, ``PIPE``, ``DEVNULL``…).
-            Défaut ``None`` = **héritée** du processus parent (#66 : auparavant
-            un ``PIPE`` ouvert jamais alimenté, source de blocage).
         :param cwd:      répertoire de travail du sous-processus.
         :param env:      environnement (dict) du sous-processus.
         :param timeout:  délai max en secondes ; à l'expiration, ``subprocess``
@@ -134,19 +139,16 @@ class Executant(object):
             (défaut ``False`` = ``bytes``, comportement historique).
         :param encoding: encodage utilisé quand ``text`` (ou ``encoding``) est
             fourni.
-
-        Tout ``**kwargs`` restant est transmis à ``subprocess.run`` (échappatoire
-        pour les options non listées). ⚠️ Contrairement aux versions ≤ 0.13, les
-        ``kwargs`` ne sont **plus** convertis en arguments CLI : passer les
-        arguments du programme en positionnel via ``args``.
         """
         procargs = [self.executable, *args]
+        for k, v in kwargs.items():
+            procargs += [k, v]
 
         msg_redir = " < 'stdin'" if stdin is not None else ""
         LOGGER.debug("Executant.exec : procargs=%s%s", procargs, msg_redir)
         return subprocess.run(
             procargs,
-            stdin=stdin,
+            stdin=stdin if stdin is not None else subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=cwd,
@@ -155,5 +157,4 @@ class Executant(object):
             check=check,
             text=text,
             encoding=encoding,
-            **kwargs,
         )

--- a/src/automatheque/tests/test_dependances_externes.py
+++ b/src/automatheque/tests/test_dependances_externes.py
@@ -36,10 +36,10 @@ def test_exec_propage_cwd_env_timeout():
     assert kw["timeout"] == 5
 
 
-def test_exec_stdin_herite_par_defaut():
-    """#66 : par défaut, stdin est héritée (None), plus un PIPE jamais alimenté."""
+def test_exec_stdin_pipe_par_defaut():
+    """Par défaut (comportement historique préservé), stdin est un PIPE."""
     run = _exec()
-    assert run.call_args.kwargs["stdin"] is None
+    assert run.call_args.kwargs["stdin"] == subprocess.PIPE
 
 
 def test_exec_stdin_explicite_transmis():
@@ -59,11 +59,20 @@ def test_exec_check_defaut_false():
     assert _exec().call_args.kwargs["check"] is False
 
 
-def test_exec_kwargs_transmis_a_subprocess_pas_en_cli():
-    """Les kwargs vont à subprocess.run (échappatoire), plus en arguments CLI."""
-    run = _exec("arg", start_new_session=True)
-    assert run.call_args.args[0] == ["/bin/truc", "arg"]  # aucun token en plus
-    assert run.call_args.kwargs["start_new_session"] is True
+def test_exec_kwargs_deviennent_arguments_cli():
+    """Les kwargs (hors noms réservés) sont ajoutés en paires clé/valeur au CLI."""
+    run = _exec("build", mode="rapide")
+    assert run.call_args.args[0] == ["/bin/truc", "build", "mode", "rapide"]
+    # ...et ne sont PAS passés à subprocess.run.
+    assert "mode" not in run.call_args.kwargs
+
+
+def test_exec_noms_reserves_ne_partent_pas_en_cli():
+    """Un nom réservé (cwd/timeout/…) va à subprocess.run, pas dans la commande."""
+    run = _exec("build", cwd="/x", timeout=5)
+    assert run.call_args.args[0] == ["/bin/truc", "build"]  # cwd/timeout absents
+    assert run.call_args.kwargs["cwd"] == "/x"
+    assert run.call_args.kwargs["timeout"] == 5
 
 
 def test_exec_timeout_propage_timeoutexpired():

--- a/src/automatheque/tests/test_dependances_externes.py
+++ b/src/automatheque/tests/test_dependances_externes.py
@@ -36,10 +36,10 @@ def test_exec_propage_cwd_env_timeout():
     assert kw["timeout"] == 5
 
 
-def test_exec_stdin_pipe_par_defaut():
-    """Par défaut (comportement historique préservé), stdin est un PIPE."""
+def test_exec_stdin_herite_par_defaut():
+    """#66 : par défaut, stdin est héritée (None), plus un PIPE jamais alimenté."""
     run = _exec()
-    assert run.call_args.kwargs["stdin"] == subprocess.PIPE
+    assert run.call_args.kwargs["stdin"] is None
 
 
 def test_exec_stdin_explicite_transmis():


### PR DESCRIPTION
Corrige une **surinterprétation de #66** dans #68 (déjà mergé) : j'avais retiré
la conversion `kwargs → arguments CLI` (`exec("build", mode="rapide")` →
`[exe, "build", "mode", "rapide"]`). Or #66 ne demandait que des paramètres
nommés explicites avant `**kwargs`, ce qui cohabite très bien avec cette
conversion.

## Ce qui change

- **`kwargs → arguments CLI` : restauré** (fonctionnalité conservée).
- **`stdin` par défaut : `None` (héritée)** — conservé (l'amélioration de #66 :
  fini le `PIPE` ouvert jamais alimenté, source de blocage).
- **`cwd`/`env`/`timeout`/`check`/`text`/`encoding` : conservés** — simplement
  réservés (ces noms ne peuvent plus servir d'option CLI via `kwargs`, seul
  compromis, exactement ce que #66 demandait).

Bilan par rapport à 0.13.1 : **ajout** des options `subprocess` + **un seul**
changement de comportement assumé (`stdin` héritée par défaut).

## Tests

`test_dependances_externes.py` : `kwargs → CLI`, `stdin` héritée par défaut,
noms réservés qui vont à `subprocess.run` et **pas** dans la commande.
**64 passed**, cœur ruff clean.

## Suite

À merger **avant** de re-couper la 0.14.0 (l'ancienne release #69, coupée sur le
code erroné, est fermée — je recoupe après ce merge).