### PR TITLE
release: coupe 0.15.0 (automatheque + factrice + schema)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.14.3"
+version = "0.15.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-22
+
 ### Fixed
 
 * `expedition.ExpeditriceEsmtp.expedie` : `process.check_returncode()` peut

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.factrice"
-version = "0.14.2"
+version = "0.15.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-22
+
 ### Fixed
 
 * `courriel` : correction d'un bug d'horodatage figé. `_date_envoi` utilisait

--- a/src/automatheque.schema/pyproject.toml
+++ b/src/automatheque.schema/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.schema"
-version = "0.14.3"
+version = "0.15.0"
 description = "Domaine pour des classes courantes et partagées"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-22
+
 ### Added
 
 * `greffon` : décorateur `signale_appel` pour **journaliser les appels de

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.14.2"
+version = "0.15.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
## Description

Coupe la version **0.15.0**. En lockstep, les **trois paquets** ont évolué
depuis 0.14.3 (changements mergés mais non publiés) et prennent tous la nouvelle
version globale.

| Paquet | Avant | Après | Contenu |
| --- | --- | --- | --- |
| monas (global) | 0.14.3 | **0.15.0** | — |
| `automatheque` | 0.14.2 | **0.15.0** | #25 (robustesse) + #26 (erreurs/journalisation) |
| `automatheque.factrice` | 0.14.2 | **0.15.0** | retour esmtp `check_returncode` (#26) |
| `automatheque.schema` | 0.14.3 | **0.15.0** | `courriel` tz-aware + bug horodatage figé (#25) |

Invariant respecté : `monas.version == max(versions) == 0.15.0`. Le tag `0.15.0`
publiera **les trois** paquets (tous == tag).

## Faits saillants 0.15.0

- **Correctif** `courriel` : horodatage figé/partagé (`default=datetime.now()`
  → `factory`) + dates tz-aware (UTC, offset RFC 5322).
- **Robustesse** : `enleve_caracteres_invalides` par plateforme,
  `StockageRepertoire` thread-safe, sonde d'exécutabilité opt-in.
- **Journalisation** : décorateur `greffon.signale_appel`,
  `exceptions.ConfigurationInvalide`, gestion propre du code de retour esmtp.

## Contenu

- Bump des 4 `version` (monas + 3 paquets).
- Bascule `[Unreleased]` → `[0.15.0] - 2026-07-22` dans les 3 CHANGELOG.
