### PR TITLE
refactor(factrice): Executant.exec(encoding=) au lieu du décodage manuel

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* `ExpeditriceSmtp` (OAuth) : récupération du jeton via
+  `Executant.exec(..., encoding="utf-8")` — la sortie est décodée par
+  `subprocess`, plus de `.stdout.decode("utf-8")` manuel côté appelant. Tire
+  parti de l'option `text`/`encoding` d'`automatheque` 0.14.0 (#66).
+
 ## [0.12.0] - 2026-07-15
 
 ### Changed

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -106,7 +106,9 @@ class ExpeditriceSmtp(Expeditrice):
 
         if oauth and oauth_cmd is not None and oauth_client_id is not None:
             cmd, *args = oauth_cmd.split(" ")
-            oauth_jeton = Executant(cmd).exec(*args).stdout.decode("utf-8").strip("\n")
+            oauth_jeton = (
+                Executant(cmd).exec(*args, encoding="utf-8").stdout.strip("\n")
+            )
             # LOGGER.debug("jeton oauth : " + oauth_jeton)
             self.s.ehlo(oauth_client_id)
             # On pourrait utiliser self.s.auth, mais il faut travailler directement avec la chaine xoauth2

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -15,7 +15,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "automatheque>=0.9.6",
+    # >=0.14.0 : `ExpeditriceSmtp` utilise `Executant.exec(encoding=...)`,
+    # ajouté dans automatheque 0.14.0 (#66).
+    "automatheque>=0.14.0",
     # 0.9.6 est la plus ancienne version publiée d'automatheque.schema ; le
     # plancher précédent (>=0.9.5) référençait une version jamais publiée. Le
     # job CI « tests-plancher » valide que factrice fonctionne contre ces


### PR DESCRIPTION
Dogfooding manqué repéré par toi : en 0.14.0 (#66) on a ajouté `text`/`encoding`
à `Executant.exec` **pour éviter le `.decode()` systématique**, mais l'appel de
factrice n'en profitait pas encore.

## Changement

`ExpeditriceSmtp.__connecter` (chemin OAuth) :

```python
# avant
oauth_jeton = Executant(cmd).exec(*args).stdout.decode("utf-8").strip("\n")
# après
oauth_jeton = Executant(cmd).exec(*args, encoding="utf-8").stdout.strip("\n")
```

`subprocess` décode lui-même, l'appelant récupère une `str`. Comportement
identique (utf-8).

## Dépendance

Plancher relevé : **`automatheque>=0.14.0`** (l'option `encoding=` n'existe que
depuis là — sans ça le chemin OAuth casserait avec un vieux automatheque). Le
job CI `tests-plancher` valide factrice contre ce plancher.

## Tests

`pytest src` → **64 passed**. Chemin OAuth non couvert par un test dédié (il faut
un vrai sous-processus) ; changement mécanique équivalent.

## Note

Le `process.stderr` (bytes) journalisé dans `ExpeditriceEsmtp.expedie` reste tel
quel — simple log, non prioritaire.

## Livraison

Changement factrice → au prochain bump, factrice **s'aligne sur la version
globale** (lockstep monas, comme aux 0.11.0/0.12.0), soit **0.14.1** si on coupe
maintenant (automatheque reste 0.14.0 ; tag `0.14.1` ne publie que factrice), ou
la version du prochain train si on bundle avec d'autres changements.