### PR TITLE
feat(factrice): entrée standard, émetteur configurable, fichier temp sûr (#27)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,8 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `app` : le corps du mail peut venir de l'**entrée standard**
+  (`cat contenu | factrice sujet adresse`). `<texte_du_mail>` devient optionnel
+  dans l'usage ; s'il est omis, le corps est lu sur `stdin`. — cf. #27
+* `expedition` (esmtp) : l'**émetteur par défaut** est configurable via
+  `[factrice.esmtp] emetteur` (repli historique `osuser@localhost`). — cf. #27
+
 ### Changed
 
+* `app` : le câblage `@script_automatheque` est **différé dans `main()`** (au
+  lieu de s'exécuter à l'import). Importer `automatheque.factrice.app` ne
+  déclenche donc plus le parsing d'`argv` ni la (re)configuration du logging :
+  le module redevient importable et testable. — cf. #27
+* `expedition` (esmtp) : le fichier temporaire remis à esmtp est créé via
+  `tempfile.mkstemp` (nom **unique**, répertoire temporaire système) avec un
+  sujet **assaini** (`enleve_caracteres_invalides`). Fini le `/tmp` codé en dur
+  et le plantage sur un sujet contenant un `/`. — cf. #27
 * `expedition` : `ExpeditriceSmtp` et `ExpeditriceEsmtp` **valident** leur
   paramètre `config` (validator attrs : `optional(instance_of(ConfigParser))`).
   Un `config` du mauvais type est rejeté dès la construction (`TypeError`) au

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   paramètre `config` (validator attrs : `optional(instance_of(ConfigParser))`).
   Un `config` du mauvais type est rejeté dès la construction (`TypeError`) au
   lieu d'échouer plus loin ; `config=None` reste accepté. — cf. #24
+* Dépendance : plancher `automatheque.schema` relevé de `>=0.9.6` à `>=0.9.7`.
+  factrice construit un `Courriel` sans émetteur (rempli ensuite par
+  l'expéditrice) ; l'émetteur n'est facultatif que depuis schema 0.9.7. Le
+  plancher annoncé était donc faux (bug latent révélé par les nouveaux tests
+  d'`app`). — cf. #27
 
 ## [0.15.0] - 2026-07-22
 

--- a/src/automatheque.factrice/automatheque/factrice/app/__init__.py
+++ b/src/automatheque.factrice/automatheque/factrice/app/__init__.py
@@ -5,22 +5,38 @@
 Application pour envoyer des mails simplement en utilisant la connexion
 configurée dans config.ini.
 
-TODO(#27) pouvoir faire `cat contenu | factrice sujet email`
+Le texte du mail peut être passé en argument **ou** via l'entrée standard, ce
+qui permet un usage en tuyau : ``cat contenu | factrice sujet adresse``. Cf. #27.
 
 Usage:
-  factrice [--via-esmtp] <sujet> <adresse_mail_cible> <texte_du_mail>
+  factrice [--via-esmtp] <sujet> <adresse_mail_cible> [<texte_du_mail>]
 
 Options:
   -h --help
   <adresse_mail_cible>  Adresse mail ou liste d'adresses séparées par des , sans espace
+  <texte_du_mail>       Corps du mail ; si omis, lu sur l'entrée standard.
   --via-esmtp
 """
+
+import sys
 
 from automatheque.factrice.expedition import ExpeditriceEsmtp, ExpeditriceSmtp
 from automatheque.schema.texte.courriel import Courriel
 from automatheque.script import ScriptAutomatheque, script_automatheque
 
 __version__ = "0.0.1"
+
+
+def recupere_texte(arguments):
+    """Renvoie le texte du mail : l'argument s'il est fourni, sinon ``stdin``.
+
+    Permet ``cat contenu | factrice sujet adresse`` (le corps arrive alors sur
+    l'entrée standard). Cf. #27.
+    """
+    texte = arguments["<texte_du_mail>"]
+    if texte is None:
+        texte = sys.stdin.read()
+    return texte
 
 
 def envoi_mail_simple(sujet, adresse, txt, via_esmtp=False):
@@ -42,16 +58,27 @@ def envoi_mail_simple(sujet, adresse, txt, via_esmtp=False):
     return return_code
 
 
-@script_automatheque(__doc__, __version__)
-def main(_script: ScriptAutomatheque = None):
+def traite(_script: ScriptAutomatheque = None):
+    """Corps du script : config déjà chargée et arguments parsés par le décorateur."""
     _script.logger.debug(_script.arguments)
 
     envoi_mail_simple(
         _script.arguments["<sujet>"],
         _script.arguments["<adresse_mail_cible>"],
-        _script.arguments["<texte_du_mail>"],
+        recupere_texte(_script.arguments),
         _script.arguments["--via-esmtp"],
     )
+
+
+def main():
+    """Point d'entrée console de ``factrice`` (cf. ``[project.scripts]``).
+
+    Le câblage ``@script_automatheque`` est fait **ici**, à l'appel, et non à
+    l'import du module : importer ``automatheque.factrice.app`` ne déclenche donc
+    plus le parsing d'``argv`` ni la (re)configuration du logging — le module
+    redevient importable (et testable). Cf. #27.
+    """
+    return script_automatheque(__doc__, __version__)(traite)()
 
 
 if __name__ == "__main__":

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 import abc
 import logging
+import os
 import smtplib
 import subprocess
+import tempfile
 from configparser import ConfigParser
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -14,6 +15,7 @@ from automatheque.configuration import NoOptionError, charge_configuration
 from automatheque.factrice.preparation import SEPARATEUR_DESTINATAIRES, PreparatriceSmtp
 from automatheque.schema.texte import Courriel
 from automatheque.util.dependances_externes import Executant, charge_dependance
+from automatheque.util.fichier import enleve_caracteres_invalides
 
 LOGGER = logging.getLogger(__name__)
 
@@ -158,21 +160,35 @@ class ExpeditriceEsmtp:
     def __gen_fichier(
         self, courriel: Courriel, fichier_sortie: Optional[Path] = None
     ) -> Path:
-        """Génère un fichier temporaire à donner à esmtp.
+        """Génère un fichier à donner à esmtp (contenu du courriel préparé).
+
+        L'émetteur par défaut est configurable via ``[factrice.esmtp] emetteur``
+        (repli historique ``osuser@localhost``). Cf. #27.
+
+        Sans ``fichier_sortie`` explicite, un fichier temporaire **unique** est
+        créé via :func:`tempfile.mkstemp` dans le répertoire temporaire système
+        (fini le ``/tmp`` codé en dur et les collisions de noms) ; le sujet,
+        assaini, ne sert que de préfixe lisible. Cf. #27.
 
         :return: Path du fichier
         """
         if courriel.emetteur is None:
-            courriel.emetteur = "osuser@localhost"  # TODO(#27) émetteur configurable
+            courriel.emetteur = self.config.get(
+                "factrice.esmtp", "emetteur", fallback="osuser@localhost"
+            )
 
-        date = datetime.now().strftime("%Y%m%d-%H%M%s")
-        # TODO(#27) nom fic
-        fic = fichier_sortie or Path("/tmp/") / f"{date}_{courriel.sujet}.txt"
-        with open(fic, "w") as f:
-            contenu = PreparatriceSmtp().prepare(courriel).as_string()
+        contenu = PreparatriceSmtp().prepare(courriel).as_string()
+
+        if fichier_sortie is not None:
+            fic = Path(fichier_sortie)
+            fic.write_text(contenu)
+            return fic
+
+        sujet_sain = enleve_caracteres_invalides(courriel.sujet or "courriel")
+        fd, chemin = tempfile.mkstemp(prefix=f"factrice_{sujet_sain}_", suffix=".txt")
+        with os.fdopen(fd, "w") as f:
             f.write(contenu)
-
-        return fic
+        return Path(chemin)
 
     def expedie(self, courriel: Courriel):
         # envoi du mail si esmtp est paramétré

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -19,11 +19,12 @@ dependencies = [
     # >=0.14.0 : `ExpeditriceSmtp` utilise `Executant.exec(encoding=...)`,
     # ajouté dans automatheque 0.14.0 (#66).
     "automatheque>=0.14.0",
-    # 0.9.6 est la plus ancienne version publiée d'automatheque.schema ; le
-    # plancher précédent (>=0.9.5) référençait une version jamais publiée. Le
-    # job CI « tests-plancher » valide que factrice fonctionne contre ces
-    # planchers.
-    "automatheque.schema>=0.9.6",
+    # >=0.9.7 : factrice construit un `Courriel` SANS émetteur (celui-ci est
+    # rempli ensuite par l'expéditrice, depuis la configuration). Or l'émetteur
+    # n'est devenu **facultatif** dans le constructeur de `Courriel` qu'en
+    # schema 0.9.7 ; avec 0.9.6 la construction lève `TypeError`. Le job CI
+    # « tests-plancher » éprouve réellement ce plancher.
+    "automatheque.schema>=0.9.7",
 ]
 
 [project.urls]

--- a/src/automatheque.factrice/tests/test_app.py
+++ b/src/automatheque.factrice/tests/test_app.py
@@ -1,0 +1,56 @@
+"""Tests de l'application ``factrice`` (app/__init__.py, #27).
+
+Le module redevient importable sans effet de bord (le câblage
+``@script_automatheque`` est différé dans ``main``), ce qui rend ces tests
+possibles.
+"""
+
+import io
+
+from automatheque.factrice import app
+from automatheque.factrice.app import envoi_mail_simple, recupere_texte
+
+
+def test_recupere_texte_argument_prioritaire():
+    """Le texte fourni en argument est utilisé tel quel."""
+    assert recupere_texte({"<texte_du_mail>": "coucou"}) == "coucou"
+
+
+def test_recupere_texte_depuis_stdin(monkeypatch):
+    """#27 : sans argument, le corps est lu sur l'entrée standard (`cat | factrice`)."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("depuis le tuyau"))
+    assert recupere_texte({"<texte_du_mail>": None}) == "depuis le tuyau"
+
+
+def test_envoi_mail_simple_smtp_construit_le_courriel(monkeypatch):
+    """Sans `--via-esmtp` : route vers SMTP et construit un Courriel cohérent."""
+    envoye = {}
+
+    class FakeSmtp:
+        def __init__(self, *a, **k):
+            pass
+
+        def expedie(self, mail):
+            envoye["mail"] = mail
+
+    monkeypatch.setattr(app, "ExpeditriceSmtp", FakeSmtp)
+    app.envoi_mail_simple("sujet", "a@b.c,d@e.f", "corps", via_esmtp=False)
+
+    mail = envoye["mail"]
+    assert mail.sujet == "sujet"
+    assert mail.destinataires == ["a@b.c", "d@e.f"]
+    assert mail.contenu == "corps"
+
+
+def test_envoi_mail_simple_esmtp_renvoie_le_code(monkeypatch):
+    """Avec `--via-esmtp` : route vers esmtp et renvoie son code de retour."""
+
+    class FakeEsmtp:
+        def __init__(self, *a, **k):
+            pass
+
+        def expedie(self, mail):
+            return 7
+
+    monkeypatch.setattr(app, "ExpeditriceEsmtp", FakeEsmtp)
+    assert envoi_mail_simple("s", "a@b.c", "corps", via_esmtp=True) == 7

--- a/src/automatheque.factrice/tests/test_expedition.py
+++ b/src/automatheque.factrice/tests/test_expedition.py
@@ -99,3 +99,52 @@ def test_config_none_reste_accepte(monkeypatch):
         expedition, "charge_configuration", lambda *a, **k: _config_smtp()
     )
     ExpeditriceSmtp()  # ne doit pas lever au titre du validator
+
+
+# --- #27 : émetteur par défaut configurable + nom de fichier temporaire sûr --
+
+
+def _esmtp_avec_config(monkeypatch, config):
+    """ExpeditriceEsmtp dont l'exécutant réussit, avec la ``config`` donnée."""
+    process = MagicMock(returncode=0, stderr=b"")
+    process.check_returncode.return_value = None
+    executant = MagicMock()
+    executant.exec.return_value = process
+    monkeypatch.setattr(expedition, "charge_dependance", lambda *a, **k: executant)
+    return ExpeditriceEsmtp(config=config)
+
+
+def test_esmtp_emetteur_par_defaut_configurable(monkeypatch):
+    """L'émetteur par défaut vient de `[factrice.esmtp] emetteur`."""
+    conf = ConfigParser()
+    conf.add_section("factrice.esmtp")
+    conf.set("factrice.esmtp", "emetteur", "boite@ex.fr")
+    exp = _esmtp_avec_config(monkeypatch, conf)
+
+    courriel = Courriel(sujet="sujet", destinataires=["dest@ex.fr"])  # emetteur None
+    exp.expedie(courriel)
+    assert courriel.emetteur == "boite@ex.fr"
+
+
+def test_esmtp_emetteur_par_defaut_repli_historique(monkeypatch):
+    """Sans configuration, l'émetteur retombe sur `osuser@localhost`."""
+    exp = _esmtp_avec_config(monkeypatch, ConfigParser())
+
+    courriel = Courriel(sujet="sujet", destinataires=["dest@ex.fr"])
+    exp.expedie(courriel)
+    assert courriel.emetteur == "osuser@localhost"
+
+
+def test_esmtp_sujet_avec_separateur_ne_casse_pas_le_chemin(monkeypatch):
+    """Un sujet contenant un `/` ne crée plus de sous-répertoire inexistant.
+
+    L'ancien nommage `/tmp/<date>_<sujet>.txt` plantait (`FileNotFoundError`)
+    pour un sujet du type `rapport/2026`. Le fichier temporaire assaini règle
+    le problème.
+    """
+    exp = _esmtp_avec_config(monkeypatch, ConfigParser())
+
+    courriel = Courriel(
+        emetteur="exp@ex.fr", sujet="rapport/2026", destinataires=["dest@ex.fr"]
+    )
+    assert exp.expedie(courriel) == 0

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `script.ScriptAutomatheque` est convertie en **classe attrs** (`eq=False` :
   sémantique d'identité préservée, objet hachable) ; le `repr` masque la chaîne
   docopt (verbeuse) et le logger. — cf. #24
+* `configuration.charge_configuration` : documentation du choix de charger le
+  **premier** emplacement trouvé pour un fichier supplémentaire (mécanisme de
+  *résolution*, pas de fusion). Pour superposer plusieurs configurations,
+  passer plusieurs entrées dans `fichiers_supplementaires`. — cf. #27
 
 ### Deprecated
 

--- a/src/automatheque/automatheque/configuration.py
+++ b/src/automatheque/automatheque/configuration.py
@@ -48,7 +48,14 @@ def charge_configuration(fichiers_supplementaires=None, ecraser=False, recharger
                 continue
 
             _charge_fichier_configuration(fichier, charge_configuration.config)
-            break  # TODO(#27) sauf si on veut charger les 2 fichiers ?
+            # On s'arrête au PREMIER emplacement trouvé : `paths_a_tester` est un
+            # mécanisme de *résolution* (« où se trouve `f` ? »), pas de fusion.
+            # Les deux chemins désignent le même nom de fichier à deux endroits ;
+            # les charger tous les deux fusionnerait deux fichiers homonymes sans
+            # lien voulu. Pour superposer plusieurs configurations, passer
+            # plusieurs entrées dans `fichiers_supplementaires` (traitées dans
+            # l'ordre, chacune surchargeant la précédente). Cf. #27.
+            break
     # Si on veut conserver la configuration de automatheque, alors on charge
     # sa configuration en dernier :
     if not ecraser:


### PR DESCRIPTION
## Description

Sous-ensemble **cohérent et bien spécifié** de #27 (fonctionnalités factrice
+ une décision côté `automatheque`). Ne ferme pas #27 : 3 items restants sont
bloqués ou hors périmètre (voir plus bas).

### `factrice.app` — entrée standard (`cat contenu | factrice sujet adresse`)
- `<texte_du_mail>` devient **optionnel** ; s'il est omis, le corps est lu sur
  `stdin`. Extrait dans `recupere_texte()` (testable).
- **Bonus testabilité** : le câblage `@script_automatheque` est **différé dans
  `main()`** au lieu de s'exécuter à l'import → le module redevient importable.
  Entrée console `app:main` inchangée.

### `factrice.expedition` (esmtp)
- **Émetteur par défaut configurable** via `[factrice.esmtp] emetteur` (repli
  `osuser@localhost`).
- **Fichier temporaire sûr** : `tempfile.mkstemp` (nom **unique**, répertoire
  système) + sujet **assaini**. Corrige le plantage sur un sujet contenant `/`.

### `factrice` — plancher de dépendance (fix CI)
- Plancher `automatheque.schema` relevé **`>=0.9.6` → `>=0.9.7`** : factrice
  construit un `Courriel` **sans émetteur** (rempli ensuite par l'expéditrice),
  or l'émetteur n'est facultatif que depuis schema **0.9.7**. Le plancher
  annoncé était **faux** — bug latent révélé par les nouveaux tests d'`app`
  (le job CI `tests-plancher` le validait à vide jusqu'ici).

### `automatheque.configuration` — décision « 2 fichiers de conf »
- `charge_configuration` charge le **premier** emplacement trouvé (mécanisme de
  *résolution*, pas de fusion) : `break` **volontaire**, désormais documenté.
  Aucun changement de comportement.

## Tests
`app` (`recupere_texte`, routage smtp/esmtp) ; `expedition` (émetteur
configurable + repli, sujet dangereux). `pytest src` : **142 passés**.
`ruff`/`format`/`mypy` verts. `tests-plancher` corrigé par le relèvement du
plancher.

## Reste de #27 — non traité ici
| Item | Pourquoi pas maintenant |
| --- | --- |
| **Fusion conf + arguments** (`script.py`) | Débloqué depuis le merge de #86 ; sémantique du merge à préciser → prochain lot. |
| Option **date** du journal (`suivi/journal.py`) | Décorateur cible = **stub** (`pass`) ; « option date » trop vague. |
| Livrer le **script OAuth** en dépendance | Aucun script concret à empaqueter. |

## Note versioning
Touche **`automatheque` (doc) ET `factrice`** → lockstep au prochain
`release: coupe`.

## Issues liées

cf. #27 (ne ferme pas — 3 items restants)
