### PR TITLE
release: coupe 0.14.2 (automatheque + factrice)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.14.1"
+version = "0.14.2"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-07-20
+
 ### Added
 
 * Typage exporté : `py.typed` embarqué dans le wheel

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.factrice"
-version = "0.14.1"
+version = "0.14.2"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-07-20
+
 ### Added
 
 * Typage exporté : le marqueur `py.typed` est désormais **embarqué dans le
@@ -269,7 +271,8 @@ Nouvel utilitaire, pour gérer les dépendances externes.
 
 * Corrige lien entre media et photo
 
-[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.14.0...HEAD
+[Unreleased]: https://github.com/jaegerbobomb/automatheque/compare/0.14.2...HEAD
+[0.14.2]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.14.2
 [0.14.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.14.0
 [0.13.1]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.13.1
 [0.13.0]: https://github.com/jaegerbobomb/automatheque/releases/tag/0.13.0

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.14.0"
+version = "0.14.2"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
Patch **0.14.2**. À merger **avant** de poser le tag `0.14.2`.

## Contenu

- **automatheque** (0.14.0 → 0.14.2) : correction `greffon.active_greffons_conf`
  (ne renvoie plus de `None`), code **mypy-propre + job `qualite` bloquant**
  (#71), **`py.typed` embarqué** dans le wheel (#3).
- **factrice** (0.14.1 → 0.14.2) : **`py.typed` embarqué** (#3).

## Périmètre (règle monas — lockstep)

| Paquet | → | |
|--------|---|--|
| `automatheque` | **0.14.2** | #71 + #3 |
| `automatheque.factrice` | **0.14.2** | #3 |
| `automatheque.schema` | *0.9.7* | inchangé (tenu hors republication) |

Invariant monas respecté (`version` monas == max == `0.14.2`).

## Après merge

Tag **`0.14.2`** (sans `v`) sur `main` → publie **`automatheque` et
`automatheque.factrice`** (schema en 0.9.7 ne matche pas le tag).