### PR TITLE
feat(suivi): implémente ni_fait_ni_à_refaire + option date (#27)

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `suivi.journal.JournalSuivi.ni_fait_ni_à_refaire` est **implémenté** : un
+  décorateur qui ne joue une fonction qu'une fois par référence (lue dans un
+  argument nommé), et **rejouable par période** via `periode=`
+  (`"jour"`/`"semaine"`/`"mois"`/`"annee"`) — un sceau de date entre alors dans
+  la clé de suivi. La clé est assainie (nom de fichier). Auparavant un simple
+  `pass`. — cf. #27
+
 ## [0.16.0] - 2026-07-23
 
 ### Added

--- a/src/automatheque/automatheque/suivi/journal.py
+++ b/src/automatheque/automatheque/suivi/journal.py
@@ -1,7 +1,21 @@
+import datetime
+import functools
+import inspect
+
 import attr
 
 from automatheque.suivi.adaptateurs.repertoire import StockageRepertoire
 from automatheque.suivi.ports import StockageAbstraite
+from automatheque.util.fichier import enleve_caracteres_invalides
+
+#: Fabriques de « sceau » de date par période : la clé de suivi inclut ce sceau,
+#: de sorte qu'une nouvelle période produit une nouvelle clé (donc un rejeu).
+_SCEAUX_DATE = {
+    "jour": lambda d: d.isoformat(),
+    "semaine": lambda d: "{}-S{:02d}".format(*d.isocalendar()[:2]),
+    "mois": lambda d: d.strftime("%Y-%m"),
+    "annee": lambda d: str(d.year),
+}
 
 
 @attr.s
@@ -26,17 +40,74 @@ class JournalSuivi:
     def deja_fait(self, reference: str) -> bool:
         return self.stockage.existe(reference)
 
-    # decorator !!
-    def ni_fait_ni_à_refaire(self, nom_arg_reference: str):
-        """Décore une fonction pour qu'elle ne soit jouée qu'une fois pour un
-        argument donné.
+    def _cle_suivi(self, nom_fonction, reference, periode=None, date=None):
+        """Construit la clé de suivi ``nom_fonction_reference`` (+ sceau de date).
 
