### PR TITLE
release: coupe 0.17.0 (automatheque + factrice)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.16.0"
+version = "0.17.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-24
+
 ### Changed
 
 * `expedition` (smtp/oauth) : la commande `oauth_cmd` (générateur de jeton

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.factrice"
-version = "0.16.0"
+version = "0.17.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-24
+
 ### Added
 
 * `suivi.journal.JournalSuivi.ni_fait_ni_à_refaire` est **implémenté** : un

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.16.0"
+version = "0.17.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
## Description

Coupe la version **0.17.0**. `automatheque` et `automatheque.factrice` ont
évolué depuis 0.16.0 (dernière tranche de la dette **#27**) → nouvelle version
globale. `schema` reste à **0.15.0**.

| Paquet | Avant | Après | Contenu |
| --- | --- | --- | --- |
| monas (global) | 0.16.0 | **0.17.0** | — |
| `automatheque` | 0.16.0 | **0.17.0** | `journal.ni_fait_ni_à_refaire` implémenté + option date (#27) |
| `automatheque.factrice` | 0.16.0 | **0.17.0** | `oauth_cmd` (BYO) vérifié via `charge_dependance` (#27) |
| `automatheque.schema` | 0.15.0 | **0.15.0** | inchangé (seul son README a été reformaté en #91 — cosmétique) |

Invariant : `monas.version == max(versions) == 0.17.0`. Le tag `0.17.0` publiera
**`automatheque` + `factrice`**, pas `schema`.

## Faits saillants 0.17.0
- **`suivi.journal.ni_fait_ni_à_refaire`** : décorateur d'idempotence
  (une fois par référence) avec **option `periode=`** (rejeu par jour/semaine/
  mois/année via un sceau de date). Était un `pass`.
- **`factrice` — `oauth_cmd` (BYO)** : la commande de génération de jeton OAuth2
  (p. ex. `oama`) est vérifiée via `charge_dependance` → `DependanceManquante`
  claire si absente.

## Contenu
- Bump `version` : monas + `automatheque` + `factrice` (pas `schema`).
- Bascule `[Unreleased]` → `[0.17.0] - 2026-07-24` dans les CHANGELOG
  `automatheque` et `factrice`.

**Clôt la dette #24–#27.** 🎉
