### PR TITLE
feat(secret): filtre de caviardage des logs (clôt #15)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+* `expedition.ExpeditriceSmtp` — le **jeton OAuth** est désormais enveloppé dans
+  un `Secret` (comme le mot de passe) : caviardé dans les logs/tracebacks et pris
+  en compte par le filtre de caviardage d'automatheque (`FiltreCaviardage`). Ceci
+  clôt le volet « redaction des logs » de #15.
+
 ## [0.19.0] - 2026-07-27
 
 ### Security

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -15,7 +15,7 @@ import attr
 from automatheque.configuration import NoOptionError, charge_configuration
 from automatheque.factrice.preparation import SEPARATEUR_DESTINATAIRES, PreparatriceSmtp
 from automatheque.schema.texte import Courriel
-from automatheque.secret import recup_secret
+from automatheque.secret import Secret, recup_secret
 from automatheque.util.dependances_externes import Executant, charge_dependance
 from automatheque.util.fichier import enleve_caracteres_invalides
 
@@ -165,12 +165,17 @@ class ExpeditriceSmtp(Expeditrice):
                     "chemin dans [factrice.smtp] oauth_cmd."
                 ),
             )
-            oauth_jeton = executant.exec(*args, encoding="utf-8").stdout.strip("\n")
-            # LOGGER.debug("jeton oauth : " + oauth_jeton)
+            # Jeton OAuth enveloppé dans un `Secret` (#8/#15) : caviardé dans les
+            # logs/tracebacks et pris en compte par le filtre de caviardage. On
+            # ne `.reveler()` qu'au point d'usage (la commande AUTH).
+            oauth_jeton = Secret(
+                executant.exec(*args, encoding="utf-8").stdout.strip("\n")
+            )
+            # LOGGER.debug("jeton oauth : %s", oauth_jeton)  # affiche « *** »
             self.s.ehlo(oauth_client_id)
             # On pourrait utiliser self.s.auth, mais il faut travailler
             # directement avec la chaine xoauth2 non encodée en b64.
