### PR TITLE
fix(structures): les registres d'instances préservent l'ordre d'insertion

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * documentation d'usage (README) : à quoi sert le module et exemples
     (`Secret`, `recup_secret`, résolveurs personnalisés).
 
+### Fixed
+
+* `conception.structures` — les registres d'instances (`MetaInstanceRegistre`,
+  `MetaInstancePersistanteRegistre`) **préservent l'ordre d'insertion** : le
+  stockage passe d'un `set` (ordre arbitraire) à un dict/`WeakKeyDictionary`
+  utilisé comme ensemble ordonné, et le dédoublonnage de `_instances()` conserve
+  l'ordre (`dict.fromkeys`). Les recherches qui s'appuient dessus deviennent
+  **déterministes** — notamment `Greffon.greffons_par_capacite`, dont l'ordre
+  reflète désormais l'ordre d'enregistrement des greffons.
+
 ## [0.18.0] - 2026-07-24
 
 ### Added

--- a/src/automatheque/automatheque/conception/structures/registre.py
+++ b/src/automatheque/automatheque/conception/structures/registre.py
@@ -19,8 +19,11 @@ que l'on peut parcourir grâce à RegistreElements._instances(inclure_enfants=Tr
 NB: On peut également utiliser Element._instances() pour avoir accès à toutes les
 instances d'Element.
 
-Il s'agit d'un set que l'on peut ensuite parcourir pour trouver celle que l'on
-souhaite.
+Le stockage se fait dans un **dict utilisé comme ensemble ordonné** (les valeurs
+sont ignorées) : on **dédoublonne** les instances tout en **préservant l'ordre
+d'insertion**. `_instances()` renvoie donc les instances dans l'ordre où elles
+ont été créées, ce qui rend déterministes les recherches qui s'appuient dessus
+(p. ex. `greffons_par_capacite`).
 
 NB: La classe fille doit être hashable. Si l'on utilise attrs il faut penser à déclarer
     @attr.s(eq=False) pour activer le hashage.
@@ -88,15 +91,17 @@ class MetaInstanceRegistre(type):
         # Lors de la création **de la classe** du registre (et pas de l'instance)
         super(MetaInstanceRegistre, cls).__init__(name, bases, attrs)
 
-        # Initialise le stockage des instances, pas besoin pour l'instant d'une
-        # "weak ref"
-        cls.__instances = weakref.WeakSet()
+        # Stockage "weak ref" **ordonné** : une WeakKeyDictionary (adossée à un
+        # dict) dédoublonne et préserve l'ordre d'insertion, là où une WeakSet
+        # perdrait l'ordre. Les instances non référencées ailleurs disparaissent
+        # au passage du ramasse-miettes.
+        cls.__instances = weakref.WeakKeyDictionary()
 
     def __call__(cls, *args, **kwargs):
         # Crée l'instance (appelle les méthodes __init__ et __new__)
         inst = super(MetaInstanceRegistre, cls).__call__(*args, **kwargs)
 
-        cls.__instances.add(inst)  # inst doit être hashable
+        cls.__instances[inst] = None  # inst doit être hashable
 
         return inst
 
@@ -104,14 +109,15 @@ class MetaInstanceRegistre(type):
         """Renvoie les instances de **cette classe** stockées dans le registre.
 
         Si inclure_enfants=True, on renvoie aussi les instances des sous-classes.
+        L'ordre d'insertion (ordre de création) est **préservé**.
         """
         instances = list(cls.__instances)
         if inclure_enfants:
             for child in cls.__subclasses__():
                 instances += child._instances(inclure_enfants=inclure_enfants)
 
-        # Remove duplicates from multiple inheritance.
-        return list(set(instances))
+        # Dédoublonne (héritage multiple) EN préservant l'ordre d'insertion.
+        return list(dict.fromkeys(instances))
 
 
 class MetaInstancePersistanteRegistre(type):
@@ -150,15 +156,16 @@ class MetaInstancePersistanteRegistre(type):
         # Lors de la création **de la classe** du registre (et pas de l'instance)
         super(MetaInstancePersistanteRegistre, cls).__init__(name, bases, attrs)
 
-        # Initialise le stockage des instances, pas besoin pour l'instant d'une
-        # "weak ref"
-        cls.__instances = set()
+        # Stockage des instances dans un dict utilisé comme **ensemble ordonné**
+        # (valeurs ignorées) : on dédoublonne SANS perdre l'ordre d'insertion
+        # (un `set` déduplique mais perd l'ordre). Pas besoin de "weak ref" ici.
+        cls.__instances = {}
 
     def __call__(cls, *args, **kwargs):
         # Crée l'instance (appelle les méthodes __init__ et __new__)
         inst = super(MetaInstancePersistanteRegistre, cls).__call__(*args, **kwargs)
 
