### PR TITLE
refactor(modernisation): attrs, pathlib, argv explicite, validators (#24)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* `expedition` : `ExpeditriceSmtp` et `ExpeditriceEsmtp` **valident** leur
+  paramètre `config` (validator attrs : `optional(instance_of(ConfigParser))`).
+  Un `config` du mauvais type est rejeté dès la construction (`TypeError`) au
+  lieu d'échouer plus loin ; `config=None` reste accepté. — cf. #24
+
 ## [0.15.0] - 2026-07-22
 
 ### Fixed

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -56,7 +56,10 @@ class ExpeditriceSmtp(Expeditrice):
     ```
     """
 
-    config: ConfigParser = attr.ib(default=None)  # TODO(#24) validator
+    config: ConfigParser = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(ConfigParser)),
+    )
     s: smtplib.SMTP = attr.ib(init=False)
     preparatrice = attr.ib(init=False, default=PreparatriceSmtp)
 
@@ -143,7 +146,10 @@ class ExpeditriceSmtp(Expeditrice):
 
 @attr.s
 class ExpeditriceEsmtp:
-    config: ConfigParser = attr.ib(default=None)  # TODO(#24) validator
+    config: ConfigParser = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(ConfigParser)),
+    )
 
     def __attrs_post_init__(self):
         self.config = self.config if self.config else charge_configuration()

--- a/src/automatheque.factrice/tests/test_expedition.py
+++ b/src/automatheque.factrice/tests/test_expedition.py
@@ -79,3 +79,23 @@ def test_esmtp_echec_journalise_et_renvoie_le_code(monkeypatch, caplog):
         code = exp.expedie(_courriel())
     assert code == 42
     assert any("esmtp" in r.getMessage() for r in caplog.records)
+
+
+# --- #24 : validator attrs sur `config` -------------------------------------
+
+
+def test_config_non_configparser_leve(monkeypatch):
+    """#24 : un `config` qui n'est pas un ConfigParser est rejeté à la construction."""
+    with pytest.raises(TypeError):
+        ExpeditriceSmtp(config="pas-un-configparser")
+
+
+def test_config_none_reste_accepte(monkeypatch):
+    """`config=None` reste valide (le validator est `optional`)."""
+    fake = MagicMock()
+    monkeypatch.setattr(expedition.smtplib, "SMTP_SSL", lambda *a, **k: fake)
+    # config non fourni → charge_configuration() ; on le neutralise.
+    monkeypatch.setattr(
+        expedition, "charge_configuration", lambda *a, **k: _config_smtp()
+    )
+    ExpeditriceSmtp()  # ne doit pas lever au titre du validator

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * `script` : `script_automatheque` / `ScriptAutomatheque` acceptent désormais
-  **`argv`** et **`nom`** explicites → l'API phare est utilisable **hors** d'un
-  `__main__` (module, test, REPL) sans dépendre de `sys.argv`. En conséquence,
-  `essai.execute_script` n'a plus besoin de bricoler `sys.argv`. — cf. #24
+  **`argv`** et **`nom`** explicites (défaut = `sys.argv`) → un script se pilote
+  sans dépendre de `sys.argv`, ce qui sert surtout à le **tester** : le harness
+  `essai.execute_script` n'a plus à bricoler `sys.argv`. — cf. #24
 
 ### Changed
 

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `script` : `script_automatheque` / `ScriptAutomatheque` acceptent désormais
+  **`argv`** et **`nom`** explicites → l'API phare est utilisable **hors** d'un
+  `__main__` (module, test, REPL) sans dépendre de `sys.argv`. En conséquence,
+  `essai.execute_script` n'a plus besoin de bricoler `sys.argv`. — cf. #24
+
+### Changed
+
+* `script.ScriptAutomatheque` est convertie en **classe attrs** (`eq=False` :
+  sémantique d'identité préservée, objet hachable) ; le `repr` masque la chaîne
+  docopt (verbeuse) et le logger. — cf. #24
+
+### Deprecated
+
+* `util.repertoire.mkdir_p` est **déprécié** (émet un `DeprecationWarning`) au
+  profit de `Path(path).mkdir(parents=True, exist_ok=True)`. Le comportement est
+  conservé jusqu'à son retrait ultérieur. — cf. #24
+
 ## [0.15.0] - 2026-07-22
 
 ### Added

--- a/src/automatheque/automatheque/essai.py
+++ b/src/automatheque/automatheque/essai.py
@@ -29,7 +29,6 @@ Exemple ::
     assert script.arguments["--action"] is True
 """
 
-import sys
 from collections import namedtuple
 from pathlib import Path
 
@@ -91,15 +90,11 @@ def execute_script(doc, fonction, argv=None, version=None, reinitialise=True):
         capture["script"] = _script
         return fonction(*args, _script=_script, **kwds)
 
-    # `script_automatheque` lit sys.argv et charge la config dès la décoration,
-    # d'où le pilotage de sys.argv autour de cette ligne.
-    faux_argv = ["script-de-test", *(argv or [])]
-    ancien_argv = sys.argv
-    sys.argv = faux_argv
-    try:
-        decoree = script_automatheque(doc, version)(fonction_capturante)
-        resultat = decoree()
-    finally:
-        sys.argv = ancien_argv
+    # `script_automatheque` accepte désormais `argv`/`nom` explicites (#24) :
+    # plus besoin de bricoler `sys.argv` pour piloter le script depuis un test.
+    decoree = script_automatheque(
+        doc, version, argv=list(argv or []), nom="script-de-test"
+    )(fonction_capturante)
+    resultat = decoree()
 
     return ResultatScript(resultat=resultat, script=capture.get("script"))

--- a/src/automatheque/automatheque/script.py
+++ b/src/automatheque/automatheque/script.py
@@ -1,8 +1,9 @@
 # -*- coding:utf-8 -*-
 """API phare d'automatheque : faciliter la création de scripts.
 
-Il faut pouvoir l'utiliser aussi dans les modules, pas juste dans les scripts.
-TODO(#24)
+Utilisable aussi **hors** d'un ``__main__`` (module, test, REPL) : passer
+``argv`` (et éventuellement ``nom``) à ``script_automatheque`` au lieu de
+dépendre de ``sys.argv``. Cf. #24.
 
 Le format que l'on souhaite est le suivant :
 ```
@@ -84,6 +85,7 @@ import re
 import sys
 from functools import wraps
 
+import attr
 import docopt
 
 # Ré-exportés pour offrir une seule surface d'import aux scripts
@@ -112,14 +114,23 @@ OPTIONS_INTERNES = frozenset(
 commande = commandopt
 
 
-def script_automatheque(chaine_docopt, version=None):
+def script_automatheque(chaine_docopt, version=None, argv=None, nom=None):
     """Decorateur pour ScriptAutomatheque.
 
     - signale le début et la fin du traitement
     - passe un objet ScriptAutomatheque à la fonction appelante
+
+    :param argv: arguments de ligne de commande (**sans** le nom du programme).
+        Défaut ``None`` = ``sys.argv``. Le fournir permet d'utiliser le
+        décorateur hors d'un ``__main__`` (module, test, REPL). Cf. #24.
+    :param nom: nom du programme (utilisé pour ``nom_court`` et les logs). Défaut
+        ``None`` = ``sys.argv[0]``. Cf. #24.
     """
     s = ScriptAutomatheque(
-        nom=sys.argv[0], chaine_docopt=chaine_docopt, version=version
+        nom=nom if nom is not None else sys.argv[0],
+        chaine_docopt=chaine_docopt,
+        version=version,
+        argv=argv,
     )
     s.initialise()
 
@@ -153,7 +164,8 @@ def script_automatheque(chaine_docopt, version=None):
     return decorateur
 
 
-class ScriptAutomatheque(object):
+@attr.s(eq=False)
+class ScriptAutomatheque:
     """Objet ScriptAutomatheque qui automatise la creation de scripts.
 
     Cet objet contient :
@@ -163,27 +175,32 @@ class ScriptAutomatheque(object):
     - self.parametres : merge de arguments avec config
     - self.logger : logger pour les appels internes de ScriptAutomatheque
 
+    ``eq=False`` : l'objet garde une sémantique d'**identité** (comparaison et
+    hachage par référence), comme avant le passage à attrs — deux scripts ne
+    sont jamais « égaux » par valeur, et l'objet reste hachable. Cf. #24.
     """
 
-    def __init__(self, nom, chaine_docopt, version=None):
-        self.nom = nom
-        self.nom_court = re.sub(r"\.py$", "", os.path.basename(nom))
-        self.chaine_docopt = chaine_docopt
-        self.version = version
-        self.arguments = None
-        self.config = None
-        #: Vrai si le script a été appelé avec ``--dry-run`` (câblé
-        #: automatiquement si l'option figure dans l'usage docopt). Au script
-        #: d'en tenir compte pour ne rien modifier de définitif.
-        self.dry_run = False
-        self._debut = None
-        self._logger = None
+    nom = attr.ib()
+    chaine_docopt = attr.ib(repr=False)  # trop longue pour le repr
+    version = attr.ib(default=None)
+    #: ``argv`` explicite (liste d'arguments **sans** le nom du programme) pour
+    #: piloter le script hors ``__main__`` : depuis un module, un test ou un
+    #: REPL. Défaut ``None`` = docopt lit ``sys.argv``. Cf. #24.
+    argv = attr.ib(default=None)
+    nom_court = attr.ib(init=False)
+    arguments = attr.ib(init=False, default=None)
+    config = attr.ib(init=False, default=None)
+    #: Vrai si le script a été appelé avec ``--dry-run`` (câblé automatiquement
+    #: si l'option figure dans l'usage docopt). Au script d'en tenir compte pour
+    #: ne rien modifier de définitif.
+    dry_run = attr.ib(init=False, default=False)
+    _debut = attr.ib(init=False, default=None, repr=False)
+    _logger = attr.ib(init=False, default=None, repr=False)
 
-    def __repr__(self):
-        """TODO(#24) utiliser attrs."""
-        return "<ScriptAutomatheque {} {} {}>".format(
-            self.nom, self.arguments, self.config
-        )
+    @nom_court.default
+    def _defaut_nom_court(self):
+        """Dérive le nom court du script depuis ``nom`` (sans ``.py``)."""
+        return re.sub(r"\.py$", "", os.path.basename(self.nom))
 
     @property
     def logger(self):
@@ -216,7 +233,11 @@ class ScriptAutomatheque(object):
         # Un script EST une application : c'est le bon endroit pour activer le
         # logging console par défaut (la lib, elle, ne configure rien à l'import).
         configure_logging_defaut()
-        self.arguments = docopt.docopt(self.chaine_docopt, version=self.version)
+        # ``argv`` explicite (usage module/test) ou ``sys.argv`` par défaut
+        # (``argv=None`` → docopt lit ``sys.argv[1:]``). Cf. #24.
+        self.arguments = docopt.docopt(
+            self.chaine_docopt, argv=self.argv, version=self.version
+        )
         # Configuration en couches, de la plus générale à la plus spécifique
         # (chaque couche surcharge la précédente) :
         #   1. config.ini partagé d'automatheque  (chargé par ecraser=True)

--- a/src/automatheque/automatheque/script.py
+++ b/src/automatheque/automatheque/script.py
@@ -1,9 +1,9 @@
 # -*- coding:utf-8 -*-
 """API phare d'automatheque : faciliter la création de scripts.
 
-Utilisable aussi **hors** d'un ``__main__`` (module, test, REPL) : passer
-``argv`` (et éventuellement ``nom``) à ``script_automatheque`` au lieu de
-dépendre de ``sys.argv``. Cf. #24.
+``script_automatheque`` accepte un ``argv`` (et un ``nom``) explicites pour ne
+pas dépendre de ``sys.argv`` — utile **surtout pour tester** un script sans
+bricoler cette variable globale (cf. :mod:`automatheque.essai`). Cf. #24.
 
 Le format que l'on souhaite est le suivant :
 ```
@@ -121,8 +121,9 @@ def script_automatheque(chaine_docopt, version=None, argv=None, nom=None):
     - passe un objet ScriptAutomatheque à la fonction appelante
 
     :param argv: arguments de ligne de commande (**sans** le nom du programme).
-        Défaut ``None`` = ``sys.argv``. Le fournir permet d'utiliser le
-        décorateur hors d'un ``__main__`` (module, test, REPL). Cf. #24.
+        Défaut ``None`` = ``sys.argv``. Le fournir sert surtout à **tester** un
+        script sans bricoler ``sys.argv`` (cf. :mod:`automatheque.essai`).
+        Cf. #24.
     :param nom: nom du programme (utilisé pour ``nom_court`` et les logs). Défaut
         ``None`` = ``sys.argv[0]``. Cf. #24.
     """
@@ -184,8 +185,9 @@ class ScriptAutomatheque:
     chaine_docopt = attr.ib(repr=False)  # trop longue pour le repr
     version = attr.ib(default=None)
     #: ``argv`` explicite (liste d'arguments **sans** le nom du programme) pour
-    #: piloter le script hors ``__main__`` : depuis un module, un test ou un
-    #: REPL. Défaut ``None`` = docopt lit ``sys.argv``. Cf. #24.
+    #: piloter le script sans dépendre de ``sys.argv`` — surtout pour le test
+    #: (cf. :mod:`automatheque.essai`). Défaut ``None`` = docopt lit
+    #: ``sys.argv``. Cf. #24.
     argv = attr.ib(default=None)
     nom_court = attr.ib(init=False)
     arguments = attr.ib(init=False, default=None)

--- a/src/automatheque/automatheque/util/repertoire.py
+++ b/src/automatheque/automatheque/util/repertoire.py
@@ -8,6 +8,7 @@ Divers utilitaires.
 import errno
 import logging
 import os
+import warnings
 from pathlib import Path
 
 LOGGER = logging.getLogger(__name__)
@@ -18,15 +19,24 @@ def mkdir_p(path):
 
     Renvoie une erreur si la cible existe et n'est pas un répertoire.
 
-    TODO(#24) déprécier pour Path.mkdir()
+    .. deprecated::
+        Utiliser directement :meth:`pathlib.Path.mkdir` ::
+
+            Path(path).mkdir(parents=True, exist_ok=True)
+
+        Ce raccourci maison n'apporte plus rien face à ``pathlib`` (Python 3) et
+        sera retiré dans une version ultérieure. Cf. #24.
     """
-    try:
-        os.makedirs(path)
-    except OSError as exc:  # Python >2.5
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
+    warnings.warn(
+        "mkdir_p est déprécié : utilisez "
+        "Path(path).mkdir(parents=True, exist_ok=True).",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    # Comportement conservé : crée l'arborescence, ne lève pas si le répertoire
+    # existe déjà, mais lève si la cible est un fichier existant
+    # (``FileExistsError``, sous-classe d'``OSError``).
+    Path(path).mkdir(parents=True, exist_ok=True)
 
 
 def supprime(repertoire, force=False):

--- a/src/automatheque/tests/test_script.py
+++ b/src/automatheque/tests/test_script.py
@@ -8,12 +8,19 @@ rétrocompatibilité qui ré-exporte les mêmes objets et émet un
 
 import importlib
 import logging
+import sys
 import warnings
 
+import attr
 import commandopt
 import pytest
-from automatheque.essai import execute_script
-from automatheque.script import OPTIONS_INTERNES, commande
+from automatheque.essai import execute_script, reinitialise_configuration
+from automatheque.script import (
+    OPTIONS_INTERNES,
+    ScriptAutomatheque,
+    commande,
+    script_automatheque,
+)
 from commandopt import NoCommandFoundError, Registry
 
 #: Usage docopt déclarant les commodités câblées par #5.
@@ -75,6 +82,60 @@ def test_shim_reexporte_les_memes_objets():
     assert ancien.script_automatheque is nouveau.script_automatheque
     assert ancien.ScriptAutomatheque is nouveau.ScriptAutomatheque
     assert ancien.script is nouveau.script
+
+
+# --- #24 : ScriptAutomatheque en attrs + pilotage hors sys.argv ----------------
+
+
+def test_script_est_une_classe_attrs():
+    """#24 : ScriptAutomatheque est désormais une classe attrs."""
+    assert attr.has(ScriptAutomatheque)
+
+
+def test_nom_court_derive_du_nom():
+    """`nom_court` est dérivé de `nom` (basename sans `.py`)."""
+    s = ScriptAutomatheque(nom="/chemin/mon_script.py", chaine_docopt="doc")
+    assert s.nom_court == "mon_script"
+
+
+def test_repr_ne_deverse_pas_la_chaine_docopt():
+    """Le repr attrs masque la chaîne docopt (verbeuse) et le logger."""
+    s = ScriptAutomatheque(nom="x.py", chaine_docopt="USAGE ENORME " * 50)
+    rendu = repr(s)
+    assert "chaine_docopt" not in rendu
+    assert "ENORME" not in rendu
+    assert "x.py" in rendu  # les champs utiles restent visibles
+
+
+def test_script_reste_hachable_et_par_identite():
+    """`eq=False` : identité préservée (hachable, pas d'égalité par valeur)."""
+    a = ScriptAutomatheque(nom="x.py", chaine_docopt="doc")
+    b = ScriptAutomatheque(nom="x.py", chaine_docopt="doc")
+    assert a != b  # deux instances distinctes ne sont pas égales
+    assert len({a, b}) == 2  # hachables
+
+
+def test_pilotable_par_argv_explicite_sans_sys_argv(monkeypatch):
+    """#24 : argv/nom explicites permettent d'exécuter hors d'un __main__.
+
+    On casse `sys.argv` pour prouver qu'il n'est plus consulté.
+    """
+    monkeypatch.setattr(sys, "argv", ["NE-DOIT-PAS-ETRE-LU", "--introuvable"])
+    reinitialise_configuration()
+
+    capture = {}
+
+    def main(_script=None):
+        capture["script"] = _script
+        return _script.arguments["--dry-run"]
+
+    decoree = script_automatheque(DOC_OPTIONS, argv=["--dry-run"], nom="mon_module")(
+        main
+    )
+    resultat = decoree()
+
+    assert resultat is True
+    assert capture["script"].nom_court == "mon_module"
 
 
 # --- #5 : enrichissement de @script_automatheque -------------------------------

--- a/src/automatheque/tests/util/test_repertoire.py
+++ b/src/automatheque/tests/util/test_repertoire.py
@@ -12,10 +12,17 @@ from automatheque.util.repertoire import (
 )
 
 
+def test_mkdir_p_est_deprecie(tmp_path):
+    """#24 : mkdir_p émet un DeprecationWarning renvoyant vers Path.mkdir."""
+    with pytest.warns(DeprecationWarning, match="Path"):
+        mkdir_p(str(tmp_path / "x"))
+
+
 def test_mkdir_p_cree_arborescence(tmp_path):
     """mkdir_p crée toute l'arborescence manquante."""
     cible = tmp_path / "a" / "b" / "c"
-    mkdir_p(str(cible))
+    with pytest.warns(DeprecationWarning):
+        mkdir_p(str(cible))
     assert cible.is_dir()
 
 
@@ -23,7 +30,8 @@ def test_mkdir_p_idempotent_sur_repertoire_existant(tmp_path):
     """Recréer un répertoire existant ne lève pas d'erreur."""
     cible = tmp_path / "deja"
     cible.mkdir()
-    mkdir_p(str(cible))  # ne doit pas lever
+    with pytest.warns(DeprecationWarning):
+        mkdir_p(str(cible))  # ne doit pas lever
     assert cible.is_dir()
 
 


### PR DESCRIPTION
## Description

Modernisation issue du tri des TODO — les 5 items de #24.

### `automatheque` — `script` (API phare)
- **`ScriptAutomatheque` → classe attrs** (`eq=False` : sémantique d'**identité**
  préservée, objet hachable, comme avant). Le `repr` généré masque la chaîne
  docopt (verbeuse) et le logger.
- **`argv` / `nom` explicites** sur `script_automatheque` / `ScriptAutomatheque`
  (défaut = `sys.argv`) pour piloter un script sans dépendre de `sys.argv`. Le
  cas d'usage concret est le **test** : le harness `essai.execute_script` cessait
  de bricoler `sys.argv` (son propre commentaire le déplorait) et passe
  désormais `argv=`/`nom=`. (Discussion : pas de vrai cas « appeler un script
  décoré depuis un module » — le décorateur *est* le point d'entrée ; la doc a
  été recadrée sur la motivation test.)

### `automatheque` — `util.repertoire`
- **`mkdir_p` déprécié** (`DeprecationWarning`) au profit de
  `Path(path).mkdir(parents=True, exist_ok=True)`. Comportement conservé
  (idempotent, lève toujours si la cible est un fichier existant) jusqu'au
  retrait ultérieur.

### `factrice` — `expedition`
- **`ExpeditriceSmtp` / `ExpeditriceEsmtp` valident `config`** via un validator
  attrs `optional(instance_of(ConfigParser))` : un `config` du mauvais type est
  rejeté **dès la construction** (`TypeError`) ; `config=None` reste accepté.

## Tests
- `script` : classe attrs (`attr.has`), `nom_court` dérivé de `nom`, `repr` sans
  la chaîne docopt, identité/hachage (`eq=False`), pilotage par `argv` explicite
  (`sys.argv` cassé volontairement).
- `repertoire` : `mkdir_p` émet la dépréciation (comportement inchangé).
- `expedition` : `config` mauvais type → `TypeError`, `config=None` accepté.

`pytest src` : **135 passés**. `ruff check`/`format`/`mypy` verts.

## Note versioning
Touche **`automatheque` ET `factrice`** → lockstep au prochain `release: coupe`.
CHANGELOG posé sous `[Unreleased]` des deux paquets.

## Issues liées

Closes #24
