### PR TITLE
release: coupe 0.14.0 (automatheque)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.13.1"
+version = "0.14.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-17
+
 ### Added
 
 * `util.dependances_externes.Executant.exec` accepte les options `subprocess`
@@ -246,7 +248,8 @@ Nouvel utilitaire, pour gérer les dépendances externes.
 
 * Corrige lien entre media et photo
 
-[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.13.1...HEAD
+[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.14.0...HEAD
+[0.14.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.14.0
 [0.13.1]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.13.1
 [0.13.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.13.0
 [0.12.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.12.0

--- a/src/automatheque/automatheque/util/dependances_externes.py
+++ b/src/automatheque/automatheque/util/dependances_externes.py
@@ -126,8 +126,8 @@ class Executant(object):
         * les ``**kwargs`` sont ajoutés par **paires clé/valeur** :
           ``exec("build", mode="rapide")`` → ``[exe, "build", "mode", "rapide"]``.
 
-        Options ``subprocess`` (paramètres nommés **réservés**, donc utilisables
-        comme options CLI via ``kwargs``) :
+        Options ``subprocess`` (paramètres nommés **réservés** : ces noms ne
+        peuvent donc plus servir d'option CLI via ``kwargs``) :
 
         :param stdin:    entrée standard (objet fichier, ``PIPE``, ``DEVNULL``…).
             Défaut ``None`` = **héritée** du parent (auparavant un ``PIPE`` ouvert

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.13.1"
+version = "0.14.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
Mineur **0.14.0** (re-coupée sur le code corrigé — l'ancienne #69 était sur la
version erronée d'`Executant.exec`). À merger **avant** de poser le tag `0.14.0`.

## Contenu

`Executant.exec` (#66, corrigé par #70) :
- **ajout** des options `subprocess` explicites (`cwd`, `env`, `timeout` +
  `TimeoutExpired`, `check`, `text`/`encoding`) ;
- la conversion **`kwargs → arguments CLI` est préservée** ;
- seul changement de comportement : **`stdin` héritée par défaut** (`None`) au
  lieu d'un `PIPE` jamais alimenté.

(+ correction d'une coquille de docstring d'`exec`.)

## Périmètre (règle monas)

| Paquet | → | |
|--------|---|--|
| `automatheque` | **0.14.0** | #66 |
| `automatheque.factrice` | *0.12.0* | inchangé |
| `automatheque.schema` | *0.9.7* | inchangé |

Invariant monas respecté (`version` monas == max == `0.14.0`). 64 tests verts.

## Après merge

Tag **`0.14.0`** (sans `v`) sur `main` → publie **uniquement `automatheque`**.

_(PR de release : ne ferme pas d'issue — #66 fermée par le `Closes` de #68.)_