-        cls.__instances.add(inst)  # inst doit être hashable
+        cls.__instances[inst] = None  # inst doit être hashable
 
         return inst
 
@@ -166,11 +173,12 @@ class MetaInstancePersistanteRegistre(type):
         """Renvoie les instances de **cette classe** stockées dans le registre.
 
         Si inclure_enfants=True, on renvoie aussi les instances des sous-classes.
+        L'ordre d'insertion (ordre de création) est **préservé**.
         """
         instances = list(cls.__instances)
         if inclure_enfants:
             for child in cls.__subclasses__():
                 instances += child._instances(inclure_enfants=inclure_enfants)
 
-        # Remove duplicates from multiple inheritance.
-        return list(set(instances))
+        # Dédoublonne (héritage multiple) EN préservant l'ordre d'insertion.
+        return list(dict.fromkeys(instances))

--- a/src/automatheque/tests/test_registre.py
+++ b/src/automatheque/tests/test_registre.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Tests des registres d'instances : dédoublonnage **sans perte d'ordre**.
+
+Le stockage se fait dans un dict (ensemble ordonné) et non un `set` : les
+instances sont donc renvoyées dans l'ordre de création. C'est ce qui rend
+déterministes les recherches qui s'appuient dessus (p. ex.
+`greffons_par_capacite`).
+"""
+
+import gc
+
+from automatheque.conception.structures import (
+    MetaInstancePersistanteRegistre,
+    MetaInstanceRegistre,
+)
+
+
+def test_persistante_preserve_lordre_dinsertion():
+    class R(metaclass=MetaInstancePersistanteRegistre):
+        def __init__(self, nom):
+            self.nom = nom
+
+    instances = [R(str(i)) for i in range(12)]
+    # mêmes objets, dans l'ordre de création (et non un ordre de set arbitraire)
+    assert R._instances() == instances
+
+
+def test_persistante_dedoublonne_enfants_en_preservant_lordre():
+    class Base(metaclass=MetaInstancePersistanteRegistre):
+        pass
+
+    class Enfant(Base):
+        pass
+
+    a = Base()
+    b = Enfant()
+    c = Base()
+
+    res = Base._instances(inclure_enfants=True)
+    # les 3 instances, sans doublon
+    assert set(res) == {a, b, c}
+    assert len(res) == 3
+    # instances propres de Base d'abord, dans l'ordre d'insertion, puis enfants
+    assert res.index(a) < res.index(c) < res.index(b)
+
+
+def test_weak_preserve_lordre_des_instances_vivantes():
+    class RW(metaclass=MetaInstanceRegistre):
+        def __init__(self, nom):
+            self.nom = nom
+
+    vivantes = [RW(str(i)) for i in range(6)]
+    # une instance non référencée disparaît du registre (weak ref) : on ne garde
+    # que les vivantes, et dans l'ordre de création.
+    RW("ephemere")
+    gc.collect()
+    assert RW._instances() == vivantes


### PR DESCRIPTION
## Description

Les registres d'instances (`conception.structures`) stockaient les instances
dans un **`set`** : il déduplique bien, mais **perd l'ordre**. Or le `set`
n'était là que pour éviter les doublons — pas pour renoncer à l'ordre
d'insertion. `_instances()` terminait de surcroît par `list(set(...))`, achevant
de rendre l'ordre arbitraire.

Résultat : `Greffon.greffons_par_capacite` (qui s'appuie sur `_instances`)
renvoyait les greffons dans un ordre **non déterministe** — gênant dès qu'on veut
une précédence stable entre greffons d'une même capacité.

## Changement

* **`MetaInstancePersistanteRegistre`** : `set` → **dict utilisé comme ensemble
  ordonné** (valeurs ignorées) — dédoublonne *et* préserve l'ordre.
* **`MetaInstanceRegistre`** : `weakref.WeakSet` → **`weakref.WeakKeyDictionary`**
  (adossée à un dict, donc ordonnée ; les instances non référencées ailleurs
  disparaissent toujours au ramasse-miettes).
* **`_instances()`** : dédoublonnage via **`dict.fromkeys`** (préserve l'ordre)
  au lieu de `list(set(...))`.

Aucun changement d'API : même signatures, même sémantique de dédoublonnage — on
ajoute seulement la **garantie d'ordre**.

## Pourquoi pas un index par capacité

Écarté volontairement : indexer `capacité → greffons` ajouterait un état à tenir
cohérent pour un registre de très petite taille. Le filtrage à la lecture
(`greffons_par_capacite`) suffit ; c'est l'ordre qu'il fallait corriger.

## Tests

Nouveau `tests/test_registre.py` : ordre d'insertion préservé (registre
persistant **et** faible), dédoublonnage des enfants sans réordonner, disparition
d'une instance faible non référencée. Suite `automatheque` verte (146),
`ruff`/`format`/`mypy` verts.

## Note versioning

`automatheque` uniquement.
