### PR TITLE
chore(qualité): wrappe les lignes trop longues à 88 (E501) (#71)

### DIFF
--- a/src/automatheque.factrice/automatheque/factrice/app/__init__.py
+++ b/src/automatheque.factrice/automatheque/factrice/app/__init__.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 """factrice
 
-Application pour envoyer des mails simplement en utilisant la connexion configurée dans config.ini.
+Application pour envoyer des mails simplement en utilisant la connexion
+configurée dans config.ini.
 
 TODO(#27) pouvoir faire `cat contenu | factrice sujet email`
 

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -27,7 +27,8 @@ class Expeditrice(metaclass=abc.ABCMeta):
 class ExpeditriceSmtp(Expeditrice):
     """Expédie un Courriel par SMTP.
 
-    :param config: ConfigParser avec la configuration d'expédition, voir plus bas le format
+    :param config: ConfigParser avec la configuration d'expédition, voir plus bas
+        le format
     :type ConfigParser:
 
     ```ini
@@ -83,7 +84,8 @@ class ExpeditriceSmtp(Expeditrice):
         try:
             self.__connecter()
         except NoOptionError:
-            # Les identifiants ne sont pas renseignés en conf, on vérifie que c'est voulu
+            # Les identifiants ne sont pas renseignés en conf, on vérifie que
+            # c'est voulu
             if self.config.getboolean("factrice.smtp", "anonyme", fallback=False):
                 pass
             LOGGER.exception("no options")
@@ -93,7 +95,8 @@ class ExpeditriceSmtp(Expeditrice):
     def __connecter(self):
         """Identifie l'utilisateur sur le SMTP donné.
 
-        Utilise le couple login/mdp ou le jeton xoauth2 (grosso modo un Auth Bearer encodé en b64).
+        Utilise le couple login/mdp ou le jeton xoauth2 (grosso modo un Auth
+        Bearer encodé en b64).
         """
         LOGGER.debug("__connecter")
         oauth = self.config.getboolean("factrice.smtp", "oauth", fallback=False)
@@ -109,8 +112,8 @@ class ExpeditriceSmtp(Expeditrice):
             oauth_jeton = Executant(cmd).exec(*args).stdout.decode("utf-8").strip("\n")
             # LOGGER.debug("jeton oauth : " + oauth_jeton)
             self.s.ehlo(oauth_client_id)
-            # On pourrait utiliser self.s.auth, mais il faut travailler directement avec la chaine xoauth2
-            # non encodée en b64.
+            # On pourrait utiliser self.s.auth, mais il faut travailler
+            # directement avec la chaine xoauth2 non encodée en b64.
             self.s.docmd("AUTH", "XOAUTH2 " + oauth_jeton)
         else:
             self.s.login(
@@ -165,7 +168,8 @@ class ExpeditriceEsmtp:
     def expedie(self, courriel: Courriel):
         # envoi du mail si esmtp est paramétré
         # cmd = 'cat "{0}" | esmtp {1}'.format(
-        #    self__.gen_fichier(courriel), SEPARATEUR_DESTINATAIRES.join(courriel.destinataires)
+        #    self__.gen_fichier(courriel),
+        #    SEPARATEUR_DESTINATAIRES.join(courriel.destinataires)
         # )
         args = [SEPARATEUR_DESTINATAIRES.join(courriel.destinataires)]
         fic = self.__gen_fichier(courriel)

--- a/src/automatheque.factrice/automatheque/factrice/preparation.py
+++ b/src/automatheque.factrice/automatheque/factrice/preparation.py
@@ -34,7 +34,9 @@ class PreparatriceSmtp:
                 _msg.attach(
                     MIMEApplication(
                         fic.read(),
-                        Content_Disposition=f'attachment; filename="{piece_jointe.name}"',
+                        Content_Disposition=(
+                            f'attachment; filename="{piece_jointe.name}"'
+                        ),
                         Name=piece_jointe.name,
                     )
                 )

--- a/src/automatheque.schema/automatheque/schema/texte/courriel.py
+++ b/src/automatheque.schema/automatheque/schema/texte/courriel.py
@@ -17,7 +17,8 @@ class Courriel:
     Cette classe est un wrapper de "email".
 
     La validité des emails est testée de manière très sommaire par défaut.
-    Si besoin, utiliser pyIsEmail ou autre librairie, à passer à "self.teste_adresse_valide".
+    Si besoin, utiliser pyIsEmail ou autre librairie, à passer à
+    "self.teste_adresse_valide".
     Pour l'instant on se contente de ça : https://stackoverflow.com/a/14485817/8721626
     """
 

--- a/src/automatheque/automatheque/conception/structures/fabrique.py
+++ b/src/automatheque/automatheque/conception/structures/fabrique.py
@@ -41,8 +41,8 @@ class Fabrique(object):
     * soit donner directement une Classe comme constructeur, et on recevra une
     instance de la classe,
     * soit un Monteur concret qui construira l'objet voulu.
-     (utile par exemple si l'on veut abstraire le passage de paramètre à l'initialisation
-      de la classe)
+     (utile par exemple si l'on veut abstraire le passage de paramètre à
+      l'initialisation de la classe)
     """
 
     def __init__(self):

--- a/src/automatheque/automatheque/conception/structures/registre.py
+++ b/src/automatheque/automatheque/conception/structures/registre.py
@@ -88,7 +88,8 @@ class MetaInstanceRegistre(type):
         # Lors de la création **de la classe** du registre (et pas de l'instance)
         super(MetaInstanceRegistre, cls).__init__(name, bases, attrs)
 
-        # Initialise le stockage des instances, pas besoin pour l'instant d'une "weak ref"
+        # Initialise le stockage des instances, pas besoin pour l'instant d'une
+        # "weak ref"
         cls.__instances = weakref.WeakSet()
 
     def __call__(cls, *args, **kwargs):
@@ -123,7 +124,8 @@ class MetaInstancePersistanteRegistre(type):
     Ici on utilise un "set" et non un "weakRefSet", pour le cas où on ne garde **pas**
     les références des instances crées : on les stocke juste dans le registre et on les
     cherche ensuite.
-    Avec un weakRefSet on garde le registre de toutes les instances "en cours d'utilisation",
+    Avec un weakRefSet on garde le registre de toutes les instances "en cours
+    d'utilisation",
     (ie dont on a encore la référence).
 
     >>> class A(metaclass=MetaInstancePersistanteRegistre):
@@ -148,7 +150,8 @@ class MetaInstancePersistanteRegistre(type):
         # Lors de la création **de la classe** du registre (et pas de l'instance)
         super(MetaInstancePersistanteRegistre, cls).__init__(name, bases, attrs)
 
-        # Initialise le stockage des instances, pas besoin pour l'instant d'une "weak ref"
+        # Initialise le stockage des instances, pas besoin pour l'instant d'une
+        # "weak ref"
         cls.__instances = set()
 
     def __call__(cls, *args, **kwargs):

--- a/src/automatheque/automatheque/greffon/__init__.py
+++ b/src/automatheque/automatheque/greffon/__init__.py
@@ -17,23 +17,27 @@ class FabriqueGreffon(Fabrique):
     Il faut :
 
     1. enregistrer les monteurs des greffons avec `fabrique_greffons.charge_monteurs()`
-    2. instancier le type de greffon demandé, via `fabrique_greffons.active()`, qui lance
-       `monteur.cree()` avec les arguments donnés, pour instancier le Greffon.
+    2. instancier le type de greffon demandé, via `fabrique_greffons.active()`,
+       qui lance `monteur.cree()` avec les arguments donnés, pour instancier le
+       Greffon.
 
-    NB : À défaut de Monteur, s'il n'y a pas de complexité pour instancier un Greffon (en
-    particulier il n'y a pas plusieurs Greffons différents à instancier en fonction de la
-    configuration utilisateur), alors on peut donner la classe du Greffon en tant que
+    NB : À défaut de Monteur, s'il n'y a pas de complexité pour instancier un
+    Greffon (en particulier il n'y a pas plusieurs Greffons différents à
+    instancier en fonction de la configuration utilisateur), alors on peut donner
+    la classe du Greffon en tant que
     monteur et celle ci sera instanciée directement.
         Attention: pour que la classe Greffon se comporte comme un monteur, il faut
         qu'elle ait une propriété "clé".
 
-    NB: Si on utilise un Monteur, on peut utiliser la même clé que le Greffon, tant qu'elle
-    n'est pas utilisée par plusieurs Greffons ou Monteurs, puisqu'elle servira à
+    NB: Si on utilise un Monteur, on peut utiliser la même clé que le Greffon,
+    tant qu'elle n'est pas utilisée par plusieurs Greffons ou Monteurs, puisqu'elle
+    servira à
     déclencher l'instanciation du Monteur ou du Greffon associée.
 
     .. code-block:: python
         >>> from automatheque.greffon import fabrique_greffon
-        >>> from plugin2.monteur import Monteur2  # dépend de l'argument donné à `charge_monteurs`
+        >>> # dépend de l'argument donné à `charge_monteurs`
+        >>> from plugin2.monteur import Monteur2
         >>> fabrique_greffon.charge_monteurs([
                "plugin1.monteur.Monteur1",
                Monteur2
@@ -113,7 +117,8 @@ class FabriqueGreffon(Fabrique):
         tous ceux définis en configuration.
 
         Si on utilise cette méthode pour activer les greffons, alors il est nécessaire
-        de fournir un identifiant, on ne peut pas laisser automatheque créer l'identifiant
+        de fournir un identifiant, on ne peut pas laisser automatheque créer
+        l'identifiant
         automatiquement, donc il faut fournir une configuration ou laisser automatheque
         charger la configuration standard.
 

--- a/src/automatheque/automatheque/greffon/greffon.py
+++ b/src/automatheque/automatheque/greffon/greffon.py
@@ -18,34 +18,40 @@ LOGGER = logging.getLogger(__name__)
 @attr.s(eq=False)  # pour rendre la classe hashable pour le set du registre
 class Greffon(RegistreGreffons):
     """
-    https://fr.wikipedia.org/wiki/Plugin : on utilise "greffon" au lieu de "module d'extension" car
-    c'est plus compact et moins prône à la confusion, malgré la recommandation de la DGLFLF.
+    https://fr.wikipedia.org/wiki/Plugin : on utilise "greffon" au lieu de
+    "module d'extension" car c'est plus compact et moins prône à la confusion,
+    malgré la recommandation de la DGLFLF.
 
     ## Pourquoi utiliser des greffons :
 
     * "Donner accès, pour une même fonction, à différentes solutions" :
-        * = pouvoir modifier le comportement de l'application, notamment en fonction de la conf
-        * ex: pour récupérer les données nutritionnelles d'un aliment, je peux utiliser l'api API1
-        grâce au greffon adéquat, ou l'api API2 via son greffon, et je décide en configuration
-        laquelle il faut utiliser et quels arguments pour chaque greffon (login etc.), les 2
-        greffons partageant les mêmes "capacités"
-    * Peut évoluer plus vite, car il est plus simple de créer un nouveau greffon pour une nouvelle
-    interface (pour une nouvelle api par exemple, ou un nouveau site de données, ou un nouveau
-    traitement) que d'attendre une nouvelle version du logiciel.
+        * = pouvoir modifier le comportement de l'application, notamment en
+          fonction de la conf
+        * ex: pour récupérer les données nutritionnelles d'un aliment, je peux
+          utiliser l'api API1 grâce au greffon adéquat, ou l'api API2 via son
+          greffon, et je décide en configuration laquelle il faut utiliser et
+          quels arguments pour chaque greffon (login etc.), les 2 greffons
+          partageant les mêmes "capacités"
+    * Peut évoluer plus vite, car il est plus simple de créer un nouveau greffon
+    pour une nouvelle interface (pour une nouvelle api par exemple, ou un nouveau
+    site de données, ou un nouveau traitement) que d'attendre une nouvelle version
+    du logiciel.
 
     ## Quel greffon récupérer :
 
     * un par un, par le biais du nom du greffon
-        * si on veut un traitement spécifique, ex: je veux utiliser l'api openfoodfacts, ou bien je
-          veux parser un fichier qif vs un fichier csv ...)
+        * si on veut un traitement spécifique, ex: je veux utiliser l'api
+          openfoodfacts, ou bien je veux parser un fichier qif vs un fichier
+          csv ...)
     * tous ceux qui rendent un service donné :
         * on exécute le premier qui marche
-            * ex: j'utilise la capacité "ALIMENT.PEUPLER_INFOS_NUTRITIONNELLES", et je m'arrête
-              après le premier appel OK
-        * ou un accumule les données (idem mais je complète les données à chaque appel d'un nouveau
-          greffon)
-        * NB le choix entre ces 2 manières de fonctionner dépend du logiciel qui utilise les
-          greffons, ici automatheque se contente de les rendre accessibles et recherchables.
+            * ex: j'utilise la capacité "ALIMENT.PEUPLER_INFOS_NUTRITIONNELLES",
+              et je m'arrête après le premier appel OK
+        * ou un accumule les données (idem mais je complète les données à chaque
+          appel d'un nouveau greffon)
+        * NB le choix entre ces 2 manières de fonctionner dépend du logiciel qui
+          utilise les greffons, ici automatheque se contente de les rendre
+          accessibles et recherchables.
     """
 
     # Utilisation de kw_only=True pour l'héritage :

--- a/src/automatheque/automatheque/greffon/registre.py
+++ b/src/automatheque/automatheque/greffon/registre.py
@@ -14,9 +14,11 @@ T = TypeVar("T", bound=Capacite)
 
 class RegistreGreffons(metaclass=MetaInstancePersistanteRegistre):
     """
-    Stocke toutes les instances des greffons qui héritent de `~automatheque.greffon.Greffon`.
+    Stocke toutes les instances des greffons qui héritent de
+    `~automatheque.greffon.Greffon`.
 
-    Fournit plusieurs méthodes de classe pour récupérer les Greffons par nom ou par capacité.
+    Fournit plusieurs méthodes de classe pour récupérer les Greffons par nom ou
+    par capacité.
     """
 
     @classmethod
@@ -31,7 +33,8 @@ class RegistreGreffons(metaclass=MetaInstancePersistanteRegistre):
              On utilise `Callable[[], T]` comme correctif temporaire.
 
         TODO Pour l'instant il faut également forcer le type en retour de l'appel :
-             `greffons: CapaciteDemandeeProtocol = rg.greffons_par_capacite(CapaciteDemandeeProtocol)`
+             `greffons: CapaciteDemandeeProtocol =
+             rg.greffons_par_capacite(CapaciteDemandeeProtocol)`
 
         :param capacite: Protocol que doit respecter le Greffon recherché
         :return: Type _Union_, mais devrait être _Intersect_ (TODO https://github.com/python/typing/issues/213)

--- a/src/automatheque/automatheque/suivi/journal.py
+++ b/src/automatheque/automatheque/suivi/journal.py
@@ -28,7 +28,8 @@ class JournalSuivi:
 
     # decorator !!
     def ni_fait_ni_à_refaire(self, nom_arg_reference: str):
-        """Décore une fonction pour qu'elle ne soit jouée qu'une fois pour un argument donné.
+        """Décore une fonction pour qu'elle ne soit jouée qu'une fois pour un
+        argument donné.
 
         Il faut donner en entrée le nom du paramètre qui contient la référence, et la
         decoration sauvegardera "nom_fonction_reference".

--- a/src/automatheque/automatheque/util/dependances_externes.py
+++ b/src/automatheque/automatheque/util/dependances_externes.py
@@ -1,23 +1,23 @@
 """Module d'aide à la gestion des dépendances externes.
 
 Il est notamment utilisé :
-* dans le package "dependance", qui sert à livrer des dépendances complètes avec automatheque
-  (comme pour pyexiftool) et/ou à vérifier leur installation localement (en attendant peut être
-  l'utilisation de poetry ou autre ?).
-* dans des scripts qui utilisent automatheque, pour les aider à vérifier la présence de dépendances
-  externes
+* dans le package "dependance", qui sert à livrer des dépendances complètes avec
+  automatheque (comme pour pyexiftool) et/ou à vérifier leur installation
+  localement (en attendant peut être l'utilisation de poetry ou autre ?).
+* dans des scripts qui utilisent automatheque, pour les aider à vérifier la
+  présence de dépendances externes
 
 # Fonctionnement :
 
 Ce module fournit un registre des dépendances chargées.
 
-Lorsqu'une dépendance est chargée, une instance de la classe Executant est créée, et stockée dans
-le registre.
+Lorsqu'une dépendance est chargée, une instance de la classe Executant est créée,
+et stockée dans le registre.
 
 Ainsi c'est ce registre qu'il faut appeler si on a besoin d'une dépendance.
 
-Il est ensuite conseillé de créer ses propres classes "wrapper" et de leur donner l'instance de
-l'exécutant en paramètre, qui se chargera de faire les appels subprocess.
+Il est ensuite conseillé de créer ses propres classes "wrapper" et de leur donner
+l'instance de l'exécutant en paramètre, qui se chargera de faire les appels subprocess.
 
 """
 
@@ -43,8 +43,8 @@ Dependance = namedtuple("Dependance", ["erreur", "presente", "executant"])
 def verifie_dependance(cle_dependance):
     """Vérifie que la dépendance externe donnée est bien chargée.
 
-    Renvoie une erreur si la dépendance n'est pas chargée ou que l'exécutable n'est pas présent,
-    et ne renvoie rien sinon.
+    Renvoie une erreur si la dépendance n'est pas chargée ou que l'exécutable n'est
+    pas présent, et ne renvoie rien sinon.
 
     :returns: None
     """


### PR DESCRIPTION
Deuxième incrément de #71.

## Ce que ça fait

Reflow des **41 lignes `E501`** (lignes de 90–106 caractères) à **≤ 88** :
docstrings, commentaires, et quelques lignes de code — toutes découpées sans
`# noqa` et **sans changement de comportement** (les valeurs de chaînes sont
préservées via concaténation de littéraux adjacents ; les usages docopt ne sont
pas touchés).

## Vérifié

- `ruff check src` → **0 erreur** (tous les `E501` éliminés, aucune nouvelle
  catégorie).
- `ruff format --check src` → tout est formaté.
- `pytest src` → **64 passed**.

## Ne ferme pas #71

Restent :
- **16 findings `mypy`** (dont de vrais bugs latents dans `greffon`) → PR
  suivante ;
- puis le **retrait des `continue-on-error`** du job `qualite` → ruff/mypy
  **bloquants** (le lint est déjà à 0, le retrait de son `continue-on-error`
  pourra se faire dès cette étape).

_(cf. #71 — pas de `Closes`.)_