### PR TITLE
feat(packaging): embarque py.typed dans le wheel (#3)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Typage exporté : `py.typed` embarqué dans le wheel
+  (`[tool.setuptools.package-data]`) + classifier `Typing :: Typed`. — cf. #3
+
 ## [0.14.1] - 2026-07-20
 
 > Alignement sur la version globale du monorepo (règle monas : un paquet qui

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
 ]
 dependencies = [
     # >=0.14.0 : `ExpeditriceSmtp` utilise `Executant.exec(encoding=...)`,
@@ -35,3 +36,7 @@ factrice = "automatheque.factrice.app:main"
 [build-system]
 requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
+
+# Embarque le marqueur py.typed dans le wheel (typage exporté). Cf. #3.
+[tool.setuptools.package-data]
+"automatheque.factrice" = ["py.typed"]

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Typage exporté : le marqueur `py.typed` est désormais **embarqué dans le
+  wheel** (`[tool.setuptools.package-data]`) et le classifier trove
+  `Typing :: Typed` est déclaré. Les consommateurs voient enfin le typage
+  d'automatheque via mypy (légitime depuis que le code passe mypy, #71). — cf. #3
+
 ### Fixed
 
 * `greffon.FabriqueGreffon.active_greffons_conf` ne renvoie plus d'éléments

--- a/src/automatheque/MANIFEST.in
+++ b/src/automatheque/MANIFEST.in
@@ -1,0 +1,1 @@
+include automatheque/py.typed

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
 ]
 dependencies = [
     # docopt-ng : fork maintenu de docopt, même module importable `docopt`
@@ -40,6 +41,11 @@ requires = [
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+# Embarque le marqueur py.typed dans le wheel (sinon mypy côté consommateur ne
+# voit pas le typage exporté). Cf. #3.
+[tool.setuptools.package-data]
+automatheque = ["py.typed"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Adresse #3 pour les paquets publiés.

## Le problème

Les marqueurs `py.typed` **existaient** dans l'arborescence des 3 paquets, mais
n'étaient déclarés dans **aucune** `package-data` → ils n'étaient pas embarqués
dans le wheel, donc `mypy` côté consommateur ne voyait pas le typage exporté.
(Historiquement le typage était « déclaré à tort » — maintenant que le code
passe mypy, #71, c'est légitime.)

## Correctif (automatheque + factrice)

- **`[tool.setuptools.package-data]`** embarque `py.typed` dans le wheel.
- **`MANIFEST.in`** ajouté à automatheque (sdist ; schema/factrice en avaient
  déjà un).
- Classifier trove **`Typing :: Typed`**.

## Vérifié

Le build wheel échoue localement sur un quirk setuptools/distutils de cet env
(indépendant de la config), mais le **sdist d'automatheque contient bien
`automatheque/py.typed`** et la config parse ; `package-data` garantit
l'inclusion wheel côté CI (env propre).

## schema laissé de côté (à confirmer)

Je n'ai **pas** touché `automatheque.schema` : tu l'as gardé hors des
republications jusqu'ici, et le modifier l'obligerait à republier (jump lockstep
à la version globale, en embarquant aussi ses métadonnées LGPL/py3.9 en attente).
Son `py.typed` recevra le même traitement lors de sa prochaine publication. Dis
si tu veux l'inclure maintenant.

Du coup **#3 reste ouverte** pour la part schema (cf. #3, pas de `Closes`).

## Livraison

Changements automatheque + factrice → au prochain cut, les deux s'alignent sur
la version globale (lockstep).