### PR TITLE
release(schema): py.typed dans le wheel + coupe 0.14.3 (#3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.14.2"
+version = "0.14.3"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -12,7 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.3] - 2026-07-20
+
+> Première republication de `schema` depuis 0.9.7 : il s'aligne sur la version
+> globale du monorepo (lockstep) et embarque enfin ses métadonnées en attente
+> (licence LGPL, plancher py3.9) en plus du typage exporté.
+
 ### Added
+
+* Typage exporté : `py.typed` embarqué dans le wheel
+  (`[tool.setuptools.package-data]`) + classifier `Typing :: Typed`. — cf. #3
 
 ### Changed
 

--- a/src/automatheque.schema/pyproject.toml
+++ b/src/automatheque.schema/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.schema"
-version = "0.9.7"
+version = "0.14.3"
 description = "Domaine pour des classes courantes et partagées"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
 ]
 dependencies = [
     "attrs",
@@ -31,6 +32,10 @@ dev = [
 [build-system]
 requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
+
+# Embarque le marqueur py.typed dans le wheel (typage exporté). Cf. #3.
+[tool.setuptools.package-data]
+"automatheque.schema" = ["py.typed"]
 
 [tool.tox]
 legacy_tox_ini = """


### PR DESCRIPTION
Dernière brique de #3 : `automatheque.schema` reçoit le même traitement py.typed
que les deux autres paquets. Comme 0.14.2 est déjà publiée, schema part sur le
prochain global **0.14.3**.

Closes #3

## Changement schema

- **`[tool.setuptools.package-data]`** embarque `py.typed` dans le wheel +
  classifier **`Typing :: Typed`**.

## Republication (lockstep)

C'est la **première republication de schema depuis 0.9.7**. Il s'aligne sur la
version globale (**0.9.7 → 0.14.3**) et embarque au passage ses **métadonnées en
attente** :
- licence **LGPL-3.0-or-later** (#20),
- plancher **py3.9** + classifiers (#32).

| Paquet | → | |
|--------|---|--|
| `automatheque.schema` | **0.14.3** | #3 + métadonnées LGPL/py3.9 en attente |
| `automatheque` | *0.14.2* | inchangé |
| `automatheque.factrice` | *0.14.2* | inchangé |

Invariant monas respecté (`version` monas == max == `0.14.3`).

## Vérifié

Le **sdist schema contient bien `automatheque/schema/py.typed`** ; `package-data`
garantit l'inclusion wheel côté CI.

## Après merge

Tag **`0.14.3`** (sans `v`) sur `main` → publie **uniquement
`automatheque.schema`**. **#3 est alors bouclée** (py.typed sur les 3 paquets).