-        Il faut donner en entrée le nom du paramètre qui contient la référence, et la
-        decoration sauvegardera "nom_fonction_reference".
-
-        TODO(#27) ajouter option pour date.
+        Assainie (`enleve_caracteres_invalides`) car elle sert de nom de
+        fichier au stockage. Cf. #27.
         """
-        pass
+        cle = "{}_{}".format(nom_fonction, reference)
+        if periode is not None:
+            if periode not in _SCEAUX_DATE:
+                raise ValueError(
+                    "période inconnue : {!r} (attendu : {}).".format(
+                        periode, ", ".join(_SCEAUX_DATE)
+                    )
+                )
+            jour = date or datetime.date.today()
+            cle = "{}_{}".format(cle, _SCEAUX_DATE[periode](jour))
+        return enleve_caracteres_invalides(cle)
+
+    def ni_fait_ni_à_refaire(self, nom_arg_reference, periode=None, date=None):
+        """Décore une fonction pour qu'elle ne soit jouée qu'une fois par référence.
+
+        La référence est lue dans l'argument ``nom_arg_reference`` de la fonction
+        décorée ; la clé de suivi sauvegardée est ``nom_fonction_reference``. Si
+        l'action a déjà été jouée pour cette clé, la fonction n'est **pas**
+        rappelée et le décorateur renvoie ``None``.
+
+        :param nom_arg_reference: nom du paramètre de la fonction décorée qui
+            porte la référence unique de l'action.
+        :param periode: si fournie, l'action redevient **rejouable à chaque
+            nouvelle période** (le sceau de date entre dans la clé). Valeurs :
+            ``"jour"``, ``"semaine"``, ``"mois"``, ``"annee"``. Défaut ``None`` =
+            une seule fois, définitivement. Cf. #27.
+        :param date: date de référence pour le sceau (défaut : le jour de l'appel).
+            Surtout utile pour tester de façon déterministe.
+
+        .. code-block:: python
+
+            @journal.ni_fait_ni_à_refaire("identifiant")
+            def traite(identifiant):
+                ...  # joué une seule fois par identifiant
+
+            @journal.ni_fait_ni_à_refaire("flux", periode="jour")
+            def synchronise(flux):
+                ...  # rejoué au plus une fois par jour et par flux
+        """
+
+        def decorateur(fonction):
+            @functools.wraps(fonction)
+            def enveloppe(*args, **kwargs):
+                lies = inspect.signature(fonction).bind(*args, **kwargs)
+                lies.apply_defaults()
+                if nom_arg_reference not in lies.arguments:
+                    raise KeyError(
+                        "paramètre {!r} absent de l'appel à {}().".format(
+                            nom_arg_reference, fonction.__name__
+                        )
+                    )
+                reference = lies.arguments[nom_arg_reference]
+                cle = self._cle_suivi(fonction.__name__, reference, periode, date)
+                if self.deja_fait(cle):
+                    return None
+                resultat = fonction(*args, **kwargs)
+                self.coche(cle, "" if resultat is None else str(resultat))
+                return resultat
+
+            return enveloppe
+
+        return decorateur
 
     def coche(self, reference: str, contenu: str) -> bool:
         return self.stockage.sauvegarde(reference, contenu)

--- a/src/automatheque/tests/suivi/test_suivi.py
+++ b/src/automatheque/tests/suivi/test_suivi.py
@@ -127,10 +127,108 @@ def test_journal_references_independantes(tmp_path):
     assert journal.deja_fait("pas_faite") is False
 
 
-def test_journal_ni_fait_ni_a_refaire_est_neutre(tmp_path):
-    """La méthode ``ni_fait_ni_à_refaire`` n'est pas implémentée (renvoie None)."""
+# --- #27 : décorateur ni_fait_ni_à_refaire (idempotence + option date) -------
+
+
+def test_ni_fait_ni_a_refaire_joue_une_seule_fois(tmp_path):
+    """La fonction n'est jouée qu'une fois par référence ; ensuite → None."""
     journal = JournalSuivi(StockageRepertoire(tmp_path))
-    assert journal.ni_fait_ni_à_refaire("arg") is None
+    appels = []
+
+    @journal.ni_fait_ni_à_refaire("ref")
+    def action(ref):
+        appels.append(ref)
+        return "fait"
+
+    assert action(ref="a") == "fait"
+    assert action(ref="a") is None  # déjà fait → non rejoué
+    assert appels == ["a"]
+
+
+def test_ni_fait_ni_a_refaire_references_distinctes(tmp_path):
+    """Deux références différentes sont suivies indépendamment."""
+    journal = JournalSuivi(StockageRepertoire(tmp_path))
+    appels = []
+
+    @journal.ni_fait_ni_à_refaire("ref")
+    def action(ref):
+        appels.append(ref)
+
+    action(ref="a")
+    action(ref="b")
+    assert appels == ["a", "b"]
+
+
+def test_ni_fait_ni_a_refaire_reference_positionnelle(tmp_path):
+    """La référence est aussi extraite d'un argument positionnel."""
+    journal = JournalSuivi(StockageRepertoire(tmp_path))
+    appels = []
+
+    @journal.ni_fait_ni_à_refaire("ref")
+    def action(ref, autre=None):
+        appels.append(ref)
+
+    action("x")
+    action("x")
+    assert appels == ["x"]
+
+
+def test_ni_fait_ni_a_refaire_periode_rejoue_a_chaque_jour(tmp_path):
+    """Avec ``periode``, l'action redevient rejouable à chaque nouvelle date."""
+    import datetime
+
+    journal = JournalSuivi(StockageRepertoire(tmp_path))
+    appels = []
+
+    def fabrique(jour):
+        @journal.ni_fait_ni_à_refaire("ref", periode="jour", date=jour)
+        def action(ref):
+            appels.append((ref, jour))
+
+        return action
+
+    j1 = datetime.date(2026, 7, 23)
+    j2 = datetime.date(2026, 7, 24)
+    fabrique(j1)(ref="a")
+    fabrique(j1)(ref="a")  # même jour → non rejoué
+    fabrique(j2)(ref="a")  # nouveau jour → rejoué
+    assert appels == [("a", j1), ("a", j2)]
+
+
+def test_ni_fait_ni_a_refaire_periode_inconnue_leve(tmp_path):
+    journal = JournalSuivi(StockageRepertoire(tmp_path))
+
+    @journal.ni_fait_ni_à_refaire("ref", periode="decennie")
+    def action(ref):
+        pass
+
+    with pytest.raises(ValueError, match="période inconnue"):
+        action(ref="a")
+
+
+def test_ni_fait_ni_a_refaire_argument_absent_leve(tmp_path):
+    journal = JournalSuivi(StockageRepertoire(tmp_path))
+
+    @journal.ni_fait_ni_à_refaire("inexistant")
+    def action(ref):
+        pass
+
+    with pytest.raises(KeyError, match="inexistant"):
+        action(ref="a")
+
+
+def test_ni_fait_ni_a_refaire_reference_avec_separateur(tmp_path):
+    """Une référence contenant un `/` est assainie (pas de sous-répertoire)."""
+    journal = JournalSuivi(StockageRepertoire(tmp_path))
+    appels = []
+
+    @journal.ni_fait_ni_à_refaire("ref")
+    def action(ref):
+        appels.append(ref)
+
+    action(ref="rapport/2026")  # ne doit pas lever
+    action(ref="rapport/2026")
+    assert appels == ["rapport/2026"]
 
 
 def test_journal_stockage_par_defaut(tmp_path):


### PR DESCRIPTION
## Description

Implémente l'item **« option date du journal »** de #27.

`suivi.journal.JournalSuivi.ni_fait_ni_à_refaire` était un **stub** (`pass`). Il
est désormais un vrai décorateur d'**idempotence** :

- Il ne joue une fonction **qu'une fois par référence** — la référence est lue
  dans l'argument nommé passé au décorateur (`@journal.ni_fait_ni_à_refaire("id")`
  → lit `id` dans l'appel). Déjà fait → la fonction n'est pas rappelée, renvoie
  `None`.
- **Option date (#27)** : `periode=` (`"jour"`/`"semaine"`/`"mois"`/`"annee"`)
  insère un **sceau de date** dans la clé de suivi → l'action redevient
  **rejouable à chaque nouvelle période**. `date=` permet un test déterministe.
- La clé de suivi est **assainie** (`enleve_caracteres_invalides`) car elle sert
  de nom de fichier au stockage.

```python
@journal.ni_fait_ni_à_refaire("flux", periode="jour")
def synchronise(flux):
    ...  # rejoué au plus une fois par jour et par flux
```

## Tests
Joué une seule fois, références distinctes, argument positionnel, rejeu par
jour (dates injectées), période inconnue → `ValueError`, argument absent →
`KeyError`, référence contenant un `/` (assainie). `pytest src` : **148 passés**.
`ruff`/`format`/`mypy` verts.

## Note versioning
`automatheque` uniquement → seul `automatheque` bumpe au prochain `release`.

## Issues liées
cf. #27 (avancement — restent la décision « fusion conf/args » et le script
OAuth ; traités dans #90).
