### PR TITLE
feat(secret): objet Secret caviardé + greffons résolveurs (#8)

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `secret` : nouveau module de **gestion des secrets** (cf. #8).
+  * objet **`Secret`** dont `repr`/`str`/f-string/logging affichent `***` — la
+    valeur réelle n'est accessible que via `.reveler()` (anti-fuite dans les
+    logs/tracebacks) ;
+  * les sources de secrets sont des **greffons** rendant la capacité
+    **`ResoudreSecret`** (cf. `automatheque.greffon`) : `GreffonSecretEnv`
+    (variable d'environnement), `GreffonSecretConfig` (configuration,
+    `section.option`), `GreffonSecretKeyring` (trousseau système, dépendance
+    optionnelle `keyring`, neutre si absente), `GreffonSecretCommande` (commande
+    externe via `Executant`) ;
+  * **`recup_secret(cle, config=, resolveurs=)`** résout un secret via des
+    greffons **ordonnés** (par défaut : variable d'environnement puis, si
+    fournie, la configuration ; premier gagnant). Ordre et sources
+    personnalisables via `resolveurs=`.
+  * documentation d'usage (README) : à quoi sert le module et exemples
+    (`Secret`, `recup_secret`, résolveurs personnalisés).
+
 ## [0.18.0] - 2026-07-24
 
 ### Added

--- a/src/automatheque/README.md
+++ b/src/automatheque/README.md
@@ -75,6 +75,79 @@ if __name__ == "__main__":
     main()
 ```
 
+## Gestion des secrets
+
+Un mot de passe ou un jeton ne doit **jamais** fuiter dans les logs ou une
+traceback, et sa **source** ne devrait pas être figée dans le code (parfois une
+variable d'environnement, parfois la config, parfois un trousseau système…).
+Le module `automatheque.secret` répond aux deux besoins.
+
+### `Secret` : une valeur qui ne fuite pas
+
+`Secret` enveloppe une valeur sensible : son `repr`, son `str`, un f-string et le
+logging affichent tous `***`. La valeur réelle n'est accessible qu'au **point
+d'usage**, via `.reveler()`.
+
+```python
+from automatheque.secret import Secret
+
+mdp = Secret("s3cr3t")
+print(mdp)  # ***
+print(f"mdp={mdp}")  # mdp=***
+logging.info("mdp=%s", mdp)  # …mdp=***  (pas de fuite dans les logs)
+
+connexion.login("moi", mdp.reveler())  # .reveler() UNIQUEMENT ici
+```
+
+### `recup_secret` : d'où vient le secret ?
+
+`recup_secret(cle, config=, resolveurs=)` cherche la valeur auprès de plusieurs
+sources **essayées dans l'ordre** (premier gagnant) et renvoie un `Secret` (ou
+`None` si introuvable). Par défaut : la **variable d'environnement** puis, si on
+lui passe une `config`, la **configuration**.
+
+```python
+from automatheque.secret import recup_secret
+
+# factrice.smtp.mdp  →  variable FACTRICE_SMTP_MDP,
+#                       sinon [factrice.smtp] mdp = … dans la config
+mdp = recup_secret("factrice.smtp.mdp", config=_script.config)
+if mdp is not None:
+    serveur.login(user, mdp.reveler())
+```
+
+### Les sources sont des greffons
+
+Chaque source est un **greffon** (cf. `automatheque.greffon`) rendant la capacité
+`ResoudreSecret` — on ajoute donc une nouvelle source comme n'importe quel
+greffon. Fournis d'origine :
+
+| Greffon                 | Source                                                        |
+| ----------------------- | ------------------------------------------------------------- |
+| `GreffonSecretEnv`      | variable d'env (`factrice.smtp.mdp` → `FACTRICE_SMTP_MDP`)     |
+| `GreffonSecretConfig`   | configuration (`section.option`)                              |
+| `GreffonSecretKeyring`  | trousseau système (dépendance optionnelle `keyring`)          |
+| `GreffonSecretCommande` | sortie d'une commande externe (p. ex. `pass show {cle}`)      |
+
+Pour un ordre ou des sources personnalisés, on passe `resolveurs=` (liste
+ordonnée de greffons) — ici on interroge d'abord le trousseau, puis une commande :
+
+```python
+from automatheque.secret import (
+    recup_secret,
+    GreffonSecretKeyring,
+    GreffonSecretCommande,
+)
+
+mdp = recup_secret(
+    "factrice.smtp.mdp",
+    resolveurs=[
+        GreffonSecretKeyring(service="mon-appli"),
+        GreffonSecretCommande(gabarit="pass show {cle}"),
+    ],
+)
+```
+
 ## Configuration du logging
 
 Automathèque **ne configure rien à l'import** (une bibliothèque ne doit pas

--- a/src/automatheque/automatheque/secret.py
+++ b/src/automatheque/automatheque/secret.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+"""Gestion des secrets : objet :class:`Secret` **caviardé** + résolution par greffons.
+
+But (cf. #8) : ne jamais laisser fuiter un identifiant/jeton dans les logs ou les
+tracebacks, et centraliser leur récupération (variable d'environnement,
+configuration, trousseau système, commande externe) derrière une API unique.
+
+Les sources de secrets sont des **greffons** (cf. :mod:`automatheque.greffon`)
+qui rendent la capacité :class:`ResoudreSecret` : on privilégie ainsi le
+système de greffons pour toute source enfichable, plutôt qu'un mécanisme ad hoc.
+
+.. code-block:: python
+
+    from automatheque.secret import recup_secret
+
+    mdp = recup_secret("factrice.smtp.mdp", config=ma_config)
+    if mdp is not None:
+        serveur.login(user, mdp.reveler())  # .reveler() UNIQUEMENT au point d'usage
+
+``str(mdp)``, ``repr(mdp)``, un f-string ou le logging affichent tous ``***`` :
+la valeur réelle n'est accessible que via :meth:`Secret.reveler`.
+"""
+
+import os
+import shlex
+from configparser import ConfigParser, NoOptionError, NoSectionError
+from typing import Any, Dict, List, Optional, Protocol
+
+import attr
+
+from automatheque.greffon import Greffon, signale_appel
+from automatheque.greffon.capacite import Capacite
+
+#: Chaîne affichée à la place d'un secret dans les représentations textuelles.
+CAVIARDAGE = "***"
+
+
+@attr.s(repr=False, eq=False)
+class Secret:
+    """Enveloppe une valeur sensible dont le ``repr``/``str`` est **caviardé**.
+
+    La valeur réelle n'est accessible que via :meth:`reveler` — jamais via
+    ``str()``, ``repr()``, un f-string ou le logging, qui affichent tous
+    :data:`CAVIARDAGE`. Cela évite les fuites accidentelles dans les logs et les
+    tracebacks.
+    """
+
+    _valeur: str = attr.ib()
+
+    def reveler(self) -> str:
+        """Renvoie la valeur réelle (à n'utiliser qu'au point d'usage)."""
+        return self._valeur
+
+    def __str__(self) -> str:
+        return CAVIARDAGE
+
+    def __repr__(self) -> str:
+        return "Secret({})".format(CAVIARDAGE)
+
+
+class ResoudreSecret(Capacite, Protocol):
+    """Capacité : **résoudre** une clé logique en la valeur brute d'un secret.
+
+    Un greffon qui déclare cette capacité (``CAPACITES = [ResoudreSecret]``)
+    implémente :meth:`resout_secret`, renvoyant la valeur (chaîne brute) ou
+    ``None`` s'il ne connaît pas la clé. :func:`recup_secret` enveloppe ensuite
+    cette valeur dans un :class:`Secret`.
+    """
+
+    def resout_secret(self, cle: str) -> Optional[str]: ...
+
+
+@attr.s(eq=False)
+class GreffonSecretEnv(Greffon):
+    """Greffon **variable d'environnement**.
+
+    ``factrice.smtp.mdp`` → variable ``FACTRICE_SMTP_MDP`` (majuscules, ``.`` et
+    ``-`` remplacés par ``_``).
+    """
+
+    CAPACITES = [ResoudreSecret]
+
+    @signale_appel
+    def resout_secret(self, cle: str) -> Optional[str]:
+        nom = cle.upper().replace(".", "_").replace("-", "_")
+        return os.environ.get(nom)
+
+
+@attr.s(eq=False)
+class GreffonSecretConfig(Greffon):
+    """Greffon **configuration** : ``section.option`` → ``config.get(...)``.
+
+    La clé est coupée sur le **dernier** point : ``factrice.smtp.mdp`` →
+    section ``factrice.smtp``, option ``mdp``. Par défaut le greffon lit sa
+    propre configuration (``self.config``) ; on peut lui imposer un
+    :class:`~configparser.ConfigParser` précis via ``source``.
+    """
+
+    CAPACITES = [ResoudreSecret]
+
+    source: Optional[ConfigParser] = attr.ib(
+        default=None,
+        kw_only=True,
+        validator=attr.validators.optional(attr.validators.instance_of(ConfigParser)),
+    )
+
+    @signale_appel
+    def resout_secret(self, cle: str) -> Optional[str]:
+        conf = self.source if self.source is not None else self.config
+        section, _, option = cle.rpartition(".")
+        if not section or not option:
+            return None
+        try:
+            return conf.get(section, option)
+        except (NoSectionError, NoOptionError):
+            return None
+
+
+@attr.s(eq=False)
+class GreffonSecretKeyring(Greffon):
+    """Greffon **trousseau système** (dépendance optionnelle ``keyring``).
+
+    Si ``keyring`` n'est pas installé, le greffon est **neutre** (renvoie
+    ``None``) plutôt que d'échouer.
+    """
+
+    CAPACITES = [ResoudreSecret]
+
+    service: str = attr.ib(default="automatheque", kw_only=True)
+
+    @signale_appel
+    def resout_secret(self, cle: str) -> Optional[str]:
+        try:
+            import keyring
+        except ImportError:
+            return None
+        return keyring.get_password(self.service, cle)
+
+
+@attr.s(eq=False)
+class GreffonSecretCommande(Greffon):
+    """Greffon **commande externe** : la sortie standard de la commande EST le secret.
+
+    ``gabarit`` peut contenir ``{cle}`` (substituée). La commande est découpée
+    avec :func:`shlex.split` et exécutée **sans shell** via ``Executant``
+    (``subprocess.run(liste)``) — donc pas d'injection.
+    """
+
+    CAPACITES = [ResoudreSecret]
+
+    gabarit: str = attr.ib(default="", kw_only=True)
+
+    @signale_appel
+    def resout_secret(self, cle: str) -> Optional[str]:
+        from automatheque.util.dependances_externes import Executant
+
+        cmd, *args = shlex.split(self.gabarit.format(cle=cle))
+        sortie = Executant(cmd).exec(*args, encoding="utf-8").stdout or ""
+        return sortie.strip("\n") or None
+
+
+#: Cache des greffons résolveurs *par défaut* : le registre des greffons est
+#: **persistant** (toute instance y reste), donc on réutilise un unique greffon
+#: par configuration plutôt que d'en créer un à chaque appel de :func:`recup_secret`.
+_RESOLVEURS: Dict[Any, ResoudreSecret] = {}
+
+
+def _resolveur(cle_cache: Any, fabrique) -> ResoudreSecret:
+    """Renvoie le greffon résolveur mis en cache pour ``cle_cache`` (le crée sinon)."""
+    resolveur = _RESOLVEURS.get(cle_cache)
+    if resolveur is None:
+        resolveur = _RESOLVEURS[cle_cache] = fabrique()
+    return resolveur
+
+
+def recup_secret(
+    cle: str,
+    config: Optional[ConfigParser] = None,
+    resolveurs: Optional[List[ResoudreSecret]] = None,
+) -> Optional[Secret]:
+    """Résout ``cle`` via des greffons **dans l'ordre** ; premier gagnant.
+
+    Ordre par défaut : **variable d'environnement** (:class:`GreffonSecretEnv`)
+    puis, si ``config`` est fourni, la **configuration**
+    (:class:`GreffonSecretConfig`). Pour un ordre ou des sources personnalisés
+    (trousseau, commande externe…), passer ``resolveurs`` : une liste ordonnée
+    de greffons rendant la capacité :class:`ResoudreSecret` (p. ex.
+    :class:`GreffonSecretKeyring`, :class:`GreffonSecretCommande`).
+
+    :returns: un :class:`Secret` (caviardé) ou ``None`` si aucun greffon ne
+        fournit la clé.
+    """
+    if resolveurs is None:
+        resolveurs = [_resolveur("env", GreffonSecretEnv)]
+        if config is not None:
+            resolveurs.append(
+                _resolveur(
+                    ("config", id(config)),
+                    lambda: GreffonSecretConfig(source=config),
+                )
+            )
+    for resolveur in resolveurs:
+        valeur = resolveur.resout_secret(cle)
+        if valeur is not None:
+            return Secret(valeur)
+    return None

--- a/src/automatheque/tests/test_secret.py
+++ b/src/automatheque/tests/test_secret.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""Tests du module secret (objet caviardé + greffons résolveurs, #8)."""
+
+from configparser import ConfigParser
+from typing import Optional
+from unittest.mock import MagicMock
+
+from automatheque.secret import (
+    GreffonSecretCommande,
+    GreffonSecretConfig,
+    GreffonSecretEnv,
+    GreffonSecretKeyring,
+    ResoudreSecret,
+    Secret,
+    recup_secret,
+)
+
+# --- Secret : caviardage -----------------------------------------------------
+
+
+def test_secret_reveler_renvoie_la_valeur():
+    assert Secret("mon-mot-de-passe").reveler() == "mon-mot-de-passe"
+
+
+def test_secret_str_est_caviarde():
+    s = Secret("mon-mot-de-passe")
+    assert str(s) == "***"
+    assert "mon-mot-de-passe" not in str(s)
+
+
+def test_secret_repr_est_caviarde():
+    s = Secret("mon-mot-de-passe")
+    assert repr(s) == "Secret(***)"
+    assert "mon-mot-de-passe" not in repr(s)
+
+
+def test_secret_ne_fuite_pas_en_fstring_ni_format():
+    s = Secret("xyz")
+    assert f"mdp={s}" == "mdp=***"
+    assert "mdp={}".format(s) == "mdp=***"
+    assert "mdp=%s" % s == "mdp=***"
+
+
+def test_secret_ne_fuite_pas_dans_les_logs(caplog):
+    import logging
+
+    s = Secret("ultra-secret")
+    with caplog.at_level(logging.INFO):
+        logging.getLogger("t").info("mdp=%s", s)
+    assert "ultra-secret" not in caplog.text
+    assert "***" in caplog.text
+
+
+# --- Greffons résolveurs -----------------------------------------------------
+
+
+def test_greffon_env(monkeypatch):
+    monkeypatch.setenv("FACTRICE_SMTP_MDP", "depuis-env")
+    g = GreffonSecretEnv()
+    assert g.resout_secret("factrice.smtp.mdp") == "depuis-env"
+    assert g.resout_secret("absente.quelque.part") is None
+
+
+def test_greffon_config():
+    c = ConfigParser()
+    c.add_section("factrice.smtp")
+    c.set("factrice.smtp", "mdp", "depuis-config")
+    g = GreffonSecretConfig(source=c)
+    assert g.resout_secret("factrice.smtp.mdp") == "depuis-config"
+    assert g.resout_secret("factrice.smtp.absente") is None  # option absente
+    assert g.resout_secret("section.inexistante.x") is None  # section absente
+    assert g.resout_secret("sanspoint") is None  # pas de section extractible
+
+
+def test_greffons_declarent_bien_la_capacite():
+    """Chaque greffon résolveur déclare la capacité ResoudreSecret."""
+    for classe in (
+        GreffonSecretEnv,
+        GreffonSecretConfig,
+        GreffonSecretKeyring,
+        GreffonSecretCommande,
+    ):
+        assert ResoudreSecret in classe.CAPACITES
+
+
+def test_greffon_keyring_absent_est_neutre(monkeypatch):
+    """Sans le paquet `keyring`, le greffon renvoie None (ne casse pas)."""
+    import builtins
+
+    vrai_import = builtins.__import__
+
+    def faux_import(nom, *a, **k):
+        if nom == "keyring":
+            raise ImportError("pas de keyring")
+        return vrai_import(nom, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", faux_import)
+    assert GreffonSecretKeyring().resout_secret("factrice.smtp.mdp") is None
+
+
+def test_greffon_commande(monkeypatch):
+    """La sortie de la commande (nettoyée) devient le secret."""
+    faux_exec = MagicMock()
+    faux_exec.exec.return_value = MagicMock(stdout="  le-jeton\n")
+    classe = MagicMock(return_value=faux_exec)
+    monkeypatch.setattr("automatheque.util.dependances_externes.Executant", classe)
+
+    g = GreffonSecretCommande(gabarit="pass show {cle}")
+    assert g.resout_secret("factrice.smtp.mdp") == "  le-jeton"  # strip \n seulement
+    # cmd/args découpés par shlex, {cle} substituée
+    classe.assert_called_once_with("pass")
+    assert faux_exec.exec.call_args.args == ("show", "factrice.smtp.mdp")
+
+
+# --- recup_secret : résolution ordonnée --------------------------------------
+
+
+def test_recup_secret_depuis_env(monkeypatch):
+    monkeypatch.setenv("FACTRICE_SMTP_MDP", "e")
+    s = recup_secret("factrice.smtp.mdp")
+    assert isinstance(s, Secret)
+    assert s.reveler() == "e"
+
+
+def test_recup_secret_depuis_config(monkeypatch):
+    monkeypatch.delenv("FACTRICE_SMTP_MDP", raising=False)
+    c = ConfigParser()
+    c.add_section("factrice.smtp")
+    c.set("factrice.smtp", "mdp", "c")
+    assert recup_secret("factrice.smtp.mdp", config=c).reveler() == "c"
+
+
+def test_recup_secret_env_prioritaire_sur_config(monkeypatch):
+    monkeypatch.setenv("FACTRICE_SMTP_MDP", "env-gagne")
+    c = ConfigParser()
+    c.add_section("factrice.smtp")
+    c.set("factrice.smtp", "mdp", "config-perd")
+    assert recup_secret("factrice.smtp.mdp", config=c).reveler() == "env-gagne"
+
+
+def test_recup_secret_introuvable_renvoie_none(monkeypatch):
+    monkeypatch.delenv("FACTRICE_SMTP_MDP", raising=False)
+    assert recup_secret("factrice.smtp.mdp") is None
+
+
+def test_recup_secret_resolveurs_personnalises():
+    """On peut fournir sa propre liste ordonnée de greffons résolveurs."""
+
+    class ResolveurMuet:
+        def resout_secret(self, cle: str) -> Optional[str]:
+            return None
+
+    class ResolveurFixe:
+        def resout_secret(self, cle: str) -> Optional[str]:
+            return "depuis-b2"
+
+    s = recup_secret("x", resolveurs=[ResolveurMuet(), ResolveurFixe()])
+    assert s.reveler() == "depuis-b2"


### PR DESCRIPTION
## Description

Nouveau module **`automatheque.secret`** (cf. #8).

### `Secret` — anti-fuite
Enveloppe une valeur sensible dont `repr` / `str` / f-string / logging affichent
tous **`***`** ; la valeur réelle n'est accessible que via **`.reveler()`**
(au point d'usage). Évite les fuites accidentelles d'identifiants/jetons dans
les logs et les tracebacks.

```python
from automatheque.secret import recup_secret
mdp = recup_secret("factrice.smtp.mdp", config=ma_config)
serveur.login(user, mdp.reveler())   # str(mdp) / logs → "***"
```

### Sources de secrets = **greffons**
Les backends sont des **greffons** (`automatheque.greffon`) rendant la capacité
**`ResoudreSecret`** (`resout_secret(cle) -> Optional[str]`) — on privilégie le
système de greffons pour toute source enfichable. Greffons fournis :

* **`GreffonSecretEnv`** — variable d'environnement (`factrice.smtp.mdp` →
  `FACTRICE_SMTP_MDP`) ;
* **`GreffonSecretConfig`** — configuration (`section.option`), sur le
  `ConfigParser` passé via `source=` ou, à défaut, sa propre `self.config` ;
* **`GreffonSecretKeyring`** — trousseau système (dépendance optionnelle
  `keyring`, **neutre si absente**) ;
* **`GreffonSecretCommande`** — commande externe via `Executant` (sans shell,
  `shlex.split`, `{cle}` substituée).

### `recup_secret` — résolution ordonnée
Essaie les greffons **dans l'ordre** ; premier gagnant. Par défaut : **variable
d'environnement** puis, si fournie, la **configuration**. Ordre/sources
personnalisables via `resolveurs=` (liste ordonnée de greffons rendant
`ResoudreSecret`). Les résolveurs par défaut sont **mis en cache** (le registre
des greffons est persistant : on évite d'en recréer un à chaque appel).

## Historique de conception
La première version proposait des backends *callables* légers ; suite au retour
« en règle générale je préfère les greffons », les backends sont désormais des
greffons rendant une capacité — cohérent avec le reste d'`automatheque`. La
capacité a été renommée `PeutResoudreSecret` → **`ResoudreSecret`**.

> À noter : #98 (le registre des greffons préserve l'ordre d'insertion) rend
> `greffons_par_capacite` déterministe. Le cache de `recup_secret` reste utile
> (éviter de ré-enregistrer un greffon à chaque appel), mais la précédence
> env > config est portée par une liste ordonnée explicite — indépendante du
> registre.

## Tests
Caviardage (`str`/`repr`/f-string/`%`/logging ne fuient pas ; `reveler` rend la
valeur), chaque greffon (env, config, keyring absent = neutre, commande via
`Executant` mocké, déclaration de capacité), résolution ordonnée (env prioritaire
sur config, config, `None`, `resolveurs` custom). Suite `automatheque` **verte**
(143 passés), `ruff`/`format`/`mypy` verts (ruff 0.16.0, mypy 1.19.1).

## Lien avec #15
Fournit la **primitive** pour le durcissement des logs de `factrice` (envelopper
`mdp`/jeton dans un `Secret`). Le filtre de redaction générique des logs reste
un pas suivant.

## Note versioning
`automatheque` uniquement.

## Issues liées
Closes #8
