### PR TITLE
feat(script): conf.d drop-in + --config répétable (#93)

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `script` — configuration en couches enrichie (cf. #93) :
+  * **répertoire drop-in `conf.d/`** : `~/.config/<script>/conf.d/*.ini` sont
+    lus **triés** (préfixe numérique conseillé) après le `config.ini` du script.
+    Chaque raccord/intégration dépose son fragment ; désinstallation = suppression
+    du fichier.
+  * **`--config` répétable** : avec `--config=<c>...` dans l'usage docopt, les
+    fichiers sont empilés dans l'ordre (le dernier surcharge). Un `--config=<f>`
+    simple continue de fonctionner.
+
 ## [0.17.0] - 2026-07-24
 
 ### Added

--- a/src/automatheque/automatheque/script.py
+++ b/src/automatheque/automatheque/script.py
@@ -22,9 +22,10 @@ Options:
 __version__ = '0.1a'  # ou importer depuis mon_package.__version__
 
 # La configuration est chargée en couches, sans rien déclarer ici :
-#   ~/.config/automatheque/config.ini   (partagé entre scripts)
-#   ~/.config/<mon_script>/config.ini   (propre à ce script ; surcharge)
-#   --config <fichier>                  (ponctuel ; surcharge)
+#   ~/.config/automatheque/config.ini      (partagé entre scripts)
+#   ~/.config/<mon_script>/config.ini      (propre à ce script ; surcharge)
+#   ~/.config/<mon_script>/conf.d/*.ini    (fragments triés ; surcharge) — #93
+#   --config <fichier> (répétable)         (ponctuel ; surcharge) — #93
 
 from automatheque.script import script  # alias court de script_automatheque
 
@@ -79,6 +80,7 @@ def main(_script):
 """
 
 import datetime
+import glob
 import logging
 import os
 import re
@@ -242,17 +244,23 @@ class ScriptAutomatheque:
         )
         # Configuration en couches, de la plus générale à la plus spécifique
         # (chaque couche surcharge la précédente) :
-        #   1. config.ini partagé d'automatheque  (chargé par ecraser=True)
-        #   2. <racine>/<nom_court>/config.ini     (propre au script)
-        #   3. --config <fichier>                  (explicite, ponctuel)
-        fichiers = [
-            os.path.join(
-                constantes.repertoire_config_script(self.nom_court), "config.ini"
-            )
-        ]
+        #   1. config.ini partagé d'automatheque   (chargé par ecraser=True)
+        #   2. <racine>/<nom_court>/config.ini      (propre au script)
+        #   3. <racine>/<nom_court>/conf.d/*.ini    (fragments, triés) — cf. #93
+        #   4. --config <fichier> (répétable)       (explicite, ponctuel)
+        dossier_script = constantes.repertoire_config_script(self.nom_court)
+        fichiers = [os.path.join(dossier_script, "config.ini")]
+        # conf.d/ : chaque raccord/intégration dépose son fragment ; on les lit
+        # TRIÉS (préfixe numérique conseillé, p. ex. 10-x.ini) après le
+        # config.ini du script. Répertoire absent → glob vide → no-op. Cf. #93.
+        fichiers += sorted(glob.glob(os.path.join(dossier_script, "conf.d", "*.ini")))
+        # --config peut être répété : avec docopt `--config=<c>...` la valeur est
+        # une liste (on empile dans l'ordre) ; un `--config=<f>` simple reste une
+        # chaîne. On gère les deux pour ne rien casser. Cf. #93.
         config_cli = self.arguments.get("--config")
-        if config_cli:
-            fichiers.append(config_cli)
+        if isinstance(config_cli, str):  # `--config=<f>` simple → liste à 1 élément
+            config_cli = [config_cli]
+        fichiers += config_cli or []  # None/[] → rien ; liste docopt → empilée
         self.config = charge_configuration(fichiers, ecraser=True, recharger=True)
         # Commodités câblées automatiquement si le script les déclare dans son
         # usage docopt (sinon `.get` renvoie None → comportement par défaut).

--- a/src/automatheque/tests/test_script.py
+++ b/src/automatheque/tests/test_script.py
@@ -297,3 +297,76 @@ def test_parseur_est_docopt_ng():
     import importlib.metadata as md
 
     assert md.version("docopt-ng")  # lève PackageNotFoundError si absent
+
+
+# --- #93 : conf.d drop-in + --config répétable ---------------------------------
+
+
+#: Usage déclarant `--config` **répétable** (`...`).
+DOC_MULTICONF = """Script de démonstration du --config répétable.
+
+Usage:
+  demo [--config=<c>...]
+
+Options:
+  --config=<c>  Fichier de configuration (répétable, empilé dans l'ordre).
+"""
+
+
+def _prepare_dossier_script(tmp_path, monkeypatch):
+    """Pointe la config sur ``tmp_path`` et crée ``<racine>/script-de-test/``.
+
+    ``essai.execute_script`` nomme le script « script-de-test » → son répertoire
+    de config est ``$XDG_CONFIG_HOME/script-de-test/``.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    dossier = tmp_path / "script-de-test"
+    (dossier / "conf.d").mkdir(parents=True)
+    return dossier
+
+
+def test_conf_d_fragments_superposes_tries(tmp_path, monkeypatch):
+    """Les fragments `conf.d/*.ini` sont lus triés, après le config.ini."""
+    dossier = _prepare_dossier_script(tmp_path, monkeypatch)
+    (dossier / "config.ini").write_text("[demo]\ncle = base\n")
+    (dossier / "conf.d" / "10-a.ini").write_text("[demo]\ncle = a\ndepuisA = 1\n")
+    (dossier / "conf.d" / "20-b.ini").write_text("[demo]\ncle = b\n")  # 20 > 10
+
+    def main(_script=None):
+        return (
+            _script.config.get("demo", "cle"),
+            _script.config.get("demo", "depuisA"),
+        )
+
+    # 20-b surcharge 10-a (tri), qui surcharge config.ini ; depuisA survit.
+    assert execute_script(DOC_OPTIONS, main, argv=[]).resultat == ("b", "1")
+
+
+def test_conf_d_absent_est_neutre(tmp_path, monkeypatch):
+    """Sans répertoire `conf.d/`, le chargement fonctionne (no-op)."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    dossier = tmp_path / "script-de-test"
+    dossier.mkdir(parents=True)  # pas de conf.d/
+    (dossier / "config.ini").write_text("[demo]\ncle = base\n")
+
+    def main(_script=None):
+        return _script.config.get("demo", "cle")
+
+    assert execute_script(DOC_OPTIONS, main, argv=[]).resultat == "base"
+
+
+def test_config_repetable_empile_dans_l_ordre(tmp_path, monkeypatch):
+    """#93 : `--config` répété empile les fichiers (le dernier surcharge)."""
+    _prepare_dossier_script(tmp_path, monkeypatch)
+    a = tmp_path / "a.ini"
+    a.write_text("[demo]\nx = a\ny = A\n")
+    b = tmp_path / "b.ini"
+    b.write_text("[demo]\nx = b\n")  # b après a → x = b, mais y = A survit
+
+    def main(_script=None):
+        return (_script.config.get("demo", "x"), _script.config.get("demo", "y"))
+
+    res = execute_script(
+        DOC_MULTICONF, main, argv=["--config", str(a), "--config", str(b)]
+    )
+    assert res.resultat == ("b", "A")


### PR DESCRIPTION
## Description

Enrichit la **configuration en couches** de `ScriptAutomatheque.initialise`
(cf. #93).

### A. Répertoire drop-in `conf.d/`
Les fragments `~/.config/<script>/conf.d/*.ini` sont lus **triés** (préfixe
numérique conseillé, p. ex. `10-x.ini`) **après** le `config.ini` du script.
Pattern Unix : chaque raccord/intégration dépose son fragment, désinstallation =
`rm`. Répertoire absent → glob vide → **no-op**. Le `glob` est fait dans
`initialise` (qui connaît `nom_court`) et passe des chemins **absolus** à
`charge_configuration`, qui reste générique.

### B. `--config` répétable
Avec `--config=<c>...` dans l'usage docopt, la valeur devient une **liste**
empilée dans l'ordre (le dernier surcharge). Un `--config=<f>` simple (chaîne)
**continue de fonctionner** (géré dans `initialise`).

### Pile de couches (précédence croissante)
1. `~/.config/automatheque/config.ini`
2. `~/.config/<script>/config.ini`
3. **`~/.config/<script>/conf.d/*.ini`** (trié) — A
4. **`--config` fichier(s)** — B

## Tests
- Fragments `conf.d` superposés et **triés** (`20-b` gagne sur `10-a`, qui gagne
  sur `config.ini`) ;
- `conf.d` absent → no-op ;
- `--config` répété → empilé dans l'ordre (le dernier surcharge, les clés non
  écrasées survivent).

`pytest src` : **153 passés**. `ruff` (0.16.0) / `format` / `mypy` verts.

## Note versioning
`automatheque` uniquement → seul `automatheque` bumpe au prochain `release`.

## Issues liées
Closes #93
