### PR TITLE
release: coupe 0.14.1 (factrice)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.14.0"
+version = "0.14.1"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-07-20
+
+> Alignement sur la version globale du monorepo (règle monas : un paquet qui
+> change prend la version globale). `factrice` saute de 0.12.0 à 0.14.1.
+
 ### Changed
 
 * `ExpeditriceSmtp` (OAuth) : récupération du jeton via

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.factrice"
-version = "0.12.0"
+version = "0.14.1"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}


### PR DESCRIPTION
Patch **0.14.1** (factrice). À merger **avant** de poser le tag `0.14.1`.

## Contenu

`factrice` (`ExpeditriceSmtp`, OAuth) utilise `Executant.exec(encoding="utf-8")`
au lieu de décoder à la main (dogfooding de l'option ajoutée en 0.14.0, #66) ;
plancher relevé `automatheque>=0.14.0`. (#75)

## Périmètre (règle monas — lockstep)

`factrice`, seul paquet modifié, **s'aligne sur la version globale** et saute de
0.12.0 à **0.14.1**.

| Paquet | → | |
|--------|---|--|
| `automatheque.factrice` | **0.14.1** | #75 |
| `automatheque` | *0.14.0* | inchangé |
| `automatheque.schema` | *0.9.7* | inchangé |

Invariant monas respecté (`version` monas == max == `0.14.1`).

## Après merge

Tag **`0.14.1`** (sans `v`) sur `main` → publie **uniquement
`automatheque.factrice`**.