-            self.s.docmd("AUTH", "XOAUTH2 " + oauth_jeton)
+            self.s.docmd("AUTH", "XOAUTH2 " + oauth_jeton.reveler())
         else:
             # Le mot de passe passe par `recup_secret` (#8) : il peut venir de la
             # variable d'environnement `FACTRICE_SMTP_MDP` (override) ou, à défaut,

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `secret` / `log` — **caviardage des logs** (cf. #15) :
+  * **`FiltreCaviardage`** (`logging.Filter`) remplace par `***` la valeur de
+    tout `Secret` **vivant** qui apparaîtrait dans un message journalisé
+    (défense en profondeur : rattrape une valeur `reveler()` loggée par erreur) ;
+  * `Secret` utilise le patron **Registre d'instances faibles**
+    (`MetaInstanceRegistre`) : chaque secret créé y est référencé faiblement, le
+    filtre les retrouve via `Secret._instances()` — rien à enregistrer à la main ;
+  * `configure_logging_defaut()` installe le filtre sur le handler racine ;
+    **`installe_caviardage(logger=None)`** l'ajoute (idempotent) aux handlers
+    d'un logger pour une configuration de log maison.
+
 ## [0.19.0] - 2026-07-27
 
 ### Added

--- a/src/automatheque/README.md
+++ b/src/automatheque/README.md
@@ -148,6 +148,30 @@ mdp = recup_secret(
 )
 ```
 
+### Caviardage des logs (défense en profondeur)
+
+La configuration de log par défaut (`configure_logging_defaut()`, appelée par un
+script `@script_automatheque`) installe un **filtre de caviardage** : si la
+valeur d'un `Secret` vivant apparaît dans un message de log, elle est remplacée
+par `***`.
+
+```python
+mdp = recup_secret("factrice.smtp.mdp", config=_script.config)
+logging.getLogger(__name__).info("connexion mdp=%s", mdp.reveler())
+# → journalisé : « connexion mdp=*** »  (même la valeur révélée est rattrapée)
+```
+
+La première ligne de défense reste de ne jamais logger un secret en clair
+(`Secret` est déjà caviardé par `str`/`repr`) ; le filtre rattrape les fuites
+indirectes. Si tu configures le logging toi-même (dictConfig maison), pose le
+filtre sur tes handlers avec `installe_caviardage()` :
+
+```python
+from automatheque.log import installe_caviardage
+
+installe_caviardage()  # racine par défaut (couvre les loggers enfants)
+```
+
 ## Configuration du logging
 
 Automathèque **ne configure rien à l'import** (une bibliothèque ne doit pas

--- a/src/automatheque/automatheque/constantes.py
+++ b/src/automatheque/automatheque/constantes.py
@@ -37,10 +37,17 @@ logger_config_dict = {
     "formatters": {
         "automatheque": {"format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"}
     },
+    # Caviardage des secrets (cf. #15) : posé sur le handler pour couvrir aussi
+    # les enregistrements propagés des loggers enfants. Résolu paresseusement
+    # par dictConfig (pas d'import de `secret` au chargement de ce module).
+    "filters": {
+        "caviardage": {"()": "automatheque.secret.FiltreCaviardage"},
+    },
     "handlers": {
         "automatheque": {
             "formatter": "automatheque",
             "class": "logging.StreamHandler",
+            "filters": ["caviardage"],
         }
     },
     # Un script EST une application : sa configuration de log vise la **racine**

--- a/src/automatheque/automatheque/log.py
+++ b/src/automatheque/automatheque/log.py
@@ -54,12 +54,36 @@ def logger_existe(nom):
 def configure_logging_defaut():
     """Active la configuration de logging par défaut d'automatheque.
 
-    Pose un handler console sur le logger ``automatheque``. À appeler par une
-    **application** (un script, p. ex. via ``@script_automatheque``), jamais à
-    l'import d'une bibliothèque : configurer le logging global est le rôle de
-    l'application, pas de la lib.
+    Pose un handler console sur la **racine** (root), muni du filtre de
+    caviardage des secrets (cf. :class:`automatheque.secret.FiltreCaviardage`).
+    À appeler par une **application** (un script, p. ex. via
+    ``@script_automatheque``), jamais à l'import d'une bibliothèque : configurer
+    le logging global est le rôle de l'application, pas de la lib.
     """
     configure_logging(logger_config_dict)
+
+
+def installe_caviardage(logger=None):
+    """Installe le filtre de **caviardage des secrets** sur les handlers d'un logger.
+
+    Par défaut la **racine** (root) : le filtre étant posé sur les *handlers*, il
+    couvre aussi les enregistrements **propagés** par les loggers enfants (un
+    filtre posé sur un logger, lui, ne verrait pas ces enregistrements).
+
+    À utiliser quand on configure le logging soi-même (dictConfig maison, section
+    ``[log] fichier_config`` d'un script) : la configuration par défaut
+    d'automatheque (:func:`configure_logging_defaut`) l'installe déjà.
+
+    Idempotent : n'ajoute pas deux fois le filtre sur un même handler.
+    """
+    from automatheque.secret import FiltreCaviardage
+
+    cible = logger if logger is not None else logging.getLogger()
+    if isinstance(cible, str):
+        cible = logging.getLogger(cible)
+    for handler in cible.handlers:
+        if not any(isinstance(f, FiltreCaviardage) for f in handler.filters):
+            handler.addFilter(FiltreCaviardage())
 
 
 # Une bibliothèque ne configure pas le logging global à l'import : on se

--- a/src/automatheque/automatheque/secret.py
+++ b/src/automatheque/automatheque/secret.py
@@ -21,6 +21,7 @@ système de greffons pour toute source enfichable, plutôt qu'un mécanisme ad h
 la valeur réelle n'est accessible que via :meth:`Secret.reveler`.
 """
 
+import logging
 import os
 import shlex
 from configparser import ConfigParser, NoOptionError, NoSectionError
@@ -28,6 +29,7 @@ from typing import Any, Dict, List, Optional, Protocol
 
 import attr
 
+from automatheque.conception.structures import MetaInstanceRegistre
 from automatheque.greffon import Greffon, signale_appel
 from automatheque.greffon.capacite import Capacite
 
@@ -36,13 +38,21 @@ CAVIARDAGE = "***"
 
 
 @attr.s(repr=False, eq=False)
-class Secret:
+class Secret(metaclass=MetaInstanceRegistre):
     """Enveloppe une valeur sensible dont le ``repr``/``str`` est **caviardé**.
 
     La valeur réelle n'est accessible que via :meth:`reveler` — jamais via
     ``str()``, ``repr()``, un f-string ou le logging, qui affichent tous
     :data:`CAVIARDAGE`. Cela évite les fuites accidentelles dans les logs et les
     tracebacks.
+
+    Patron **Registre d'instances (faibles)** : via
+    :class:`~automatheque.conception.structures.MetaInstanceRegistre`, chaque
+    ``Secret`` créé est référencé **faiblement** dans un registre — sans
+    prolonger sa vie. :class:`FiltreCaviardage` s'en sert pour caviarder toute
+    valeur de secret **vivant** qui apparaîtrait dans un message de log (rien à
+    enregistrer à la main). ``eq=False`` rend l'objet hachable (identité), requis
+    par le registre.
     """
 
     _valeur: str = attr.ib()
@@ -56,6 +66,47 @@ class Secret:
 
     def __repr__(self) -> str:
         return "Secret({})".format(CAVIARDAGE)
+
+
+def _secrets_vivants() -> List["Secret"]:
+    """Renvoie les :class:`Secret` encore vivants (registre d'instances faibles)."""
+    return Secret._instances(inclure_enfants=True)
+
+
+class FiltreCaviardage(logging.Filter):
+    """Filtre de logging qui **caviarde** les valeurs des :class:`Secret` vivants.
+
+    À poser sur un **handler** (et non un logger) pour couvrir aussi les
+    enregistrements *propagés* des loggers enfants — cf. :func:`installe_caviardage`
+    dans :mod:`automatheque.log`. Si la valeur révélée d'un secret vivant apparaît
+    dans le message rendu, elle est remplacée par :data:`CAVIARDAGE`.
+
+    Défense **en profondeur** : la première ligne reste de ne jamais logger un
+    secret en clair (utiliser :class:`Secret`, dont ``str``/``repr`` sont déjà
+    caviardés). Ce filtre rattrape les fuites indirectes (une valeur brute
+    ``reveler()`` journalisée par erreur, un secret concaténé dans un message…).
+
+    Note : le filtre remplace des **sous-chaînes littérales** ; une valeur très
+    courte peut donc caviarder large. Les vrais secrets (mots de passe, jetons)
+    sont longs, ce qui rend le cas anecdotique — raison de plus pour ne pas
+    utiliser de secret trivial.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        valeurs = [v for v in (s.reveler() for s in _secrets_vivants()) if v]
+        if not valeurs:
+            return True
+        message = record.getMessage()
+        caviarde = message
+        for valeur in valeurs:
+            if valeur in caviarde:
+                caviarde = caviarde.replace(valeur, CAVIARDAGE)
+        if caviarde != message:
+            # On fige le message rendu (et on neutralise args) pour que le
+            # caviardage tienne quel que soit le handler en aval.
+            record.msg = caviarde
+            record.args = ()
+        return True
 
 
 class ResoudreSecret(Capacite, Protocol):

--- a/src/automatheque/tests/test_log.py
+++ b/src/automatheque/tests/test_log.py
@@ -4,7 +4,9 @@ import logging
 from automatheque.log import (
     configure_logging,
     configure_logging_defaut,
+    installe_caviardage,
 )
+from automatheque.secret import FiltreCaviardage
 
 
 def _config_logging_dict(nom_logger):
@@ -24,6 +26,29 @@ def test_configure_logging_charge_fichier_json(tmp_path):
     configure_logging(str(fichier))
 
     assert logging.getLogger(nom).level == logging.DEBUG
+
+
+def test_installe_caviardage_est_idempotent():
+    """installe_caviardage pose le filtre sur les handlers, une seule fois."""
+    lg = logging.getLogger("test_caviardage_idempotent")
+    handler = logging.StreamHandler()
+    lg.addHandler(handler)
+    try:
+        installe_caviardage(lg)
+        installe_caviardage(lg)  # 2e appel : ne doit pas ajouter un doublon
+        filtres = [f for f in handler.filters if isinstance(f, FiltreCaviardage)]
+        assert len(filtres) == 1
+    finally:
+        lg.removeHandler(handler)
+
+
+def test_configure_logging_defaut_installe_le_filtre_de_caviardage():
+    """La config par défaut pose le filtre de caviardage sur le handler racine."""
+    configure_logging_defaut()
+    handlers = logging.getLogger().handlers
+    assert any(
+        any(isinstance(f, FiltreCaviardage) for f in h.filters) for h in handlers
+    )
 
 
 def test_import_pose_un_nullhandler_sur_le_logger_automatheque():

--- a/src/automatheque/tests/test_secret.py
+++ b/src/automatheque/tests/test_secret.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 """Tests du module secret (objet caviardé + greffons résolveurs, #8)."""
 
+import logging
 from configparser import ConfigParser
 from typing import Optional
 from unittest.mock import MagicMock
 
 from automatheque.secret import (
+    FiltreCaviardage,
     GreffonSecretCommande,
     GreffonSecretConfig,
     GreffonSecretEnv,
@@ -156,3 +158,47 @@ def test_recup_secret_resolveurs_personnalises():
 
     s = recup_secret("x", resolveurs=[ResolveurMuet(), ResolveurFixe()])
     assert s.reveler() == "depuis-b2"
+
+
+# --- FiltreCaviardage : redaction des logs (#15) -----------------------------
+
+
+def _record(msg, *args):
+    return logging.LogRecord("t", logging.INFO, __file__, 1, msg, args, None)
+
+
+def _fixe_secrets(monkeypatch, *secrets):
+    """Fige la liste des secrets vivants vue par le filtre (isolation du test)."""
+    from automatheque import secret as secret_mod
+
+    monkeypatch.setattr(secret_mod, "_secrets_vivants", lambda: list(secrets))
+
+
+def test_secret_est_enregistre_dans_le_registre_dinstances():
+    """Patron Registre : un Secret créé est référencé dans Secret._instances()."""
+    s = Secret("abc-registre")
+    assert s in Secret._instances(inclure_enfants=True)
+
+
+def test_filtre_caviarde_la_valeur_dun_secret_vivant(monkeypatch):
+    s = Secret("motdepasse-tres-long-42")
+    _fixe_secrets(monkeypatch, s)
+    rec = _record("connexion mdp=%s ok", "motdepasse-tres-long-42")
+    assert FiltreCaviardage().filter(rec) is True
+    assert "motdepasse-tres-long-42" not in rec.getMessage()
+    assert rec.getMessage() == "connexion mdp=*** ok"
+
+
+def test_filtre_neutre_si_aucun_secret_vivant(monkeypatch):
+    _fixe_secrets(monkeypatch)  # aucun secret
+    rec = _record("message %s sans secret", "anodin")
+    assert FiltreCaviardage().filter(rec) is True
+    assert rec.getMessage() == "message anodin sans secret"
+
+
+def test_filtre_preserve_le_record_sans_fuite(monkeypatch):
+    _fixe_secrets(monkeypatch, Secret("un-secret-absent-du-message"))
+    rec = _record("valeur=%s", "publique")
+    assert FiltreCaviardage().filter(rec) is True
+    # pas de fuite → args préservés (rendu paresseux conservé)
+    assert rec.args == ("publique",)


### PR DESCRIPTION
## Description

Dernier volet de **#15** : la **redaction des secrets dans les logs**, qui
s'appuie sur le module `secret` (#8).

### `automatheque` — `FiltreCaviardage`
* **`FiltreCaviardage`** (`logging.Filter`) remplace par `***` la valeur de tout
  `Secret` **vivant** qui apparaîtrait dans un message journalisé — défense **en
  profondeur** : rattrape une valeur `reveler()` loggée par erreur, un secret
  concaténé dans un message, etc.
* Chaque `Secret` s'enregistre dans un registre **faible** (`WeakSet`) à sa
  création : le filtre n'a **rien à configurer**, et ne retient pas la valeur
  au-delà de la vie du secret.
* Posé sur les **handlers** (et non les loggers) pour couvrir aussi les
  enregistrements **propagés** des loggers enfants. `configure_logging_defaut()`
  l'installe sur le handler racine ; **`installe_caviardage(logger=None)`**
  l'ajoute (idempotent) pour une configuration de log maison.

```python
mdp = recup_secret("factrice.smtp.mdp", config=_script.config)
logging.getLogger(__name__).info("connexion mdp=%s", mdp.reveler())
# → journalisé : « connexion mdp=*** »
```

### `factrice`
* Le **jeton OAuth** est enveloppé dans un `Secret` (comme le mot de passe) : il
  est donc caviardé et pris en compte par le filtre.

### Note de conception
La première ligne de défense reste de ne jamais logger un secret en clair
(`Secret` est déjà caviardé par `str`/`repr`). Le filtre remplace des
sous-chaînes littérales : un secret très court caviarderait large — anecdotique
pour de vrais mots de passe/jetons (longs).

## Tests

`automatheque` (152) et `factrice` (25) vertes ; `ruff`/`format` verts, `mypy`
du cœur vert. Nouveaux tests : filtre (caviarde / neutre / préserve sans fuite),
auto-enregistrement du `Secret`, idempotence d'`installe_caviardage`, installation
par la config par défaut. Sanity end-to-end : un `reveler()` loggé sur un logger
enfant ressort `***` au handler racine.

## Versioning

Touche `automatheque` **et** `factrice` → co-release à prévoir (0.20.0).

## Issues liées

Closes #15
