### PR TITLE
chore(ci): épingle ruff 0.16.0 / mypy 1.19.1 + reformate les README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e src/automatheque -e src/automatheque.schema -e src/automatheque.factrice
+          # ruff et mypy sont ÉPINGLÉS : sans version fixe, `pip install` récupère
+          # la dernière (qui change les règles de lint/format d'un jour à l'autre)
+          # et fait échouer des PR sans rapport. On bumpe délibérément.
           # types-* : stubs pour pyyaml/pytz (typage de log.py / structures_python.py).
-          pip install ruff mypy types-PyYAML types-pytz
+          pip install ruff==0.16.0 mypy==1.19.1 types-PyYAML types-pytz
 
       # ruff et mypy sont désormais **bloquants** : le code a été nettoyé (#71).
       - name: Lint (ruff check)

--- a/src/automatheque.schema/README.md
+++ b/src/automatheque.schema/README.md
@@ -22,11 +22,11 @@ donner des exemples pour l'héritage de renommable etc. qu'on ne va plus intégr
 
 ```py
 class ChansonRenommable(Chanson, Renommable):
-  def liste_champs():
-    pass
+    def liste_champs():
+        pass
 
-  def gabarits():
-    pass
+    def gabarits():
+        pass
 ```
 
 ## Requirement

--- a/src/automatheque/README.md
+++ b/src/automatheque/README.md
@@ -23,11 +23,13 @@ pip install automatheque
 ```python
 from automatheque.script import script  # alias court de script_automatheque
 
+
 @script(__doc__, __version__)
 def main(_script):
     print(_script.config)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()
 ```
 
@@ -52,21 +54,24 @@ exclues de la sélection, mais restent transmises à la commande.
 Usage:
   mon_script.py (--ajouter | --supprimer) [--config=<f>] [-v]
 """
+
 from automatheque.script import script, commande
 
+
 @commande(["--ajouter"])
-def ajouter(arguments):
-    ...
+def ajouter(arguments): ...
+
 
 @commande(["--supprimer"])
-def supprimer(arguments):
-    ...
+def supprimer(arguments): ...
+
 
 @script(__doc__, __version__)
 def main(_script):
     return _script.execute_commande()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()
 ```
 


### PR DESCRIPTION
## Description

Le job **Qualité** échouait sur #89 (et échouerait sur #90) pour une raison
**sans rapport avec ces PR** : la CI installe `ruff`/`mypy` **sans version
épinglée** (`pip install ruff mypy …`). `pip` récupère donc la **dernière**
version, et **ruff 0.16.0** (vs 0.15.x jusqu'ici) formate désormais les blocs de
code Python **à l'intérieur des `.md`** → 2 README « à reformater » qui font
planter le job sur toute PR.

## Changements
- **`ci.yml`** : épingle **`ruff==0.16.0`** et **`mypy==1.19.1`** → builds
  reproductibles (fini la dérive silencieuse ; on bumpera délibérément).
- **README** (`automatheque` + `automatheque.schema`) : reformatés par ruff
  0.16.0 — lignes vides PEP 8 autour des fonctions, guillemets doubles, corps de
  stub `...` compacts. **Purement cosmétique**, aucun changement de contenu.

## Vérification
Avec les versions épinglées : `ruff check src`, `ruff format --check src` et
`mypy src/automatheque/automatheque` sont **verts**.

## Suite
À merger **en premier** ; ensuite je rebase **#89** et **#90** dessus (ils
repasseront au vert). Décision de version (adopter 0.16.0) validée avec le
mainteneur.
