### PR TITLE
test: étend la couverture (util, suivi, factrice/preparation) (#18)

### DIFF
--- a/src/automatheque.factrice/tests/test_preparation.py
+++ b/src/automatheque.factrice/tests/test_preparation.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Tests de construction du message MIME par PreparatriceSmtp.
+
+Aucun réseau : on vérifie uniquement l'objet ``email.mime`` retourné.
+"""
+
+from email.message import Message
+
+import pytest
+from automatheque.factrice.preparation import (
+    SEPARATEUR_DESTINATAIRES,
+    Preparatrice,
+    PreparatriceSmtp,
+)
+from automatheque.schema.texte import Courriel
+
+
+def _courriel(**kwargs):
+    """Construit un Courriel prêt pour la préparation."""
+    c = Courriel(
+        sujet=kwargs.get("sujet", "Sujet du mail"),
+        emetteur=kwargs.get("emetteur", "src@mail.com"),
+    )
+    c.ajouter_destinataire("user@tld.com")
+    return c
+
+
+def test_preparatrice_base_non_implementee():
+    """La classe de base ne sait rien préparer."""
+    with pytest.raises(NotImplementedError):
+        Preparatrice.prepare(_courriel())
+
+
+def test_prepare_construit_entetes():
+    """Sujet / From / To / Date sont positionnés depuis le Courriel."""
+    c = _courriel()
+    c.ajouter_destinataire("Toto <toto@tld.com>")
+
+    msg = PreparatriceSmtp.prepare(c)
+
+    assert isinstance(msg, Message)
+    assert msg["Subject"] == "Sujet du mail"
+    assert msg["From"] == "src@mail.com"
+    assert msg["To"] == SEPARATEUR_DESTINATAIRES.join(c.destinataires)
+    assert msg["Date"] == c.date_envoi
+    assert msg.preamble == "Sujet du mail"
+    assert msg.is_multipart()
+
+
+def test_prepare_corps_texte_plain():
+    """Un contenu simple produit une partie text/plain."""
+    c = _courriel()
+    c.contenu = "Bonjour"
+
+    msg = PreparatriceSmtp.prepare(c)
+
+    parties = msg.get_payload()
+    assert parties[0].get_content_type() == "text/plain"
+    assert parties[0].get_payload() == "Bonjour"
+
+
+def test_prepare_corps_html():
+    """Un contenu commençant par <html produit une partie text/html."""
+    c = _courriel()
+    c.contenu = "<html><body>Salut</body></html>"
+
+    msg = PreparatriceSmtp.prepare(c)
+
+    partie = msg.get_payload()[0]
+    assert partie.get_content_type() == "text/html"
+
+
+def test_prepare_avec_piece_jointe(tmp_path):
+    """La pièce jointe est lue et attachée au message."""
+    fichier = tmp_path / "document.txt"
+    fichier.write_bytes(b"contenu binaire")
+
+    c = _courriel()
+    c.contenu = "Voir pièce jointe"
+    c.ajouter_piece_jointe(fichier)
+
+    msg = PreparatriceSmtp.prepare(c)
+
+    parties = msg.get_payload()
+    assert len(parties) == 2  # corps + 1 pièce jointe
+    pj = parties[1]
+    assert pj.get_content_type() == "application/octet-stream"
+    # NB : `preparation.py` passe Content_Disposition / Name en **paramètres du
+    # Content-Type** (kwargs de MIMEApplication), pas dans un header dédié.
+    assert pj.get_param("name") == "document.txt"
+    assert 'filename="document.txt"' in pj.get_param("content-disposition")
+    assert pj.get_payload(decode=True) == b"contenu binaire"

--- a/src/automatheque/tests/suivi/test_suivi.py
+++ b/src/automatheque/tests/suivi/test_suivi.py
@@ -1,0 +1,105 @@
+"""Tests du sous-système ``suivi`` : port, adaptateur répertoire et journal."""
+
+import pytest
+from automatheque.suivi.adaptateurs.repertoire import StockageRepertoire
+from automatheque.suivi.journal import JournalSuivi
+from automatheque.suivi.ports import StockageAbstraite
+
+# --- Port abstrait -----------------------------------------------------------
+
+
+def test_stockage_abstraite_non_instanciable():
+    """On ne peut pas instancier directement le port abstrait."""
+    with pytest.raises(TypeError):
+        StockageAbstraite()
+
+
+def test_stockage_abstraite_methodes_levent_notimplemented():
+    """Les méthodes du port lèvent ``NotImplementedError`` si appelées via super()."""
+
+    class StockageBidon(StockageAbstraite):
+        def existe(self, reference):
+            return super().existe(reference)
+
+        def sauvegarde(self, reference, contenu):
+            return super().sauvegarde(reference, contenu)
+
+    s = StockageBidon()
+    with pytest.raises(NotImplementedError):
+        s.existe("x")
+    with pytest.raises(NotImplementedError):
+        s.sauvegarde("x", "y")
+
+
+# --- Adaptateur StockageRepertoire ------------------------------------------
+
+
+def test_repertoire_cree_le_dossier(tmp_path):
+    """``__attrs_post_init__`` crée le répertoire (y compris les parents)."""
+    cible = tmp_path / "sous" / "dossier"
+    assert not cible.exists()
+    StockageRepertoire(cible)
+    assert cible.is_dir()
+
+
+def test_repertoire_est_un_stockage_abstraite(tmp_path):
+    assert isinstance(StockageRepertoire(tmp_path), StockageAbstraite)
+
+
+def test_repertoire_existe_faux_puis_vrai(tmp_path):
+    stockage = StockageRepertoire(tmp_path)
+    assert stockage.existe("ref1") is False
+    assert stockage.sauvegarde("ref1", "contenu") is True
+    assert stockage.existe("ref1") is True
+
+
+def test_repertoire_sauvegarde_ecrit_le_contenu(tmp_path):
+    stockage = StockageRepertoire(tmp_path)
+    stockage.sauvegarde("maref", "des données")
+    assert (tmp_path / "maref").read_text() == "des données"
+
+
+def test_repertoire_sauvegarde_ecrase_le_contenu(tmp_path):
+    stockage = StockageRepertoire(tmp_path)
+    stockage.sauvegarde("maref", "v1")
+    stockage.sauvegarde("maref", "v2")
+    assert (tmp_path / "maref").read_text() == "v2"
+
+
+# --- JournalSuivi ------------------------------------------------------------
+
+
+def test_journal_deja_fait_et_coche(tmp_path):
+    """Round-trip complet : rien fait, puis coché, puis déjà fait."""
+    journal = JournalSuivi(StockageRepertoire(tmp_path))
+    assert journal.deja_fait("action42") is False
+    assert journal.coche("action42", "résultat") is True
+    assert journal.deja_fait("action42") is True
+
+
+def test_journal_idempotence(tmp_path):
+    """Cocher deux fois reste cohérent : l'action est vue comme faite."""
+    journal = JournalSuivi(StockageRepertoire(tmp_path))
+    journal.coche("act", "a")
+    journal.coche("act", "b")
+    assert journal.deja_fait("act") is True
+    assert (tmp_path / "act").read_text() == "b"
+
+
+def test_journal_references_independantes(tmp_path):
+    journal = JournalSuivi(StockageRepertoire(tmp_path))
+    journal.coche("faite", "x")
+    assert journal.deja_fait("faite") is True
+    assert journal.deja_fait("pas_faite") is False
+
+
+def test_journal_ni_fait_ni_a_refaire_est_neutre(tmp_path):
+    """La méthode ``ni_fait_ni_à_refaire`` n'est pas implémentée (renvoie None)."""
+    journal = JournalSuivi(StockageRepertoire(tmp_path))
+    assert journal.ni_fait_ni_à_refaire("arg") is None
+
+
+def test_journal_stockage_par_defaut(tmp_path):
+    """Le stockage par défaut est un ``StockageRepertoire``."""
+    journal = JournalSuivi()
+    assert isinstance(journal.stockage, StockageRepertoire)

--- a/src/automatheque/tests/util/test_fichier.py
+++ b/src/automatheque/tests/util/test_fichier.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Tests des utilitaires de manipulation des fichiers (util/fichier.py)."""
+
+from automatheque.util.fichier import enleve_caracteres_invalides
+
+
+def test_remplace_le_slash_par_underscore():
+    """Le seul caractère invalide sous Linux (le slash) devient un underscore."""
+    assert enleve_caracteres_invalides("a/b/c") == "a_b_c"
+
+
+def test_conserve_les_autres_caracteres_speciaux():
+    """Sous Linux, les autres caractères "spéciaux" sont conservés tels quels."""
+    valeur = 'nom:*?"<>|.txt'
+    assert enleve_caracteres_invalides(valeur) == valeur
+
+
+def test_chaine_sans_caractere_invalide_inchangee():
+    """Une chaîne propre est renvoyée à l'identique."""
+    assert enleve_caracteres_invalides("fichier_normal.txt") == "fichier_normal.txt"
+
+
+def test_valeur_non_chaine_renvoyee_telle_quelle():
+    """Un int (sans méthode replace) est renvoyé sans lever d'exception."""
+    assert enleve_caracteres_invalides(42) == 42

--- a/src/automatheque/tests/util/test_repertoire.py
+++ b/src/automatheque/tests/util/test_repertoire.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Tests des utilitaires de manipulation des répertoires (util/repertoire.py)."""
+
+from pathlib import Path
+
+import pytest
+from automatheque.util.repertoire import (
+    iter_fichiers,
+    mkdir_p,
+    remonte_arborescence,
+    supprime,
+)
+
+
+def test_mkdir_p_cree_arborescence(tmp_path):
+    """mkdir_p crée toute l'arborescence manquante."""
+    cible = tmp_path / "a" / "b" / "c"
+    mkdir_p(str(cible))
+    assert cible.is_dir()
+
+
+def test_mkdir_p_idempotent_sur_repertoire_existant(tmp_path):
+    """Recréer un répertoire existant ne lève pas d'erreur."""
+    cible = tmp_path / "deja"
+    cible.mkdir()
+    mkdir_p(str(cible))  # ne doit pas lever
+    assert cible.is_dir()
+
+
+def test_mkdir_p_leve_si_cible_est_un_fichier(tmp_path):
+    """Si la cible existe et n'est pas un répertoire, l'erreur est relevée."""
+    fichier = tmp_path / "fichier.txt"
+    fichier.write_text("x")
+    with pytest.raises(OSError):
+        mkdir_p(str(fichier))
+
+
+def test_supprime_repertoire_vide(tmp_path):
+    """Un répertoire vide est supprimé."""
+    vide = tmp_path / "vide"
+    vide.mkdir()
+    supprime(str(vide))
+    assert not vide.exists()
+
+
+def test_supprime_repertoire_non_vide_conserve(tmp_path):
+    """Un répertoire non vide n'est pas supprimé (sans force)."""
+    plein = tmp_path / "plein"
+    plein.mkdir()
+    (plein / "f.txt").write_text("x")
+    supprime(str(plein))
+    assert plein.exists()
+
+
+def test_remonte_arborescence_renvoie_les_parents(tmp_path):
+    """Le générateur remonte les parents relatifs à la racine, hors racine."""
+    fichier = tmp_path / "a" / "b" / "c.txt"
+    parents = list(remonte_arborescence(fichier, racine=tmp_path))
+    assert parents == [tmp_path / "a" / "b", tmp_path / "a"]
+
+
+def test_remonte_arborescence_hors_racine_leve(tmp_path):
+    """Un fichier non rattaché à la racine lève ValueError."""
+    with pytest.raises(ValueError):
+        list(remonte_arborescence(Path("/autre/chemin/x.txt"), racine=tmp_path))
+
+
+def test_iter_fichiers_sur_repertoire(tmp_path):
+    """Sur un répertoire, tous les fichiers sont listés récursivement."""
+    (tmp_path / "sous").mkdir()
+    f1 = tmp_path / "a.txt"
+    f2 = tmp_path / "sous" / "b.txt"
+    f1.write_text("1")
+    f2.write_text("2")
+    resultat = iter_fichiers(tmp_path)
+    assert set(resultat) == {f1, f2}
+    # aucun répertoire dans le résultat
+    assert all(not p.is_dir() for p in resultat)
+
+
+def test_iter_fichiers_sur_fichier_unique(tmp_path):
+    """Sur un fichier, seul ce fichier est renvoyé."""
+    f = tmp_path / "seul.txt"
+    f.write_text("x")
+    assert iter_fichiers(f) == [f]

--- a/src/automatheque/tests/util/test_structures_python.py
+++ b/src/automatheque/tests/util/test_structures_python.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Tests des utilitaires sur les structures python (util/structures_python.py)."""
+
+from datetime import date, datetime, time
+
+import pytz
+from automatheque.util.structures_python import (
+    date_en_datetime,
+    date_est_naive,
+    datetimezone_depuis_code_pays,
+    dict_merge,
+)
+
+
+def test_dict_merge_fusionne_recursivement():
+    """Les sous-dictionnaires sont fusionnés récursivement, pas écrasés."""
+    a = {"x": 1, "sous": {"a": 1, "b": 2}}
+    b = {"y": 2, "sous": {"b": 20, "c": 30}}
+    resultat = dict_merge(a, b)
+    assert resultat == {"x": 1, "y": 2, "sous": {"a": 1, "b": 20, "c": 30}}
+
+
+def test_dict_merge_ne_modifie_pas_les_sources():
+    """La fusion travaille sur des copies profondes : les sources restent intactes."""
+    a = {"sous": {"a": 1}}
+    b = {"sous": {"b": 2}}
+    dict_merge(a, b)
+    assert a == {"sous": {"a": 1}}
+    assert b == {"sous": {"b": 2}}
+
+
+def test_dict_merge_b_non_dict_remplace_a():
+    """Si b n'est pas un dict, il remplace intégralement a."""
+    assert dict_merge({"a": 1}, "valeur") == "valeur"
+
+
+def test_date_est_naive_vrai_pour_date_sans_tz():
+    """Une datetime sans timezone est considérée comme naive."""
+    assert date_est_naive(datetime(2020, 1, 1, 12, 0)) is True
+
+
+def test_date_est_naive_faux_pour_date_avec_tz():
+    """Une datetime avec timezone n'est pas naive."""
+    aware = pytz.utc.localize(datetime(2020, 1, 1, 12, 0))
+    assert date_est_naive(aware) is False
+
+
+def test_date_en_datetime_convertit_une_date():
+    """Une date pure est transformée en datetime (minuit UTC par défaut)."""
+    resultat = date_en_datetime(date(2020, 5, 4))
+    assert isinstance(resultat, datetime)
+    assert resultat.year == 2020 and resultat.month == 5 and resultat.day == 4
+    assert resultat.hour == 0 and resultat.minute == 0
+    assert not date_est_naive(resultat)
+
+
+def test_date_en_datetime_avec_heures_personnalisees():
+    """Les paramètres heures/minutes/secondes complètent la date."""
+    resultat = date_en_datetime(date(2020, 5, 4), heures=10, minutes=30, secondes=15)
+    assert resultat.hour == 10 and resultat.minute == 30 and resultat.second == 15
+
+
+def test_date_en_datetime_avec_time_obj_fourni():
+    """Un objet time "aware" fourni est combiné avec la date."""
+    time_obj = time(8, 15, 0, tzinfo=pytz.utc)
+    resultat = date_en_datetime(date(2021, 3, 2), time_obj=time_obj)
+    assert resultat.hour == 8 and resultat.minute == 15
+
+
+def test_date_en_datetime_datetime_deja_convertie_inchangee():
+    """Une datetime en entrée n'est pas reconvertie."""
+    src = datetime(2019, 12, 31, 23, 59)
+    assert date_en_datetime(src) is src
+
+
+def test_datetimezone_depuis_code_pays_ajoute_la_tz():
+    """Une datetime naive reçoit la première timezone du pays."""
+    resultat = datetimezone_depuis_code_pays(datetime(2020, 1, 1, 10, 0), "FR")
+    assert resultat is not None
+    assert not date_est_naive(resultat)
+    assert resultat.utcoffset().total_seconds() == 3600  # UTC+1 en hiver
+
+
+def test_datetimezone_depuis_code_pays_date_deja_aware_inchangee():
+    """Une datetime déjà "aware" est renvoyée telle quelle."""
+    aware = pytz.utc.localize(datetime(2020, 1, 1, 10, 0))
+    assert datetimezone_depuis_code_pays(aware, "FR") is aware
+
+
+def test_datetimezone_depuis_code_pays_invalide_renvoie_none():
+    """Un code pays inconnu renvoie None."""
+    assert datetimezone_depuis_code_pays(datetime(2020, 1, 1), "ZZ") is None


### PR DESCRIPTION
Couverture de tests (#18).

Closes #18

## Résultat

Couverture globale **65 % → 79 %** (+14 pts, **+42 tests** → 106 au total).
L'objectif de #18 (« ~50 % avant un jalon 1.0 ») est **largement dépassé**.

> Le « ~4 % » de l'énoncé de #18 datait : la session avait déjà beaucoup ajouté
> (harness, script, config, log, reessaye…). Le vrai travail restant était de
> couvrir les modules à **0 %** ou très bas.

## Modules couverts

- **`util/`** : `fichier`, `repertoire`, `structures_python` (étaient à
  9–19 %).
- **`suivi/`** : `ports`, `journal`, adaptateur `repertoire` (étaient à **0 %**).
- **`factrice/preparation`** : construction du message MIME (sans réseau).

## Note

Le test de pièce jointe **documente le comportement réel** de `preparation.py` :
`Content_Disposition` / `Name` sont passés en **paramètres du `Content-Type`**
de `MIMEApplication`, pas dans un header `Content-Disposition` dédié (petite
bizarrerie MIME, à corriger séparément si besoin).

## Restent plus bas (suite possible, pas bloquant pour #18)

`factrice/expedition` (49 %, `smtplib` à mocker), patterns
`conception/structures`, quelques trous `greffon`. À monter dans une passe
ultérieure si tu veux viser plus haut.

## Genèse

Écrit en partie via des sous-agents (grappes de modules) ; l'un d'eux a été
coupé par une limite de session — j'ai **repris, vérifié et corrigé** à la main
(un test factrice faisait une hypothèse fausse sur le `Content-Disposition`).
`ruff` propre, `pytest src` = **106 passed**.