### PR TITLE
release: coupe 0.16.0 (automatheque + factrice)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.15.0"
+version = "0.16.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-23
+
 ### Added
 
 * `app` : le corps du mail peut venir de l'**entrée standard**

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.factrice"
-version = "0.15.0"
+version = "0.16.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-23
+
 ### Added
 
 * `script` : `script_automatheque` / `ScriptAutomatheque` acceptent désormais

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.15.0"
+version = "0.16.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
## Description

Coupe la version **0.16.0**. En lockstep, `automatheque` et `automatheque.factrice`
ont évolué depuis 0.15.0 et prennent la nouvelle version globale ; `schema` est
inchangé et **reste à 0.15.0**.

| Paquet | Avant | Après | Contenu |
| --- | --- | --- | --- |
| monas (global) | 0.15.0 | **0.16.0** | — |
| `automatheque` | 0.15.0 | **0.16.0** | #24 (attrs `ScriptAutomatheque`, `argv`/`nom`, `mkdir_p` déprécié) + #27 (décision conf) |
| `automatheque.factrice` | 0.15.0 | **0.16.0** | #24 (validators `config`) + #27 (stdin, émetteur configurable, fichier temp sûr, plancher `schema>=0.9.7`) |
| `automatheque.schema` | 0.15.0 | **0.15.0** | inchangé |

Invariant respecté : `monas.version == max(versions) == 0.16.0`. Le tag `0.16.0`
publiera **`automatheque` + `factrice`** (== tag), **pas** `schema`.

## Faits saillants 0.16.0

- **`ScriptAutomatheque` en attrs** + `argv`/`nom` explicites (testabilité).
- **`mkdir_p` déprécié** → `Path.mkdir`.
- **Validators `config`** sur les deux expéditrices.
- **factrice** : corps du mail depuis **stdin** (`cat | factrice`), émetteur par
  défaut **configurable**, fichier temporaire **sûr** ; plancher `schema`
  corrigé (`>=0.9.7`).

## Contenu
- Bump `version` : monas + `automatheque` + `factrice` (pas `schema`).
- Bascule `[Unreleased]` → `[0.16.0] - 2026-07-23` dans les CHANGELOG
  `automatheque` et `factrice`.

## Après merge
Tag `0.16.0` (sans `v`) → `release.yml` publie `automatheque` + `factrice` sur
PyPI via Trusted Publishing.
