### PR TITLE
fix(erreurs): journalisation des capacités, exception config, retour esmtp (#26)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* `expedition.ExpeditriceEsmtp.expedie` : `process.check_returncode()` peut
+  lever `CalledProcessError`. On l'attrape désormais **spécifiquement** (au lieu
+  d'un `except Exception` fourre-tout) et on journalise proprement le code de
+  retour et `stderr` ; l'appelant récupère toujours le code de retour. — cf. #26
+
 ## [0.14.2] - 2026-07-20
 
 ### Added

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -2,6 +2,7 @@
 import abc
 import logging
 import smtplib
+import subprocess
 from configparser import ConfigParser
 from datetime import datetime
 from pathlib import Path
@@ -179,9 +180,16 @@ class ExpeditriceEsmtp:
             # On execute : `esmtp courriel1,courriel2 < fic`
             process = self.executant.exec(*args, stdin=f)
 
+        # `check_returncode()` lève `CalledProcessError` si esmtp a échoué. On
+        # l'attrape spécifiquement pour journaliser proprement (code + stderr)
+        # sans interrompre l'appelant : `expedie` renvoie le code de retour,
+        # charge à lui de décider quoi en faire.
         try:
-            process.check_returncode()  # TODO(#26) attention raise !
-        except Exception:
-            LOGGER.exception(process.stderr)
-            # raise e
+            process.check_returncode()
+        except subprocess.CalledProcessError:
+            LOGGER.error(
+                "Échec de l'envoi via esmtp (code %s) : %s",
+                process.returncode,
+                process.stderr,
+            )
         return process.returncode

--- a/src/automatheque.factrice/tests/test_expedition.py
+++ b/src/automatheque.factrice/tests/test_expedition.py
@@ -1,10 +1,13 @@
+import logging
 import smtplib
+import subprocess
 from configparser import ConfigParser
 from unittest.mock import MagicMock
 
 import pytest
 from automatheque.factrice import expedition
-from automatheque.factrice.expedition import ExpeditriceSmtp
+from automatheque.factrice.expedition import ExpeditriceEsmtp, ExpeditriceSmtp
+from automatheque.schema.texte import Courriel
 
 
 def _config_smtp():
@@ -41,3 +44,38 @@ def test_erreur_non_smtp_pendant_connexion_se_propage(monkeypatch):
 
     with pytest.raises(ValueError):
         ExpeditriceSmtp(config=_config_smtp())
+
+
+# --- ExpeditriceEsmtp : gestion du code de retour (#26) ---------------------
+
+
+def _esmtp(monkeypatch, process):
+    """Construit une ExpeditriceEsmtp dont l'exécutant renvoie ``process``."""
+    executant = MagicMock()
+    executant.exec.return_value = process
+    monkeypatch.setattr(expedition, "charge_dependance", lambda *a, **k: executant)
+    return ExpeditriceEsmtp(config=ConfigParser())
+
+
+def _courriel():
+    return Courriel(emetteur="exp@ex.fr", sujet="sujet", destinataires=["dest@ex.fr"])
+
+
+def test_esmtp_succes_renvoie_le_code_retour(monkeypatch, tmp_path):
+    process = MagicMock(returncode=0, stderr=b"")
+    process.check_returncode.return_value = None
+    exp = _esmtp(monkeypatch, process)
+    assert exp.expedie(_courriel()) == 0
+
+
+def test_esmtp_echec_journalise_et_renvoie_le_code(monkeypatch, caplog):
+    """`check_returncode` peut lever : l'erreur est journalisée, pas propagée."""
+    process = MagicMock(returncode=42, stderr=b"boum esmtp")
+    process.check_returncode.side_effect = subprocess.CalledProcessError(
+        42, "esmtp", stderr=b"boum esmtp"
+    )
+    exp = _esmtp(monkeypatch, process)
+    with caplog.at_level(logging.ERROR, logger="automatheque.factrice.expedition"):
+        code = exp.expedie(_courriel())
+    assert code == 42
+    assert any("esmtp" in r.getMessage() for r in caplog.records)

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `greffon` : décorateur `signale_appel` pour **journaliser les appels de
+  capacités** d'un greffon. Posé sur une méthode, il journalise début/fin
+  (avec durée) au niveau `DEBUG`, préfixés par `cle||identifiant`, et
+  l'échec au niveau `ERROR` (avec trace) avant de **propager** l'exception.
+  Exporté depuis `automatheque.greffon`. Remplace le `_signale_appel` mort
+  (jamais appelé). — cf. #26
+* `exceptions.ConfigurationInvalide` : exception dédiée à une configuration
+  inexploitable. Hérite d'`AutomathequeBaseException` **et** de `ValueError`
+  (rétro-compat des appelants existants). — cf. #26
 * `util.dependances_externes` : `recup_executable` (et `charge_dependance`)
   acceptent `teste_execution=False`. Activé, on ne se contente plus de vérifier
   la présence et le bit exécutable : on **lance réellement** le binaire (E/S
@@ -20,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* `configuration._dictconfig_depuis_ini` lève désormais
+  `ConfigurationInvalide` (au lieu d'un `ValueError` générique) quand la
+  section `[log]` contient un `%` non échappé. — cf. #26
 * `util.fichier.enleve_caracteres_invalides` tient compte de la **plateforme** :
   l'ensemble étendu des caractères interdits n'est retiré que sous Windows
   (`os.name == "nt"`) ; POSIX ne retire que le séparateur. — cf. #25

--- a/src/automatheque/automatheque/configuration.py
+++ b/src/automatheque/automatheque/configuration.py
@@ -11,6 +11,7 @@ from configparser import (
 from os import path
 
 from automatheque import constantes
+from automatheque.exceptions import ConfigurationInvalide
 from automatheque.log import configure_logging
 
 
@@ -132,8 +133,9 @@ def _dictconfig_depuis_ini(config):
 
     Renvoie ``None`` si aucune de ces clés n'est présente (rien à configurer).
 
-    :raise ValueError: si une valeur contient un ``%`` non échappé (message
-        explicite invitant à doubler le ``%``).
+    :raise ConfigurationInvalide: si une valeur contient un ``%`` non échappé
+        (message explicite invitant à doubler le ``%``). Cette exception hérite
+        aussi de ``ValueError`` (rétro-compat des appelants existants).
     """
     cles = ("niveau", "fichier", "format", "names")
     if not any(config.has_option("log", c) for c in cles):
@@ -149,7 +151,7 @@ def _dictconfig_depuis_ini(config):
         fichier = config.get("log", "fichier", fallback=None)
         names_brut = config.get("log", "names", fallback="")
     except InterpolationError as exc:
-        raise ValueError(
+        raise ConfigurationInvalide(
             "Section [log] : un '%' non échappé. Doublez-le en '%%' (convention "
             "ConfigParser), p. ex. format = %%(asctime)s %%(message)s. [{}]".format(exc)
         ) from exc

--- a/src/automatheque/automatheque/exceptions.py
+++ b/src/automatheque/automatheque/exceptions.py
@@ -20,3 +20,13 @@ class ArgumentManquant(AutomathequeBaseException):
     def __init__(self, argument):
         """Initialisation."""
         self.msg = "Argument '{}' manquant.".format(argument)
+
+
+class ConfigurationInvalide(AutomathequeBaseException, ValueError):
+    """Configuration syntaxiquement invalide ou inexploitable.
+
+    Hérite aussi de :class:`ValueError` : le code appelant qui attrapait
+    historiquement un ``ValueError`` continue de fonctionner, tout en
+    permettant désormais un filtrage spécifique via la hiérarchie
+    ``AutomathequeBaseException``.
+    """

--- a/src/automatheque/automatheque/greffon/__init__.py
+++ b/src/automatheque/automatheque/greffon/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional, Type, Union
 from automatheque.conception.structures import Fabrique, Monteur
 from automatheque.configuration import ConfigParser, charge_configuration
 from automatheque.greffon.greffon import Greffon
+from automatheque.greffon.greffon import signale_appel as signale_appel  # noqa: F401
 from automatheque.greffon.registre import MetaInstancePersistanteRegistre
 
 LOGGER = logging.getLogger(__name__)

--- a/src/automatheque/automatheque/greffon/greffon.py
+++ b/src/automatheque/automatheque/greffon/greffon.py
@@ -1,7 +1,9 @@
 # -*- coding=utf-8 -*-
 """Gestion des Greffons et de leur capacités."""
 
+import functools
 import logging
+import time
 import uuid
 from typing import List, Type
 
@@ -13,6 +15,45 @@ from automatheque.greffon.registre import RegistreGreffons
 from automatheque.util.classe import classproperty
 
 LOGGER = logging.getLogger(__name__)
+
+
+def signale_appel(methode):
+    """Décorateur journalisant l'appel d'une méthode de **capacité** d'un Greffon.
+
+    À poser sur les méthodes qui implémentent une :class:`Capacite`. Journalise
+    (niveau ``DEBUG``) le début et la fin de l'appel — avec sa durée — préfixés
+    par l'identité du greffon (``cle||identifiant``). En cas d'exception,
+    journalise l'échec (niveau ``ERROR``, avec la trace) **puis la propage** :
+    le décorateur n'avale aucune erreur.
+
+    .. code-block:: python
+
+       class LecteurGreffon(Greffon):
+           CAPACITES = [LireCapacite]
+
+           @signale_appel
+           def lire(self) -> bool:
+               ...
+    """
+
+    @functools.wraps(methode)
+    def _enveloppe(self, *args, **kwargs):
+        self._signale_appel(methode.__name__)
+        debut = time.monotonic()
+        try:
+            resultat = methode(self, *args, **kwargs)
+        except Exception:
+            LOGGER.exception(
+                "Greffon %s||%s - échec de l'appel « %s »",
+                self.cle,
+                self.identifiant,
+                methode.__name__,
+            )
+            raise
+        self._signale_fin_appel(methode.__name__, time.monotonic() - debut)
+        return resultat
+
+    return _enveloppe
 
 
 @attr.s(eq=False)  # pour rendre la classe hashable pour le set du registre
@@ -84,7 +125,21 @@ class Greffon(RegistreGreffons):
             return True
         return False
 
-    def _signale_appel(self):
-        # TODO(#26) log !!!
-        # TODO(#26) annoter tous les appels de type "capacites"
-        LOGGER.debug(f"Greffon : {self.cle}||{self.identifiant} - debut appel")
+    def _signale_appel(self, nom_appel=None):
+        """Journalise le **début** d'un appel de capacité (cf. `signale_appel`)."""
+        suffixe = f" « {nom_appel} »" if nom_appel else ""
+        LOGGER.debug(
+            "Greffon %s||%s - début appel%s", self.cle, self.identifiant, suffixe
+        )
+
+    def _signale_fin_appel(self, nom_appel=None, duree=None):
+        """Journalise la **fin** d'un appel de capacité (cf. `signale_appel`)."""
+        suffixe = f" « {nom_appel} »" if nom_appel else ""
+        detail = f" ({duree * 1000:.1f} ms)" if duree is not None else ""
+        LOGGER.debug(
+            "Greffon %s||%s - fin appel%s%s",
+            self.cle,
+            self.identifiant,
+            suffixe,
+            detail,
+        )

--- a/src/automatheque/tests/greffon/test_greffon.py
+++ b/src/automatheque/tests/greffon/test_greffon.py
@@ -1,8 +1,9 @@
+import logging
 from typing import Protocol
 
 import pytest
 from automatheque.conception.structures import Monteur
-from automatheque.greffon import Greffon, fabrique_greffon
+from automatheque.greffon import Greffon, fabrique_greffon, signale_appel
 from automatheque.greffon.capacite import Capacite
 
 
@@ -103,3 +104,52 @@ def test_active_renvoie_none_si_instanciation_echoue():
     silencieusement sur une recherche dans le registre."""
     fabrique_greffon.enregistre_monteur("monteur_qui_plante", MonteurQuiPlante())
     assert fabrique_greffon.active("monteur_qui_plante") is None
+
+
+# --- Décorateur signale_appel (#26) -----------------------------------------
+
+
+class GreffonInstrumente(Greffon):
+    """Greffon dont les capacités sont décorées pour être journalisées."""
+
+    CAPACITES = []
+
+    @signale_appel
+    def double(self, x):
+        return x * 2
+
+    @signale_appel
+    def echoue(self):
+        raise RuntimeError("boum")
+
+
+_LOGGER_GREFFON = "automatheque.greffon.greffon"
+
+
+def test_signale_appel_preserve_le_resultat_et_les_metadonnees():
+    g = GreffonInstrumente()
+    assert g.double(21) == 42
+    # functools.wraps préserve le nom de la méthode décorée.
+    assert g.double.__name__ == "double"
+
+
+def test_signale_appel_journalise_debut_et_fin(caplog):
+    g = GreffonInstrumente()
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_GREFFON):
+        g.double(3)
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("début appel" in m and "double" in m for m in messages)
+    assert any("fin appel" in m and "double" in m for m in messages)
+
+
+def test_signale_appel_journalise_erreur_et_la_propage(caplog):
+    g = GreffonInstrumente()
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_GREFFON):
+        with pytest.raises(RuntimeError, match="boum"):
+            g.echoue()
+    # Début journalisé, échec journalisé en ERROR, PAS de "fin appel".
+    assert any("début appel" in r.getMessage() for r in caplog.records)
+    assert any(
+        r.levelno == logging.ERROR and "échec" in r.getMessage() for r in caplog.records
+    )
+    assert not any("fin appel" in r.getMessage() for r in caplog.records)

--- a/src/automatheque/tests/test_configuration.py
+++ b/src/automatheque/tests/test_configuration.py
@@ -144,12 +144,29 @@ def test_dictconfig_depuis_ini_names_seul_suffit():
 
 
 def test_dictconfig_depuis_ini_pourcent_non_echappe_message_clair():
-    """Un `%` non échappé dans [log] lève un ValueError qui invite à doubler."""
+    """Un `%` non échappé dans [log] lève une erreur claire invitant à doubler."""
     config = ConfigParser()
     config.read_string("[log]\nformat = %(asctime)s\n")
 
     with pytest.raises(ValueError, match="%%"):
         _dictconfig_depuis_ini(config)
+
+
+def test_dictconfig_depuis_ini_pourcent_leve_configuration_invalide():
+    """#26 : l'exception est `ConfigurationInvalide` (compatible ValueError)."""
+    from automatheque.exceptions import (
+        AutomathequeBaseException,
+        ConfigurationInvalide,
+    )
+
+    config = ConfigParser()
+    config.read_string("[log]\nformat = %(asctime)s\n")
+
+    with pytest.raises(ConfigurationInvalide) as info:
+        _dictconfig_depuis_ini(config)
+    # Reste attrapable comme ValueError (rétro-compat) et via la hiérarchie maison.
+    assert isinstance(info.value, ValueError)
+    assert isinstance(info.value, AutomathequeBaseException)
 
 
 def test_configure_logging_couvre_un_logger_quelconque():


### PR DESCRIPTION
## Description

Traite les items restants de #26 (gestion d'erreurs, exceptions custom &
journalisation).

> Deux des six items étaient **déjà résolus** par le refactor logging #63 :
> `configuration.py:72` (la section `[log]` n'est plus forcée — retour propre si
> absente) et `log.py:80` (mémoïsation : `charge_configuration` court-circuite
> déjà via son attribut `config`). Il restait 4 items, traités ici.

### `greffon` — journaliser les appels de capacités
- Nouveau décorateur **`signale_appel`** à poser sur les méthodes implémentant
  une `Capacite`. Journalise début/fin (+ durée) en `DEBUG`, préfixés par
  `cle||identifiant`, et l'échec en `ERROR` (avec trace) **avant de propager**
  l'exception (n'avale rien).
- Remplace le `_signale_appel` **mort** (défini, jamais appelé) par ce mécanisme
  utilisable ; exporté depuis `automatheque.greffon`.

### `exceptions` / `configuration` — exception dédiée
- Nouvelle **`ConfigurationInvalide`**, qui hérite d'`AutomathequeBaseException`
  **et** de `ValueError` (les appelants qui attrapaient `ValueError` continuent
  de fonctionner).
- `configuration._dictconfig_depuis_ini` la lève désormais (au lieu d'un
  `ValueError` générique) sur un `%` non échappé dans `[log]`.

### `factrice` — code de retour esmtp
- `ExpeditriceEsmtp.expedie` attrape **spécifiquement** `CalledProcessError`
  (au lieu d'un `except Exception` fourre-tout) et journalise proprement le code
  de retour et `stderr` ; l'appelant récupère toujours le code de retour.

## Tests
- Décorateur : résultat & métadonnées (`__name__`) préservés, début+fin
  journalisés, erreur journalisée (`ERROR`) **et** propagée, pas de « fin » sur
  échec.
- Exception : `ConfigurationInvalide` bien levée, `isinstance` de `ValueError`
  **et** d'`AutomathequeBaseException`.
- esmtp : succès (code 0) et échec (code non nul journalisé, non propagé).

`pytest src` : **112 passés**. `ruff check`/`format`/`mypy` verts.

## Note versioning
Touche **`automatheque` ET `factrice`** → lockstep au prochain `release: coupe`.
CHANGELOG posé sous `[Unreleased]` des deux paquets.

## Issues liées

Closes #26
