### PR TITLE
fix(qualité): mypy propre + job qualite bloquant (#71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,20 +104,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e src/automatheque -e src/automatheque.schema -e src/automatheque.factrice
-          pip install ruff mypy
+          # types-* : stubs pour pyyaml/pytz (typage de log.py / structures_python.py).
+          pip install ruff mypy types-PyYAML types-pytz
 
-      # NB : ruff et mypy sont volontairement en mode « rapport » (non bloquant)
-      # tant que le nettoyage du code n'est pas réalisé (cf. issue #17).
-      # Une fois le code nettoyé, retirer les « continue-on-error » pour les
-      # rendre bloquants.
+      # ruff et mypy sont désormais **bloquants** : le code a été nettoyé (#71).
       - name: Lint (ruff check)
-        continue-on-error: true
         run: ruff check src
 
       - name: Format (ruff format --check)
-        continue-on-error: true
         run: ruff format --check src
 
       - name: Vérification de types (mypy)
-        continue-on-error: true
         run: mypy src/automatheque/automatheque

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* `greffon.FabriqueGreffon.active_greffons_conf` ne renvoie plus d'éléments
+  `None` : les greffons dont l'activation échoue (inactifs ou en erreur) sont
+  **exclus** de la liste retournée, qui respecte enfin son type `List[Greffon]`.
+  Correction issue de la passe de typage. — cf. #71
+
+### Changed
+
+* Qualité : le code passe `ruff` **et** `mypy` sans erreur ; le job CI `qualite`
+  devient **bloquant** (fin des `continue-on-error`). Nettoyage du typage
+  (annotations manquantes, `Type[...]` des monteurs, `CAPACITES` déclaré sur
+  `Greffon`, stubs `types-PyYAML`/`types-pytz`). — cf. #71
+
 ## [0.14.0] - 2026-07-17
 
 ### Added

--- a/src/automatheque/automatheque/conception/structures/borg.py
+++ b/src/automatheque/automatheque/conception/structures/borg.py
@@ -15,7 +15,7 @@ class Borg:
     """Classe "Singleton-like" pour partager les états de plusieurs instances."""
 
     # variable de classe contenant l'état à partager
-    __etat_partage = {}
+    __etat_partage: dict = {}
 
     def __init__(self):
         # copie de l'état lors de l'initialisation d'une nouvelle instance

--- a/src/automatheque/automatheque/conception/structures/singleton.py
+++ b/src/automatheque/automatheque/conception/structures/singleton.py
@@ -19,7 +19,7 @@ class Singleton(object):
 
     # Dictionnaire Python référençant les instances déjà créés : une pour chaque
     # sous-classe.
-    _singletons = {}
+    _singletons: dict = {}
 
     def __new__(cls, *args, **kargs):
         if Singleton._singletons.get(cls) is None:

--- a/src/automatheque/automatheque/greffon/__init__.py
+++ b/src/automatheque/automatheque/greffon/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, ABCMeta
 from copy import deepcopy
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Type, Union
 
 from automatheque.conception.structures import Fabrique, Monteur
 from automatheque.configuration import ConfigParser, charge_configuration
@@ -79,7 +79,7 @@ class FabriqueGreffon(Fabrique):
         return Greffon.greffon_par_identifiant(identifiant)
 
     def charge_monteurs(
-        self, liste_monteurs: List[Union[str, Monteur, Greffon]]
+        self, liste_monteurs: List[Union[str, Type[Monteur], Type[Greffon]]]
     ) -> List[Monteur]:
         """Enregistre les monteurs de greffons disponibles dans la fabrique.
 
@@ -88,6 +88,9 @@ class FabriqueGreffon(Fabrique):
         Dans tous les cas ensuite il faut les activer un par un dans la configuration.
         """
         monteurs = []
+        # `monteur` est résolu dynamiquement (via pydoc.locate) ou fourni par
+        # l'appelant : son type statique n'est pas connu.
+        monteur: Any
         for elem in liste_monteurs:
             if isinstance(elem, str):
                 from pydoc import locate
@@ -155,17 +158,21 @@ class FabriqueGreffon(Fabrique):
         if liste_greffons is None:
             try:
                 # On laisse dans "greffon" si on veut sortir le code un jour !
-                liste_greffons = configuration.get("greffons").get("greffons")
-                liste_greffons = [i.strip() for i in liste_greffons.split(",")]
+                liste_str = configuration["greffons"]["greffons"]
+                liste_greffons = [i.strip() for i in liste_str.split(",")]
             except Exception as e:
                 LOGGER.exception(e)
                 raise ValueError(f"pas de liste de greffons dans {configuration}")
 
         greffons_actifs = []
         for identifiant in liste_greffons:
-            conf = deepcopy(configuration.get(identifiant))
+            conf = deepcopy(configuration[identifiant])
             cle = conf.pop("greffon")
-            greffons_actifs.append(self.active(cle, identifiant=identifiant, **conf))
+            greffon = self.active(cle, identifiant=identifiant, **conf)
+            # active() peut renvoyer None (greffon inactif ou échec) : on ne
+            # l'ajoute pas — la méthode renvoie bien une List[Greffon].
+            if greffon is not None:
+                greffons_actifs.append(greffon)
         return greffons_actifs
 
 

--- a/src/automatheque/automatheque/greffon/greffon.py
+++ b/src/automatheque/automatheque/greffon/greffon.py
@@ -3,7 +3,7 @@
 
 import logging
 import uuid
-from typing import List
+from typing import List, Type
 
 import attr
 
@@ -61,8 +61,12 @@ class Greffon(RegistreGreffons):
     config_requise = attr.ib(default=False, init=False, kw_only=True)
     config = attr.ib(init=False, factory=charge_configuration, kw_only=True)
 
+    # Liste des capacités du greffon, surchargée par chaque sous-classe
+    # (cf. greffon/capacite.py) ; vide par défaut.
+    CAPACITES: List[Capacite] = []
+
     @classproperty
-    def cle(cls) -> str:
+    def cle(cls: Type["Greffon"]) -> str:
         """Retourne le nom de la classe sans "Greffon" s'il existe, en minuscule"""
         return cls.__name__.lower().replace("greffon", "")
 

--- a/src/automatheque/automatheque/util/dependances_externes.py
+++ b/src/automatheque/automatheque/util/dependances_externes.py
@@ -36,7 +36,7 @@ LOGGER = logging.getLogger(__name__)
 
 MAUVAISE_CLE_ERREUR = """Aucune dépendance à ce nom n'a été trouvée.
 Vérifiez que vous avez bien chargé la dépendance précédemment."""
-registre_dependances = {}
+registre_dependances: dict = {}
 Dependance = namedtuple("Dependance", ["erreur", "presente", "executant"])
 
 


### PR DESCRIPTION
Dernière étape de #71 : mypy à 0 et **porte qualité verrouillée**.

Closes #71

## Vrais bugs / typage `greffon`

- **`active_greffons_conf`** : ne renvoie plus d'éléments **`None`** — les
  greffons dont l'activation échoue (inactifs/en erreur) sont exclus, la liste
  respecte enfin son type `List[Greffon]`. Accès config par **indexation** au
  lieu de `.get().get()` sur `Optional` (comportement d'erreur équivalent :
  config malformée → `ValueError`).
- **`charge_monteurs`** : le paramètre est typé `Type[Monteur]`/`Type[Greffon]`
  (ce sont des **classes**, pas des instances — le hint était faux) ; `monteur`
  annoté `Any` car résolu dynamiquement (`pydoc.locate`).
- **`Greffon.CAPACITES`** déclaré sur la classe de base (défaut `[]`, surchargé
  par les sous-classes) ; **`classproperty cle`** : `cls` typé `Type[Greffon]`.

## Divers typage

- Annotations manquantes : `_singletons`, `__etat_partage`,
  `registre_dependances`.
- Stubs **`types-PyYAML`** / **`types-pytz`** ajoutés au job CI (yaml/pytz).

## Porte qualité bloquante

Retrait des `continue-on-error` sur `ruff check`, `ruff format --check` et
`mypy`. La CI **échoue** désormais sur toute régression de lint/format/typage.

## Vérifié localement

- `mypy src/automatheque/automatheque` → **Success, 0 erreur**
- `ruff check src` → **0** ; `ruff format --check src` → **0**
- `pytest src` → **64 passed**

## Note comportement

Le seul changement de comportement runtime : `active_greffons_conf` filtre les
`None` (avant, une activation ratée insérait un `None` dans la liste — bug).
Documenté au CHANGELOG.

Après ce merge, **#71 est bouclée** (badges + auto-fix #73, E501 #74, mypy + gate
ici).