### PR TITLE
fix(sécurité): durcit l'envoi SMTP — STARTTLS fatal, debug off, shlex (#15)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+* `expedition.ExpeditriceSmtp` — durcissement (cf. #15) :
+  * **S3 — STARTTLS obligatoire par défaut** : en mode non-`ssl`, si le serveur
+    ne gère pas STARTTLS, on **refuse d'envoyer en clair** (identifiants
+    exposés) au lieu d'un simple warning. ⚠️ **Changement de comportement** :
+    autoriser explicitement l'envoi en clair via `[factrice.smtp]
+    autorise_clair=1`.
+  * **S1 — debug SMTP off par défaut** : `set_debuglevel(1)` (qui dumpe le
+    trafic SMTP, dont `AUTH`/le jeton OAuth, **en clair dans les logs**) n'est
+    plus câblé en dur ; il s'active via `[factrice.smtp] debug=1`.
+  * **S5 — `oauth_cmd`** est découpé avec `shlex.split` (guillemets/espaces
+    gérés) au lieu de `str.split(" ")`. (Pas d'injection shell : `Executant`
+    utilise `subprocess.run(liste)`.)
+
 ## [0.17.0] - 2026-07-24
 
 ### Changed

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -2,6 +2,7 @@
 import abc
 import logging
 import os
+import shlex
 import smtplib
 import subprocess
 import tempfile
@@ -40,6 +41,14 @@ class ExpeditriceSmtp(Expeditrice):
     hote=https://url_smtp
     # défaut 465 si ssl = 1, sinon 25
     port=465
+
+    # Sécurité (cf. #15)
+    # Debug SMTP : dumpe TOUT le trafic (dont AUTH/jeton) en clair dans les logs.
+    # Désactivé par défaut. N'activer que pour du diagnostic ponctuel.
+    debug=0
+    # Si le serveur ne gère pas STARTTLS (mode non-ssl), refuser d'envoyer par
+    # défaut (identifiants exposés). Mettre à 1 pour autoriser l'envoi EN CLAIR.
+    autorise_clair=0
 
     # Connexion
     # Cas 1 : anonyme
@@ -87,7 +96,21 @@ class ExpeditriceSmtp(Expeditrice):
             try:
                 self.s.starttls()
             except smtplib.SMTPNotSupportedError:
-                LOGGER.warning("Attention le smtp ne gère pas le TLS.")
+                # S3 (#15) : un serveur sans STARTTLS ferait transiter les
+                # identifiants EN CLAIR. On refuse par défaut ; autorisation
+                # explicite via [factrice.smtp] autorise_clair=1.
+                if self.config.getboolean(
+                    "factrice.smtp", "autorise_clair", fallback=False
+                ):
+                    LOGGER.warning(
+                        "SMTP sans STARTTLS : envoi EN CLAIR (autorise_clair=1)."
+                    )
+                else:
+                    raise smtplib.SMTPNotSupportedError(
+                        "Le serveur SMTP ne gère pas STARTTLS ; refus d'envoyer "
+                        "en clair (identifiants exposés). Pour l'autoriser "
+                        "explicitement : [factrice.smtp] autorise_clair=1."
+                    )
 
         try:
             self.__connecter()
@@ -113,10 +136,17 @@ class ExpeditriceSmtp(Expeditrice):
             "factrice.smtp", "oauth_client_id", fallback=None
         )
 
-        self.s.set_debuglevel(1)
+        # S1 (#15) : le debug SMTP dumpe tout le trafic — dont AUTH et le jeton
+        # OAuth — EN CLAIR dans les logs. Désactivé par défaut ; activable via
+        # [factrice.smtp] debug=1 pour du diagnostic ponctuel.
+        if self.config.getboolean("factrice.smtp", "debug", fallback=False):
+            self.s.set_debuglevel(1)
 
         if oauth and oauth_cmd is not None and oauth_client_id is not None:
-            cmd, *args = oauth_cmd.split(" ")
+            # S5 (#15) : shlex.split gère guillemets/espaces (un chemin ou un
+            # argument peut en contenir). Pas d'injection shell : Executant.exec
+            # utilise subprocess.run(liste), sans shell=True.
+            cmd, *args = shlex.split(oauth_cmd)
             # `oauth_cmd` est **fourni par l'utilisateur** (BYO) : un générateur
             # de jeton OAuth2 pour le mail (p. ex. `oama`) ou un script perso —
             # automatheque n'embarque pas d'outil OAuth. On passe par

--- a/src/automatheque.factrice/tests/test_expedition.py
+++ b/src/automatheque.factrice/tests/test_expedition.py
@@ -189,3 +189,73 @@ def test_esmtp_sujet_avec_separateur_ne_casse_pas_le_chemin(monkeypatch):
         emetteur="exp@ex.fr", sujet="rapport/2026", destinataires=["dest@ex.fr"]
     )
     assert exp.expedie(courriel) == 0
+
+
+# --- #15 : durcissement (S1 debug, S3 TLS fatal, S5 shlex) -------------------
+
+
+def _config_smtp_clair():
+    """Config SMTP **sans** ssl → branche `smtplib.SMTP` + STARTTLS."""
+    c = ConfigParser()
+    c.add_section("factrice.smtp")
+    c.set("factrice.smtp", "hote", "localhost")
+    c.set("factrice.smtp", "identifiant", "user")
+    c.set("factrice.smtp", "mdp", "secret")
+    return c
+
+
+def test_s3_starttls_non_supporte_est_fatal(monkeypatch):
+    """#15 S3 : sans STARTTLS, on refuse d'envoyer en clair par défaut."""
+    fake = MagicMock()
+    fake.starttls.side_effect = smtplib.SMTPNotSupportedError("no tls")
+    monkeypatch.setattr(expedition.smtplib, "SMTP", lambda *a, **k: fake)
+
+    with pytest.raises(smtplib.SMTPNotSupportedError, match="autorise_clair"):
+        ExpeditriceSmtp(config=_config_smtp_clair())
+
+
+def test_s3_clair_autorise_explicitement(monkeypatch):
+    """#15 S3 : `autorise_clair=1` permet l'envoi sans STARTTLS."""
+    fake = MagicMock()
+    fake.starttls.side_effect = smtplib.SMTPNotSupportedError("no tls")
+    monkeypatch.setattr(expedition.smtplib, "SMTP", lambda *a, **k: fake)
+    c = _config_smtp_clair()
+    c.set("factrice.smtp", "autorise_clair", "1")
+
+    ExpeditriceSmtp(config=c)  # ne doit pas lever
+    fake.login.assert_called_once()
+
+
+def test_s1_debug_smtp_off_par_defaut(monkeypatch):
+    """#15 S1 : le debug SMTP (qui fuite AUTH/jeton) est off par défaut."""
+    fake = MagicMock()
+    monkeypatch.setattr(expedition.smtplib, "SMTP_SSL", lambda *a, **k: fake)
+
+    ExpeditriceSmtp(config=_config_smtp())
+    fake.set_debuglevel.assert_not_called()
+
+
+def test_s1_debug_smtp_activable(monkeypatch):
+    """#15 S1 : `debug=1` active explicitement le debug SMTP."""
+    fake = MagicMock()
+    monkeypatch.setattr(expedition.smtplib, "SMTP_SSL", lambda *a, **k: fake)
+    c = _config_smtp()
+    c.set("factrice.smtp", "debug", "1")
+
+    ExpeditriceSmtp(config=c)
+    fake.set_debuglevel.assert_called_once_with(1)
+
+
+def test_s5_oauth_cmd_shlex_gere_les_guillemets(monkeypatch):
+    """#15 S5 : `oauth_cmd` est découpé avec shlex (guillemets/espaces)."""
+    fake = MagicMock()
+    monkeypatch.setattr(expedition.smtplib, "SMTP_SSL", lambda *a, **k: fake)
+    faux_exec = MagicMock()
+    faux_exec.exec.return_value = MagicMock(stdout="JETON\n")
+    monkeypatch.setattr(expedition, "charge_dependance", lambda *a, **k: faux_exec)
+    c = _config_oauth()
+    c.set("factrice.smtp", "oauth_cmd", 'oama access "user name"')
+
+    ExpeditriceSmtp(config=c)
+    # "user name" reste un seul argument grâce à shlex.
+    assert faux_exec.exec.call_args.args == ("access", "user name")


### PR DESCRIPTION
## Description

Quick wins de l'audit sécurité **#15** sur `factrice.expedition.ExpeditriceSmtp`
(S2 « fichier temp » était déjà réglé par #27).

### S3 — STARTTLS obligatoire par défaut ⚠️
En mode non-`ssl`, si le serveur ne gère pas STARTTLS, on **refuse d'envoyer en
clair** (identifiants exposés) au lieu d'un simple `warning`.
**Changement de comportement** : pour autoriser l'envoi en clair, il faut
désormais l'expliciter — `[factrice.smtp] autorise_clair=1`.

### S1 — debug SMTP off par défaut
`set_debuglevel(1)` dumpe **tout** le trafic SMTP (dont `AUTH` et le jeton
OAuth) **en clair dans les logs**. Il n'est plus câblé en dur ; activable pour
diagnostic via `[factrice.smtp] debug=1`.

### S5 — `oauth_cmd` via `shlex.split`
Découpage propre (guillemets/espaces) au lieu de `str.split(" ")`. Ce n'est
**pas** une faille d'injection shell (`Executant.exec` → `subprocess.run(liste)`
sans `shell=True`), mais un parsing correct.

## Tests
- S3 : STARTTLS non supporté → **fatal** (`SMTPNotSupportedError` avec message
  clair) ; `autorise_clair=1` → passe (avec warning).
- S1 : debug **off** par défaut (`set_debuglevel` non appelé) ; `debug=1` →
  appelé.
- S5 : `oama access "user name"` → `("access", "user name")` (guillemet
  préservé).

`pytest src` : **158 passés**. `ruff` (0.16.0) / `format` verts.

## Reste de #15
Le **filtre de caviardage** des secrets dans les logs (seconde moitié de S1)
relève du **module `secret` #8** — traité là-bas. Cette PR ne ferme donc pas #15.

## Note versioning
`factrice` uniquement → seul `factrice` bumpe au prochain `release`.

## Issues liées
cf. #15 (S1 debug, S3, S5 ; caviardage → #8)
