### PR TITLE
fix(robustesse): horodatage courriel, plateforme, thread-safety, exécutabilité (#25)

### DIFF
--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -12,6 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* `courriel` : correction d'un bug d'horodatage figé. `_date_envoi` utilisait
+  `default=datetime.now()`, évalué **une seule fois** à la définition de la
+  classe : tous les courriels partageaient la date de l'import. Remplacé par
+  une **fabrique** (`attr.ib(factory=maintenant)`) réévaluée à chaque
+  instanciation. — cf. #25
+
+### Changed
+
+* `courriel` : les dates sont désormais **tz-aware** (UTC). Nouvelle fabrique
+  `maintenant()` (`datetime.now(timezone.utc)`) et `date_envoi` émet un offset
+  RFC 5322 explicite (`+0000`) via `email.utils.format_datetime` ; un
+  `datetime` naïf affecté à la main reste formaté en heure locale
+  (rétro-compat). — cf. #25
+
 ## [0.14.3] - 2026-07-20
 
 > Première republication de `schema` depuis 0.9.7 : il s'aligne sur la version

--- a/src/automatheque.schema/automatheque/schema/texte/courriel.py
+++ b/src/automatheque.schema/automatheque/schema/texte/courriel.py
@@ -1,13 +1,23 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
+from datetime import datetime, timezone
 from email.header import Header
-from email.utils import formataddr, formatdate, parseaddr
+from email.utils import format_datetime, formataddr, formatdate, parseaddr
 from pathlib import Path
 from typing import Callable, List, Sequence, Tuple, Union
 
 import attr
 
 # from automatheque.schema.medium import Medium
+
+
+def maintenant() -> datetime:
+    """Horodatage courant, **tz-aware** (UTC).
+
+    Renvoyer un ``datetime`` conscient du fuseau évite les ambiguïtés lors du
+    formatage RFC 5322 (l'offset est explicite) et les comparaisons avec
+    d'autres dates naïves. Cf. #25.
+    """
+    return datetime.now(timezone.utc)
 
 
 @attr.s
@@ -27,9 +37,12 @@ class Courriel:
     _destinataires: Sequence[Union[tuple, str]] = attr.ib(factory=list, kw_only=True)
     contenu: str = attr.ib(init=False, default="", kw_only=True)
     pieces_jointes: List[Path] = attr.ib(init=False, factory=list, kw_only=True)
-    _date_envoi: datetime = attr.ib(
-        init=False, default=datetime.now(), kw_only=True
-    )  # TODO(#25) vérifier les timezones
+    # ATTENTION : ``factory`` (et non ``default=datetime.now()``) est
+    # indispensable. Un ``default`` est évalué **une seule fois**, à la
+    # définition de la classe : toutes les instances partageraient alors
+    # l'horodatage figé de l'import. La fabrique est rappelée à chaque
+    # instanciation. Cf. #25.
+    _date_envoi: datetime = attr.ib(init=False, factory=maintenant, kw_only=True)
     teste_adresse_valide: Callable[[str], Tuple[bool, str]] = attr.ib(
         init=False, default=lambda e: ("@" in e, ""), kw_only=True
     )
@@ -96,5 +109,10 @@ class Courriel:
 
     @property
     def date_envoi(self):
+        """Date d'envoi au format RFC 5322 (en-tête ``Date`` d'un courriel)."""
         if self._date_envoi and isinstance(self._date_envoi, datetime):
-            return formatdate(datetime.timestamp(self._date_envoi))
+            if self._date_envoi.tzinfo is not None:
+                # datetime tz-aware : l'offset est écrit explicitement.
+                return format_datetime(self._date_envoi)
+            # Rétro-compat : un datetime naïf est supposé être en heure locale.
+            return formatdate(datetime.timestamp(self._date_envoi), localtime=True)

--- a/src/automatheque.schema/tests/texte/test_courriel.py
+++ b/src/automatheque.schema/tests/texte/test_courriel.py
@@ -1,5 +1,8 @@
+from datetime import datetime
+
+import attr
 import pytest  # type: ignore
-from automatheque.schema.texte.courriel import Courriel
+from automatheque.schema.texte.courriel import Courriel, maintenant
 
 
 def test_courriel():
@@ -20,3 +23,39 @@ def test_courriel():
     with pytest.raises(ValueError) as err:
         c.destinataires = ["Faux faux-mail.com"]
     assert str(err.value) == "Adresse courriel invalide"
+
+
+def test_date_envoi_utilise_une_fabrique():
+    """#25 : ``_date_envoi`` doit être une *fabrique*, pas une constante figée.
+
+    Avec ``default=datetime.now()`` la date était évaluée une seule fois à la
+    définition de la classe et partagée par toutes les instances. Ce test
+    échouerait sur l'ancien code (le ``default`` était un ``datetime``).
+    """
+    champ = attr.fields_dict(Courriel)["_date_envoi"]
+    assert isinstance(champ.default, attr.Factory)  # type: ignore[arg-type]
+    assert champ.default.factory is maintenant
+
+
+def test_date_envoi_horodatage_par_instance():
+    """Deux courriels obtiennent chacun leur propre horodatage tz-aware."""
+    c1 = Courriel(sujet="a")
+    c2 = Courriel(sujet="b")
+    assert c1._date_envoi.tzinfo is not None
+    assert c2._date_envoi.tzinfo is not None
+    # Objets distincts (pas la même constante partagée), et croissants.
+    assert c1._date_envoi <= c2._date_envoi
+
+
+def test_date_envoi_format_rfc5322_tz_aware():
+    """La date rendue porte un offset explicite (``+0000`` en UTC)."""
+    c = Courriel(sujet="x")
+    assert c.date_envoi.endswith("+0000")
+
+
+def test_date_envoi_datetime_naif_retrocompat():
+    """Un ``datetime`` naïf affecté manuellement reste formatable (heure locale)."""
+    c = Courriel(sujet="x")
+    c._date_envoi = datetime(2020, 1, 2, 3, 4, 5)  # naïf
+    rendu = c.date_envoi
+    assert "02 Jan 2020" in rendu

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `util.dependances_externes` : `recup_executable` (et `charge_dependance`)
+  acceptent `teste_execution=False`. Activé, on ne se contente plus de vérifier
+  la présence et le bit exécutable : on **lance réellement** le binaire (E/S
+  neutralisées, court délai, code de retour ignoré) pour détecter un exécutable
+  présent mais inutilisable (mauvaise architecture, interpréteur manquant…).
+  Désactivé par défaut : aucun changement de comportement. — cf. #25
+
+### Changed
+
+* `util.fichier.enleve_caracteres_invalides` tient compte de la **plateforme** :
+  l'ensemble étendu des caractères interdits n'est retiré que sous Windows
+  (`os.name == "nt"`) ; POSIX ne retire que le séparateur. — cf. #25
+* `suivi.adaptateurs.repertoire.StockageRepertoire` sérialise ses accès au
+  système de fichiers derrière un **verrou** (`threading.Lock`), le rendant sûr
+  en contexte multi-thread. — cf. #25
+
 ## [0.14.2] - 2026-07-20
 
 ### Added

--- a/src/automatheque/automatheque/suivi/adaptateurs/repertoire.py
+++ b/src/automatheque/automatheque/suivi/adaptateurs/repertoire.py
@@ -1,3 +1,4 @@
+import threading
 from pathlib import Path
 
 import attr
@@ -8,17 +9,24 @@ from automatheque.suivi.ports import StockageAbstraite
 @attr.s
 class StockageRepertoire(StockageAbstraite):
     repertoire: Path = attr.ib(default=Path("/tmp"))
+    # Sérialise les accès au système de fichiers pour rendre l'adaptateur
+    # utilisable depuis plusieurs threads. Non passé à l'``__init__``, ni
+    # comparé/affiché. Cf. #25.
+    _verrou: threading.Lock = attr.ib(
+        factory=threading.Lock, init=False, repr=False, eq=False
+    )
 
     def __attrs_post_init__(self):
         self.repertoire.mkdir(parents=True, exist_ok=True)
 
     def existe(self, reference: str):
-        # TODO(#25) mutex pour thread safety
         fichier = self.repertoire / reference
-        return fichier.exists()
+        with self._verrou:
+            return fichier.exists()
 
     def sauvegarde(self, reference: str, contenu: str):
         fichier = self.repertoire / reference
-        with open(fichier, "w") as f:
-            f.write(contenu)
+        with self._verrou:
+            with open(fichier, "w") as f:
+                f.write(contenu)
         return True

--- a/src/automatheque/automatheque/util/dependances_externes.py
+++ b/src/automatheque/automatheque/util/dependances_externes.py
@@ -56,9 +56,24 @@ def verifie_dependance(cle_dependance):
         raise DependanceManquante(cle_dependance, MAUVAISE_CLE_ERREUR)
 
 
-def charge_dependance(cle, executable, executable_complet, erreur="", verifie=True):
-    """Charge la dépendance donnée, dans le registre."""
-    executable = recup_executable(executable, executable_complet)
+def charge_dependance(
+    cle,
+    executable,
+    executable_complet,
+    erreur="",
+    verifie=True,
+    teste_execution=False,
+):
+    """Charge la dépendance donnée, dans le registre.
+
+    :param teste_execution: si vrai, ne se contente pas de vérifier la présence
+        de l'exécutable mais tente réellement de le lancer (cf.
+        ``recup_executable``). Désactivé par défaut pour ne pas exécuter de
+        binaire à l'insu de l'appelant.
+    """
+    executable = recup_executable(
+        executable, executable_complet, teste_execution=teste_execution
+    )
     executant = Executant(executable)
 
     # Ajout dans le registre des dépendances :
@@ -77,19 +92,53 @@ def charge_dependance(cle, executable, executable_complet, erreur="", verifie=Tr
     return executant
 
 
-def recup_executable(nom, chemin_complet):
+def recup_executable(nom, chemin_complet, teste_execution=False):
     """Récupère le chemin vers l'exécutable demandé.
 
+    :param teste_execution: si vrai, on ne se contente pas de vérifier que le
+        fichier existe et porte le bit exécutable : on tente réellement de le
+        lancer (cf. ``_executable_fonctionne``) pour détecter un binaire
+        présent mais inutilisable (mauvaise architecture, interpréteur ou
+        bibliothèque manquante…).
     :returns: str ou False
     """
     path = shutil.which(nom)
-    # TODO(#25) : il faut aussi tester l'execution sans args pour voir si ça marche.
     # Si on ne trouve pas l'exécutable on essaie de forcer un chemin classique :
     if path is None:
         path = chemin_complet
         if not os.path.isfile(path) or not os.access(path, os.X_OK):
             return False
+    if teste_execution and not _executable_fonctionne(path):
+        return False
     return path
+
+
+def _executable_fonctionne(path, timeout=2):
+    """Vérifie qu'un exécutable démarre réellement (au-delà du bit exécutable).
+
+    On le lance sans argument, entrées/sorties neutralisées, avec un délai
+    court. Le **code de retour est ignoré** : de nombreux outils quittent en
+    erreur sans argument (affichage de l'usage). Seul compte le fait que le
+    système ait pu *démarrer* le binaire.
+
+    * démarrage impossible (``OSError`` : « Exec format error », interpréteur
+      manquant…) → ``False`` ;
+    * délai dépassé → considéré comme fonctionnel (le binaire tournait bien) ;
+    * démarrage OK (quel que soit le code de retour) → ``True``.
+    """
+    try:
+        subprocess.run(
+            [path],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return True
+    except OSError:
+        return False
+    return True
 
 
 def _gen_erreur(cle):

--- a/src/automatheque/automatheque/util/fichier.py
+++ b/src/automatheque/automatheque/util/fichier.py
@@ -1,15 +1,27 @@
 # -*- coding: utf-8 -*-
 """Utilitaires de manipulation des fichiers."""
 
+import os
+
+# Caractères interdits dans un nom de fichier, par famille de plateforme.
+# Sous Windows (``os.name == "nt"``) l'ensemble est bien plus large ; les
+# systèmes POSIX (Linux, macOS) n'interdisent guère que le séparateur.
+# Cf. #25.
+CARACTERES_INVALIDES_NT = r'/\:*?"<>|'
+CARACTERES_INVALIDES_POSIX = "/"
+
 
 def enleve_caracteres_invalides(value):
     """Supprime les caractères incompatibles avec le système de fichier.
 
+    L'ensemble des caractères retirés dépend de la plateforme courante
+    (cf. ``os.name``).
+
     https://stackoverflow.com/questions/1033424/how-to-remove-bad-path-characters-in-python
     """
-    deletechars = r'/\:*?"<>|'
-    # TODO(#25) tester la plateforme
-    deletechars = "/"  # Linux autorise quasiment tout le reste
+    deletechars = (
+        CARACTERES_INVALIDES_NT if os.name == "nt" else CARACTERES_INVALIDES_POSIX
+    )
     try:
         for c in deletechars:
             value = value.replace(c, "_")

--- a/src/automatheque/tests/suivi/test_suivi.py
+++ b/src/automatheque/tests/suivi/test_suivi.py
@@ -66,6 +66,40 @@ def test_repertoire_sauvegarde_ecrase_le_contenu(tmp_path):
     assert (tmp_path / "maref").read_text() == "v2"
 
 
+def test_repertoire_verrou_par_instance(tmp_path):
+    """#25 : chaque adaptateur possède son propre verrou (non partagé)."""
+    a = StockageRepertoire(tmp_path)
+    b = StockageRepertoire(tmp_path)
+    assert a._verrou is not None
+    assert a._verrou is not b._verrou
+
+
+def test_repertoire_ecritures_concurrentes(tmp_path):
+    """Les accès concurrents restent cohérents (sérialisés par le verrou)."""
+    import threading
+
+    stockage = StockageRepertoire(tmp_path)
+    erreurs = []
+
+    def ecrit(n):
+        try:
+            for i in range(50):
+                stockage.sauvegarde(f"ref{n}", f"{n}-{i}")
+                stockage.existe(f"ref{n}")
+        except Exception as e:  # pragma: no cover - ne devrait pas arriver
+            erreurs.append(e)
+
+    fils = [threading.Thread(target=ecrit, args=(n,)) for n in range(8)]
+    for f in fils:
+        f.start()
+    for f in fils:
+        f.join()
+
+    assert erreurs == []
+    for n in range(8):
+        assert stockage.existe(f"ref{n}") is True
+
+
 # --- JournalSuivi ------------------------------------------------------------
 
 

--- a/src/automatheque/tests/test_dependances_externes.py
+++ b/src/automatheque/tests/test_dependances_externes.py
@@ -1,10 +1,15 @@
 """Tests de ``Executant.exec`` (options subprocess explicites, #66)."""
 
 import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
-from automatheque.util.dependances_externes import Executant
+from automatheque.util.dependances_externes import (
+    Executant,
+    _executable_fonctionne,
+    recup_executable,
+)
 
 
 def _exec(*args, **kwargs):
@@ -81,3 +86,51 @@ def test_exec_timeout_propage_timeoutexpired():
         run.side_effect = subprocess.TimeoutExpired(cmd="truc", timeout=1)
         with pytest.raises(subprocess.TimeoutExpired):
             Executant("/bin/truc").exec(timeout=1)
+
+
+# --- recup_executable / test d'exécution (#25) ------------------------------
+
+
+def test_recup_executable_absent_renvoie_false(tmp_path):
+    """Un nom introuvable et un chemin de repli inexistant → False."""
+    assert recup_executable("nom-improbable-xyz", str(tmp_path / "absent")) is False
+
+
+def test_recup_executable_sans_test_ne_lance_pas(tmp_path):
+    """Par défaut : présence + bit exécutable suffisent, sans lancer le binaire."""
+    faux = tmp_path / "faux"
+    faux.write_text("ceci n'est pas un binaire")
+    faux.chmod(0o755)
+    # Accepté sur la seule base des permissions, sans tentative d'exécution.
+    assert recup_executable("nom-improbable-xyz", str(faux)) == str(faux)
+
+
+def test_recup_executable_teste_execution_detecte_non_binaire(tmp_path):
+    """Avec ``teste_execution``, un faux exécutable (non binaire) est rejeté."""
+    faux = tmp_path / "faux"
+    faux.write_text("ceci n'est pas un binaire")
+    faux.chmod(0o755)
+    assert (
+        recup_executable("nom-improbable-xyz", str(faux), teste_execution=True) is False
+    )
+
+
+def test_recup_executable_teste_execution_accepte_vrai_binaire():
+    """Un exécutable qui démarre réellement (l'interpréteur Python) est accepté."""
+    path = recup_executable("nom-improbable-xyz", sys.executable, teste_execution=True)
+    assert path == sys.executable
+
+
+def test_executable_fonctionne_vrai_sur_binaire():
+    assert _executable_fonctionne(sys.executable) is True
+
+
+def test_executable_fonctionne_faux_sur_inexistant():
+    assert _executable_fonctionne("/chemin/qui/nexiste/pas/xyz") is False
+
+
+def test_executable_fonctionne_timeout_considere_ok():
+    """Un dépassement de délai signifie que le binaire *tournait* → True."""
+    with patch("automatheque.util.dependances_externes.subprocess.run") as run:
+        run.side_effect = subprocess.TimeoutExpired(cmd="x", timeout=2)
+        assert _executable_fonctionne("/bin/peu-importe") is True

--- a/src/automatheque/tests/util/test_fichier.py
+++ b/src/automatheque/tests/util/test_fichier.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests des utilitaires de manipulation des fichiers (util/fichier.py)."""
 
+import automatheque.util.fichier as fichier
 from automatheque.util.fichier import enleve_caracteres_invalides
 
 
@@ -23,3 +24,17 @@ def test_chaine_sans_caractere_invalide_inchangee():
 def test_valeur_non_chaine_renvoyee_telle_quelle():
     """Un int (sans méthode replace) est renvoyé sans lever d'exception."""
     assert enleve_caracteres_invalides(42) == 42
+
+
+def test_posix_ne_retire_que_le_separateur(monkeypatch):
+    """#25 : sous POSIX, seul le séparateur est invalide."""
+    monkeypatch.setattr(fichier.os, "name", "posix")
+    assert enleve_caracteres_invalides("a:b*c?/d") == "a:b*c?_d"
+
+
+def test_windows_retire_tous_les_caracteres_interdits(monkeypatch):
+    """#25 : sous Windows, l'ensemble étendu des caractères interdits est retiré."""
+    monkeypatch.setattr(fichier.os, "name", "nt")
+    assert enleve_caracteres_invalides('a/b\\c:d*e?f"g<h>i|j') == (
+        "a_b_c_d_e_f_g_h_i_j"
+    )


### PR DESCRIPTION
## Description

Traite les **5 items de robustesse & portabilité** de #25.

### `schema` — `courriel`
- **Bug corrigé : horodatage figé et partagé.** `_date_envoi` utilisait
  `default=datetime.now()`, évalué **une seule fois** à la définition de la
  classe → tous les courriels portaient la date de l'**import**, pas de leur
  création. Remplacé par une **fabrique** `attr.ib(factory=maintenant)`,
  réévaluée à chaque instanciation.
- **Dates tz-aware (UTC).** Nouvelle fabrique `maintenant()`
  (`datetime.now(timezone.utc)`) ; `date_envoi` émet un offset RFC 5322
  explicite (`+0000`) via `email.utils.format_datetime`. Un `datetime` naïf
  affecté à la main reste formaté en heure locale (rétro-compat).

### `automatheque`
- **`util/fichier`** : `enleve_caracteres_invalides` dépend de la **plateforme** —
  ensemble étendu de caractères interdits sous Windows (`os.name == "nt"`),
  séparateur seul sous POSIX.
- **`suivi/adaptateurs/repertoire`** : `StockageRepertoire` sérialise ses accès
  fichier derrière un **`threading.Lock`** (thread-safety), un verrou par
  instance.
- **`util/dependances_externes`** : `recup_executable` / `charge_dependance`
  gagnent `teste_execution=False`. Activé, on **lance réellement** le binaire
  (E/S neutralisées, court délai, code retour ignoré) pour détecter un
  exécutable présent mais inutilisable. **Off par défaut → aucun changement de
  comportement** pour les appelants existants.

## Tests

- Régression horodatage : la fabrique est bien un `attr.Factory` (échoue sur
  l'ancien code), tz-aware, format RFC 5322, rétro-compat datetime naïf.
- Plateforme fichier : `monkeypatch` de `os.name` (POSIX vs `nt`).
- Verrou par instance + écritures concurrentes (8 threads).
- Sonde d'exécutabilité : binaire OK, non-binaire rejeté, timeout considéré OK.

`pytest src` : **121 passés**. `ruff check`/`ruff format --check`/`mypy` verts.

## Note versioning

La PR touche **`schema` ET `automatheque`** → au prochain `release: coupe`, les
deux paquets prendront la version globale (lockstep). CHANGELOG posé sous
`[Unreleased]` des deux paquets.

## Issues liées

Closes #25
