### PR TITLE
release 0.19.0 : dogfooding secret dans factrice (#8) + co-release automatheque/factrice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,24 @@ jobs:
               assert m, "Dépendance intra-dépôt sans plancher '>=' : {!r}".format(dep)
               pins.append("{}=={}".format(m.group(1), m.group(2)))
 
-          print("Planchers installés depuis PyPI :", pins)
-          subprocess.check_call([sys.executable, "-m", "pip", "install", *pins])
+          print("Planchers déclarés :", pins)
+          for pin in pins:
+              nom, _, _version = pin.partition("==")
+              try:
+                  subprocess.check_call([sys.executable, "-m", "pip", "install", pin])
+              except subprocess.CalledProcessError:
+                  # Le plancher déclaré n'est pas (encore) publié sur PyPI —
+                  # typiquement une version intra-dépôt livrée dans le MÊME cycle
+                  # (co-release). On se rabat sur le build LOCAL (qui deviendra
+                  # cette version) pour tester quand même factrice contre ce code,
+                  # en le SIGNALANT (::warning::) pour ne pas masquer un plancher
+                  # fantôme (version jamais publiée par erreur).
+                  local = "src/" + nom
+                  print(
+                      "::warning::plancher {} introuvable sur PyPI ; "
+                      "repli sur le build local {}".format(pin, local)
+                  )
+                  subprocess.check_call([sys.executable, "-m", "pip", "install", local])
           PY
 
       - name: Installe factrice depuis les sources (sans toucher aux planchers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.18.0"
+version = "0.19.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-27
+
 ### Security
 
 * `expedition.ExpeditriceSmtp` — durcissement (cf. #15) :

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     gérés) au lieu de `str.split(" ")`. (Pas d'injection shell : `Executant`
     utilise `subprocess.run(liste)`.)
 
+### Changed
+
+* `expedition.ExpeditriceSmtp` — le mot de passe SMTP est désormais récupéré via
+  **`automatheque.secret.recup_secret`** (cf. #8) : il peut provenir de la
+  **variable d'environnement `FACTRICE_SMTP_MDP`** (override), sinon de
+  `[factrice.smtp] mdp`, et il est manipulé comme un **`Secret`** (caviardé dans
+  les logs/tracebacks, `.reveler()` au seul point d'usage). Comportement
+  inchangé quand `mdp` n'est défini qu'en configuration.
+* Dépendance : plancher **`automatheque>=0.19.0`** (module `secret`).
+
 ## [0.17.0] - 2026-07-24
 
 ### Changed

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -15,6 +15,7 @@ import attr
 from automatheque.configuration import NoOptionError, charge_configuration
 from automatheque.factrice.preparation import SEPARATEUR_DESTINATAIRES, PreparatriceSmtp
 from automatheque.schema.texte import Courriel
+from automatheque.secret import recup_secret
 from automatheque.util.dependances_externes import Executant, charge_dependance
 from automatheque.util.fichier import enleve_caracteres_invalides
 
@@ -171,9 +172,19 @@ class ExpeditriceSmtp(Expeditrice):
             # directement avec la chaine xoauth2 non encodée en b64.
             self.s.docmd("AUTH", "XOAUTH2 " + oauth_jeton)
         else:
+            # Le mot de passe passe par `recup_secret` (#8) : il peut venir de la
+            # variable d'environnement `FACTRICE_SMTP_MDP` (override) ou, à défaut,
+            # de `[factrice.smtp] mdp`, et il est enveloppé dans un `Secret`
+            # (caviardé dans les logs/tracebacks). On ne `.reveler()` qu'au point
+            # d'usage : l'appel à `login`.
+            mdp = recup_secret("factrice.smtp.mdp", config=self.config)
+            if mdp is None:
+                # Cohérent avec l'ancien comportement (mdp absent → NoOptionError,
+                # rattrapé plus haut pour le cas d'un compte anonyme).
+                raise NoOptionError("mdp", "factrice.smtp")
             self.s.login(
                 self.config.get("factrice.smtp", "identifiant"),
-                self.config.get("factrice.smtp", "mdp"),
+                mdp.reveler(),
             )
 
     def expedie(self, courriel: Courriel):

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -16,9 +16,10 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    # >=0.14.0 : `ExpeditriceSmtp` utilise `Executant.exec(encoding=...)`,
-    # ajouté dans automatheque 0.14.0 (#66).
-    "automatheque>=0.14.0",
+    # >=0.19.0 : `ExpeditriceSmtp` utilise `automatheque.secret.recup_secret`
+    # pour récupérer le mot de passe SMTP (#8), module ajouté en automatheque
+    # 0.19.0. (Auparavant >=0.14.0 pour `Executant.exec(encoding=...)`, #66.)
+    "automatheque>=0.19.0",
     # >=0.9.7 : factrice construit un `Courriel` SANS émetteur (celui-ci est
     # rempli ensuite par l'expéditrice, depuis la configuration). Or l'émetteur
     # n'est devenu **facultatif** dans le constructeur de `Courriel` qu'en

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.factrice"
-version = "0.17.0"
+version = "0.19.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-27
+
 ### Added
 
 * `secret` : nouveau module de **gestion des secrets** (cf. #8).

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.18.0"
+version = "0.19.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
## Description

**Co-release `0.19.0`** (un seul tag publie `automatheque` **et**
`automatheque.factrice`), portée par le premier **dogfooding** du module
`secret` (#8).

### Dogfooding — `ExpeditriceSmtp.__connecter`
Le mot de passe SMTP passe par **`recup_secret`** au lieu d'un `config.get(...)`
brut :
* il peut venir de la **variable d'environnement `FACTRICE_SMTP_MDP`**
  (override), sinon de `[factrice.smtp] mdp` ;
* il est manipulé comme un **`Secret`** (caviardé dans les logs/tracebacks) et
  n'est `.reveler()` **qu'au point d'usage** (l'appel à `login`) ;
* **comportement inchangé** quand `mdp` n'est défini qu'en configuration ; `mdp`
  absent partout → `NoOptionError` (rattrapé plus haut pour le compte anonyme).

### Versions (lockstep monas)
Les deux paquets **modifiés** prennent la nouvelle version globale ;
`monas.version == max == 0.19.0` ; `automatheque.schema` reste en `0.15.0` (non
republié).

* `automatheque` `0.18.0 → 0.19.0` — module `secret` (#8) + registres d'instances
  ordonnés (#98).
* `automatheque.factrice` `0.17.0 → 0.19.0` — durcissement SMTP (#15) + mot de
  passe via `recup_secret` (#8). Le plancher **`automatheque>=0.19.0`** est
  satisfait par la version co-livrée.
* CHANGELOG des deux paquets : `[Unreleased] → [0.19.0] - 2026-07-27`.

Le tag `0.19.0` publiera `automatheque` et `factrice` (tous deux en `0.19.0`),
pas `schema`.

### CI — `tests-plancher` tolère un plancher co-livré
Le job installe les planchers intra-dépôt **depuis PyPI**. `automatheque 0.19.0`
n'y est pas encore au moment de la PR : le job **se rabat sur le build local**
quand un plancher n'est pas publié, en le **signalant** (`::warning::`) pour ne
pas masquer un plancher fantôme. Une fois `0.19.0` publié (au tag), les
exécutions suivantes réinstallent le vrai plancher depuis PyPI.

## Tests

Suites `automatheque` (146) et `factrice` (25) vertes ; `ruff`/`format` verts,
`mypy` du cœur `automatheque` vert. Les tests SMTP existants passent sans
modification.

## Issues liées

cf. #8, #15
