### PR TITLE
chore(#27): non-fusion conf/args + vérification oauth_cmd (BYO) — clôt #27

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* `expedition` (smtp/oauth) : la commande `oauth_cmd` (générateur de jeton
+  OAuth2 **fourni par l'utilisateur** — p. ex. `oama` — automatheque n'en
+  embarque pas) est désormais chargée via `charge_dependance` : sa présence est
+  **vérifiée** et une erreur claire (`DependanceManquante`) est levée si elle
+  est introuvable, au lieu d'un échec `subprocess` obscur. — cf. #27
+
 ## [0.16.0] - 2026-07-23
 
 ### Added

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -53,7 +53,9 @@ class ExpeditriceSmtp(Expeditrice):
     # Cas 3 : token oauth
     # défaut à false
     oauth=0
-    oauth_cmd=/chemin/vers/script/generation_token # TODO(#27) livrer en dépendances ?
+    # BYO : commande externe qui écrit le jeton OAuth2 sur stdout (p. ex. `oama`
+    # ou un script perso). Sa présence est vérifiée via charge_dependance (#27).
+    oauth_cmd=/chemin/vers/oama_ou_script_generation_token
     oauth_client_id=XyXyXyX
     ```
     """
@@ -115,9 +117,24 @@ class ExpeditriceSmtp(Expeditrice):
 
         if oauth and oauth_cmd is not None and oauth_client_id is not None:
             cmd, *args = oauth_cmd.split(" ")
-            oauth_jeton = (
-                Executant(cmd).exec(*args, encoding="utf-8").stdout.strip("\n")
+            # `oauth_cmd` est **fourni par l'utilisateur** (BYO) : un générateur
+            # de jeton OAuth2 pour le mail (p. ex. `oama`) ou un script perso —
+            # automatheque n'embarque pas d'outil OAuth. On passe par
+            # `charge_dependance` (plutôt qu'un `Executant` brut) pour **vérifier
+            # que la commande est installée** et lever une erreur claire
+            # (`DependanceManquante`) sinon, au lieu d'un échec subprocess
+            # obscur. Cf. #27.
+            executant = charge_dependance(
+                "factrice.oauth",
+                cmd,
+                cmd,
+                erreur=(
+                    f"L'outil de génération de jeton OAuth « {cmd} » (oauth_cmd) "
+                    "est introuvable. Installez-le (p. ex. oama) ou corrigez le "
+                    "chemin dans [factrice.smtp] oauth_cmd."
+                ),
             )
+            oauth_jeton = executant.exec(*args, encoding="utf-8").stdout.strip("\n")
             # LOGGER.debug("jeton oauth : " + oauth_jeton)
             self.s.ehlo(oauth_client_id)
             # On pourrait utiliser self.s.auth, mais il faut travailler

--- a/src/automatheque.factrice/tests/test_expedition.py
+++ b/src/automatheque.factrice/tests/test_expedition.py
@@ -32,6 +32,47 @@ def test_smtp_exception_pendant_connexion_est_capturee(monkeypatch):
     fake.login.assert_called_once()
 
 
+def _config_oauth():
+    """Config SMTP en mode OAuth (BYO oauth_cmd)."""
+    c = _config_smtp()
+    c.set("factrice.smtp", "oauth", "1")
+    c.set("factrice.smtp", "oauth_client_id", "cid")
+    return c
+
+
+def test_oauth_cmd_absent_leve_dependance_manquante(monkeypatch):
+    """#27 : un `oauth_cmd` introuvable → `DependanceManquante` claire."""
+    from automatheque.exceptions import DependanceManquante
+
+    fake = MagicMock()
+    monkeypatch.setattr(expedition.smtplib, "SMTP_SSL", lambda *a, **k: fake)
+    c = _config_oauth()
+    c.set("factrice.smtp", "oauth_cmd", "outil-oauth-inexistant-xyz")
+
+    with pytest.raises(DependanceManquante):
+        ExpeditriceSmtp(config=c)
+
+
+def test_oauth_cmd_present_utilise_le_jeton(monkeypatch):
+    """#27 : le jeton produit par `oauth_cmd` est envoyé via AUTH XOAUTH2."""
+    fake = MagicMock()
+    monkeypatch.setattr(expedition.smtplib, "SMTP_SSL", lambda *a, **k: fake)
+    faux_exec = MagicMock()
+    faux_exec.exec.return_value = MagicMock(stdout="LE-JETON\n")
+    monkeypatch.setattr(expedition, "charge_dependance", lambda *a, **k: faux_exec)
+
+    c = _config_oauth()
+    c.set("factrice.smtp", "oauth_cmd", "oama access user")
+    ExpeditriceSmtp(config=c)
+
+    # cmd/args découpés, jeton nettoyé, envoyé en XOAUTH2.
+    assert faux_exec.exec.call_args.args == ("access", "user")
+    fake.ehlo.assert_called_once_with("cid")
+    methode, charge = fake.docmd.call_args.args
+    assert methode == "AUTH"
+    assert charge == "XOAUTH2 LE-JETON"
+
+
 def test_erreur_non_smtp_pendant_connexion_se_propage(monkeypatch):
     """Une erreur non-SMTP n'est plus avalée silencieusement : elle remonte.
 

--- a/src/automatheque/automatheque/script.py
+++ b/src/automatheque/automatheque/script.py
@@ -258,17 +258,14 @@ class ScriptAutomatheque:
         # usage docopt (sinon `.get` renvoie None → comportement par défaut).
         self.dry_run = bool(self.arguments.get("--dry-run"))
         self._applique_verbosite()
-        # TODO(#27) ici on pourrait aussi merger la conf et les arguments ...
-        # dans self.parametres ?
-        """
-        def merge(dict_1, dict_2):
-            ""Merge two dictionaries.
-            Values that evaluate to true take priority over falsy values.
-            `dict_1` takes priority over `dict_2`.
-            ""
-            return dict((str(key), dict_1.get(key) or dict_2.get(key))
-        for key in set(dict_2) | set(dict_1))
-        """
+        # DÉCISION (#27) : on ne fusionne PAS `config` et `arguments` dans un
+        # `parametres` unique. `config` est structuré (sections → clés) et
+        # persistant ; `arguments` est plat, avec des sigils docopt (`--x`,
+        # `<y>`), et propre à cet appel. Les aplatir ensemble inventerait une
+        # convention de nommage fragile et créerait des collisions entre
+        # sections. La précédence « la CLI l'emporte sur la conf » se traite
+        # explicitement au point d'usage, p. ex. :
+        #     valeur = self.arguments["--x"] or self.config.get("section", "x")
 
     def execute_commande(self, registry=None):
         """Aiguille vers la commande commandopt correspondant aux arguments.


### PR DESCRIPTION
## Description

Résout les **2 derniers items** de #27 (le 3ᵉ, l'option date du journal, est
dans #89). Cette PR **clôt #27** — à merger **après #89** pour que tout le code
de l'issue soit dans `main`.

### #1 — `script.py` : on NE fusionne PAS conf + arguments (décision validée)
`config` est structuré (sections → clés) et persistant ; `arguments` est plat,
avec des sigils docopt, et propre à l'appel. Les fusionner inventerait une
convention de nommage fragile + des collisions. La précédence « CLI > conf » se
traite explicitement au point d'usage :
```python
valeur = self.arguments["--x"] or self.config.get("section", "x")
```
Le `TODO(#27)` et le `merge()` mort (commenté) sont remplacés par ce commentaire
de décision. Aucun changement de comportement.

### #3 — `factrice` : `oauth_cmd` vérifié via `charge_dependance` (BYO)
`oauth_cmd` est un générateur de jeton OAuth2 **fourni par l'utilisateur**
(p. ex. [`oama`](https://github.com/pdobsan/oama) ou un script perso) —
automatheque n'embarque pas d'outil OAuth. Plutôt qu'un `Executant` brut, on
passe par `charge_dependance` : la présence de la commande est **vérifiée** et
une **erreur claire (`DependanceManquante`)** est levée si elle est introuvable,
au lieu d'un échec `subprocess` obscur. Docstring de config mise à jour (BYO).

## Tests
- `oauth_cmd` absent → `DependanceManquante`.
- `oauth_cmd` présent → cmd/args découpés, jeton nettoyé, envoyé en
  `AUTH XOAUTH2`.

`pytest src` : **144 passés**. `ruff`/`format`/`mypy` verts.

## Note versioning
Touche `automatheque` (commentaire) **et** `factrice` (oauth) → lockstep au
prochain `release`. CHANGELOG factrice sous `[Unreleased]` ; item #1 non
changelogué (commentaire interne, sans effet observable).

## Issues liées
Closes #27 *(avec #89 pour l'item « option date du journal »)*
