### PR TITLE
release: coupe 0.18.0 (automatheque)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.17.0"
+version = "0.18.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-24
+
 ### Added
 
 * `script` — configuration en couches enrichie (cf. #93) :

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.17.0"
+version = "0.18.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
## Description

Coupe la version **0.18.0**. Seul `automatheque` a évolué depuis 0.17.0 (#93 :
`conf.d` drop-in + `--config` répétable) → il prend la nouvelle version globale.
`factrice` et `schema` restent inchangés.

| Paquet | Avant | Après |
| --- | --- | --- |
| monas (global) | 0.17.0 | **0.18.0** |
| `automatheque` | 0.17.0 | **0.18.0** |
| `automatheque.factrice` | 0.17.0 | 0.17.0 (inchangé) |
| `automatheque.schema` | 0.15.0 | 0.15.0 (inchangé) |

Invariant : `monas.version == max(versions) == 0.18.0`. Le tag `0.18.0`
publiera **`automatheque` uniquement**.

## Faits saillants 0.18.0
- **Configuration en couches enrichie** (#93) : répertoire drop-in **`conf.d/`**
  (`~/.config/<script>/conf.d/*.ini`, triés) + **`--config` répétable**.

## Contenu
- Bump `version` : monas + `automatheque`.
- Bascule `[Unreleased]` → `[0.18.0] - 2026-07-24` dans le CHANGELOG
  `automatheque`.

## Après merge
Tag `0.18.0` (sans `v`) → `release.yml` publie `automatheque`.
