### PR TITLE
chore(qualité): badges README + passe ruff auto-fixable (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 **Utilitaires, modèles et librairies communes.**
 
+[![PyPI](https://img.shields.io/pypi/v/automatheque.svg)](https://pypi.org/project/automatheque/)
+[![Python](https://img.shields.io/pypi/pyversions/automatheque.svg)](https://pypi.org/project/automatheque/)
+[![Licence](https://img.shields.io/badge/licence-LGPL--3.0--or--later-blue.svg)](LICENSE)
+[![CI](https://github.com/jaegerbobomb/automatheque/actions/workflows/ci.yml/badge.svg)](https://github.com/jaegerbobomb/automatheque/actions/workflows/ci.yml)
+
 ## Préambule
 
 Ce dépôt est géré en "monorepo" grâce à [monas](https://monas.fming.dev/en/latest).

--- a/src/automatheque.factrice/automatheque/__init__.py
+++ b/src/automatheque.factrice/automatheque/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/src/automatheque.factrice/automatheque/factrice/app/__init__.py
+++ b/src/automatheque.factrice/automatheque/factrice/app/__init__.py
@@ -15,12 +15,9 @@ Options:
   --via-esmtp
 """
 
-import subprocess
-
-from automatheque.schema.texte.courriel import Courriel
-from automatheque.script import script_automatheque, ScriptAutomatheque
-
 from automatheque.factrice.expedition import ExpeditriceEsmtp, ExpeditriceSmtp
+from automatheque.schema.texte.courriel import Courriel
+from automatheque.script import ScriptAutomatheque, script_automatheque
 
 __version__ = "0.0.1"
 

--- a/src/automatheque.factrice/automatheque/factrice/preparation.py
+++ b/src/automatheque.factrice/automatheque/factrice/preparation.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-from pathlib import Path
+
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 
 from automatheque.schema.texte import Courriel
-from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
-from email.mime.application import MIMEApplication
-
 
 SEPARATEUR_DESTINATAIRES = ", "
 

--- a/src/automatheque.schema/automatheque/__init__.py
+++ b/src/automatheque.schema/automatheque/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/src/automatheque.schema/automatheque/schema/texte/__init__.py
+++ b/src/automatheque.schema/automatheque/schema/texte/__init__.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-"""Package destiné à gérer du texte (courriel, article ...).
-"""
-from .courriel import Courriel
-#from .nfo import FichierNfo
-#from .soustitre import SousTitre
-#from .syndication import Syndication
+"""Package destiné à gérer du texte (courriel, article ...)."""
 
-__all__ = ["Courriel"] #, "FichierNfo", "SousTitre", "Syndication"]
+from .courriel import Courriel
+
+# from .nfo import FichierNfo
+# from .soustitre import SousTitre
+# from .syndication import Syndication
+
+__all__ = ["Courriel"]  # , "FichierNfo", "SousTitre", "Syndication"]

--- a/src/automatheque.schema/tests/texte/test_courriel.py
+++ b/src/automatheque.schema/tests/texte/test_courriel.py
@@ -1,5 +1,4 @@
 import pytest  # type: ignore
-
 from automatheque.schema.texte.courriel import Courriel
 
 

--- a/src/automatheque/automatheque/__init__.py
+++ b/src/automatheque/automatheque/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/src/automatheque/automatheque/conception/structures/__init__.py
+++ b/src/automatheque/automatheque/conception/structures/__init__.py
@@ -3,12 +3,11 @@ from .borg import Borg
 from .fabrique import Fabrique
 from .monteur import Monteur
 from .registre import (
-    MetaInstanceRegistre,
-    MetaInstancePersistanteRegistre,
     MetaClasseRegistre,
+    MetaInstancePersistanteRegistre,
+    MetaInstanceRegistre,
 )
 from .singleton import Singleton
-
 
 __all__ = [
     "Adaptateur",

--- a/src/automatheque/automatheque/conception/structures/adaptateur.py
+++ b/src/automatheque/automatheque/conception/structures/adaptateur.py
@@ -2,11 +2,11 @@
 """Module pour le patron Adaptateur.
 
 Ce patron convertit l'interface d'une classe en une autre interface exploitée ailleurs.
- 
-Cela permet d'interconnecter des classes qui sans cela seraient incompatibles. Il est 
-utilisé dans le cas où un programme se sert d'une bibliothèque de classe qui ne 
-correspond plus à l'utilisation qui en est faite, à la suite d'une mise à jour de la 
-bibliothèque dont l'interface a changé. 
+
+Cela permet d'interconnecter des classes qui sans cela seraient incompatibles. Il est
+utilisé dans le cas où un programme se sert d'une bibliothèque de classe qui ne
+correspond plus à l'utilisation qui en est faite, à la suite d'une mise à jour de la
+bibliothèque dont l'interface a changé.
 
 Un objet adaptateur (en anglais adapter) expose alors l'ancienne interface en utilisant
 les fonctionnalités de la nouvelle.

--- a/src/automatheque/automatheque/conception/structures/borg.py
+++ b/src/automatheque/automatheque/conception/structures/borg.py
@@ -20,4 +20,3 @@ class Borg:
     def __init__(self):
         # copie de l'état lors de l'initialisation d'une nouvelle instance
         self.__dict__ = self.__etat_partage
-

--- a/src/automatheque/automatheque/conception/structures/fabrique.py
+++ b/src/automatheque/automatheque/conception/structures/fabrique.py
@@ -26,6 +26,7 @@ depuis realpython ci dessus :
   requests the implementation from a creator component (get_serializer()) using some
   sort of identifier (format).
 """
+
 from .monteur import Monteur
 
 

--- a/src/automatheque/automatheque/constantes.py
+++ b/src/automatheque/automatheque/constantes.py
@@ -28,6 +28,7 @@ def repertoire_config_script(nom_court):
     """
     return path.join(_racine_config(), nom_court)
 
+
 logger_config_dict = {
     "version": 1,
     # False : une bibliothèque ne doit pas désactiver les loggers déjà

--- a/src/automatheque/automatheque/greffon/greffon.py
+++ b/src/automatheque/automatheque/greffon/greffon.py
@@ -1,6 +1,6 @@
 # -*- coding=utf-8 -*-
-"""Gestion des Greffons et de leur capacités.
-"""
+"""Gestion des Greffons et de leur capacités."""
+
 import logging
 import uuid
 from typing import List

--- a/src/automatheque/automatheque/util/classe.py
+++ b/src/automatheque/automatheque/util/classe.py
@@ -4,4 +4,3 @@
 class classproperty(property):
     def __get__(self, cls, owner):
         return classmethod(self.fget).__get__(None, owner)()
-

--- a/src/automatheque/automatheque/util/dependances_externes.py
+++ b/src/automatheque/automatheque/util/dependances_externes.py
@@ -20,6 +20,7 @@ Il est ensuite conseillé de créer ses propres classes "wrapper" et de leur don
 l'exécutant en paramètre, qui se chargera de faire les appels subprocess.
 
 """
+
 import logging
 import os
 import shutil

--- a/src/automatheque/automatheque/util/fichier.py
+++ b/src/automatheque/automatheque/util/fichier.py
@@ -7,7 +7,7 @@ def enleve_caracteres_invalides(value):
 
     https://stackoverflow.com/questions/1033424/how-to-remove-bad-path-characters-in-python
     """
-    deletechars = '/\:*?"<>|'
+    deletechars = r'/\:*?"<>|'
     # TODO(#25) tester la plateforme
     deletechars = "/"  # Linux autorise quasiment tout le reste
     try:

--- a/src/automatheque/automatheque/util/structures_python.py
+++ b/src/automatheque/automatheque/util/structures_python.py
@@ -4,6 +4,7 @@
 
 Divers utilitaires pour dict, list etc.
 """
+
 from copy import deepcopy
 from datetime import date, datetime, time
 


### PR DESCRIPTION
Première étape de #71, avec les badges demandés.

## Badges (README racine)

Sous le titre : **PyPI (version)**, **versions Python**, **licence LGPL**, **CI**.
Les badges PyPI/pyversions se mettent à jour tout seuls depuis PyPI ; le badge CI
suit le workflow `ci.yml`.

## Passe qualité auto-fixable (#71, partielle)

- `ruff check --fix` : imports triés (I001), séquence d'échappement (W605),
  espaces parasites (W291/W293).
- `ruff format` : **12 fichiers** reformatés.
- Retrait d'un `import subprocess` inutilisé (`factrice/app`, référencé seulement
  dans une ligne commentée).

**64 tests** verts après reformatage (aucun changement de comportement).

## Ne ferme pas #71

Restent, pour les incréments suivants :
- **41 `E501`** (lignes trop longues, surtout vieilles docstrings) ;
- **16 findings `mypy`** (dont de vrais bugs latents dans `greffon`) ;
- puis le **retrait des `continue-on-error`** du job `qualite` → lint/typage
  **bloquants**.

_(cf. #71 — pas de `Closes`, chantier en plusieurs PR.)_