### PR TITLE
refactor(suivi): renomme suivi/adaptateurs en suivi/stockage

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -22,6 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     **`installe_caviardage(logger=None)`** l'ajoute (idempotent) aux handlers
     d'un logger pour une configuration de log maison.
 
+### Changed
+
+* `suivi` : le dossier `suivi/adaptateurs/` est **renommé `suivi/stockage/`**.
+  Ce sont des **backends de stockage** (implémentations du port
+  `StockageAbstraite`), pas des adaptateurs au sens du patron
+  `conception.structures.Adaptateur` — le nom prêtait à confusion dans un dépôt
+  qui nomme explicitement ses patrons. L'API publique
+  `from automatheque.suivi.journal import StockageRepertoire` est inchangée.
+
+### Deprecated
+
+* `automatheque.suivi.adaptateurs.repertoire` : shim de rétro-compatibilité qui
+  ré-exporte `StockageRepertoire` en émettant un `DeprecationWarning`. Importer
+  depuis `automatheque.suivi.stockage.repertoire` (ou `automatheque.suivi.journal`).
+
 ## [0.19.0] - 2026-07-27
 
 ### Added

--- a/src/automatheque/automatheque/suivi/adaptateurs/repertoire.py
+++ b/src/automatheque/automatheque/suivi/adaptateurs/repertoire.py
@@ -1,32 +1,28 @@
-import threading
-from pathlib import Path
+# -*- coding: utf-8 -*-
+"""Shim de rétro-compatibilité : ``suivi.adaptateurs`` → ``suivi.stockage``.
 
-import attr
+Le dossier a été **renommé** ``suivi/stockage/`` : ce sont des **backends de
+stockage** (implémentations du port ``StockageAbstraite``), pas des adaptateurs
+au sens du patron :class:`automatheque.conception.structures.Adaptateur` (qui,
+lui, injecte dynamiquement des méthodes). Le nom prêtait à confusion dans un
+dépôt qui nomme explicitement ses patrons.
 
-from automatheque.suivi.ports import StockageAbstraite
+Importer depuis ce chemin émet un ``DeprecationWarning``. Préférer
+``from automatheque.suivi.stockage.repertoire import StockageRepertoire`` — ou,
+API publique, ``from automatheque.suivi.journal import StockageRepertoire``.
+"""
 
+import warnings
 
-@attr.s
-class StockageRepertoire(StockageAbstraite):
-    repertoire: Path = attr.ib(default=Path("/tmp"))
-    # Sérialise les accès au système de fichiers pour rendre l'adaptateur
-    # utilisable depuis plusieurs threads. Non passé à l'``__init__``, ni
-    # comparé/affiché. Cf. #25.
-    _verrou: threading.Lock = attr.ib(
-        factory=threading.Lock, init=False, repr=False, eq=False
-    )
+from automatheque.suivi.stockage.repertoire import StockageRepertoire  # noqa: F401
 
-    def __attrs_post_init__(self):
-        self.repertoire.mkdir(parents=True, exist_ok=True)
+__all__ = ["StockageRepertoire"]
 
-    def existe(self, reference: str):
-        fichier = self.repertoire / reference
-        with self._verrou:
-            return fichier.exists()
-
-    def sauvegarde(self, reference: str, contenu: str):
-        fichier = self.repertoire / reference
-        with self._verrou:
-            with open(fichier, "w") as f:
-                f.write(contenu)
-        return True
+warnings.warn(
+    "automatheque.suivi.adaptateurs est déprécié : le dossier a été renommé "
+    "automatheque.suivi.stockage. Importez depuis "
+    "automatheque.suivi.stockage.repertoire (ou automatheque.suivi.journal). "
+    "Ce shim sera supprimé dans une version ultérieure.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/src/automatheque/automatheque/suivi/journal.py
+++ b/src/automatheque/automatheque/suivi/journal.py
@@ -4,8 +4,8 @@ import inspect
 
 import attr
 
-from automatheque.suivi.adaptateurs.repertoire import StockageRepertoire
 from automatheque.suivi.ports import StockageAbstraite
+from automatheque.suivi.stockage.repertoire import StockageRepertoire
 from automatheque.util.fichier import enleve_caracteres_invalides
 
 #: Fabriques de « sceau » de date par période : la clé de suivi inclut ce sceau,

--- a/src/automatheque/automatheque/suivi/stockage/repertoire.py
+++ b/src/automatheque/automatheque/suivi/stockage/repertoire.py
@@ -1,0 +1,32 @@
+import threading
+from pathlib import Path
+
+import attr
+
+from automatheque.suivi.ports import StockageAbstraite
+
+
+@attr.s
+class StockageRepertoire(StockageAbstraite):
+    repertoire: Path = attr.ib(default=Path("/tmp"))
+    # Sérialise les accès au système de fichiers pour rendre ce backend de
+    # stockage utilisable depuis plusieurs threads. Non passé à l'``__init__``,
+    # ni comparé/affiché. Cf. #25.
+    _verrou: threading.Lock = attr.ib(
+        factory=threading.Lock, init=False, repr=False, eq=False
+    )
+
+    def __attrs_post_init__(self):
+        self.repertoire.mkdir(parents=True, exist_ok=True)
+
+    def existe(self, reference: str):
+        fichier = self.repertoire / reference
+        with self._verrou:
+            return fichier.exists()
+
+    def sauvegarde(self, reference: str, contenu: str):
+        fichier = self.repertoire / reference
+        with self._verrou:
+            with open(fichier, "w") as f:
+                f.write(contenu)
+        return True

--- a/src/automatheque/tests/suivi/test_suivi.py
+++ b/src/automatheque/tests/suivi/test_suivi.py
@@ -1,9 +1,9 @@
-"""Tests du sous-système ``suivi`` : port, adaptateur répertoire et journal."""
+"""Tests du sous-système ``suivi`` : port, backend de stockage et journal."""
 
 import pytest
-from automatheque.suivi.adaptateurs.repertoire import StockageRepertoire
 from automatheque.suivi.journal import JournalSuivi
 from automatheque.suivi.ports import StockageAbstraite
+from automatheque.suivi.stockage.repertoire import StockageRepertoire
 
 # --- Port abstrait -----------------------------------------------------------
 
@@ -31,7 +31,23 @@ def test_stockage_abstraite_methodes_levent_notimplemented():
         s.sauvegarde("x", "y")
 
 
-# --- Adaptateur StockageRepertoire ------------------------------------------
+# --- Backend de stockage StockageRepertoire ---------------------------------
+
+
+def test_shim_suivi_adaptateurs_emet_un_deprecationwarning():
+    """L'ancien chemin ``suivi.adaptateurs`` reste importable mais est déprécié.
+
+    On recharge le module pour ré-exécuter son ``warnings.warn`` (l'import peut
+    déjà avoir été mis en cache par un autre test).
+    """
+    import importlib
+
+    with pytest.warns(DeprecationWarning, match="suivi.adaptateurs"):
+        ancien = importlib.reload(
+            importlib.import_module("automatheque.suivi.adaptateurs.repertoire")
+        )
+    # le shim ré-exporte bien la même classe que le nouveau chemin
+    assert ancien.StockageRepertoire is StockageRepertoire
 
 
 def test_repertoire_cree_le_dossier(tmp_path):


### PR DESCRIPTION
## Description

Le dossier `suivi/adaptateurs/` contient des **backends de stockage** —
implémentations du port `StockageAbstraite` (architecture hexagonale). Mais le
mot « adaptateur » **entre en collision** avec le patron nommé
`conception.structures.Adaptateur` (qui, lui, injecte dynamiquement des
méthodes). Dans un dépôt qui **nomme explicitement ses patrons** (à visée
pédagogique), c'est trompeur pour un lecteur.

## Changement

* `suivi/adaptateurs/repertoire.py` → **`suivi/stockage/repertoire.py`**.
* **Shim de rétro-compatibilité** sur l'ancien chemin : ré-exporte
  `StockageRepertoire` en émettant un `DeprecationWarning` (même convention que
  le shim `util.script`).
* Reformulation des mentions « adaptateur » → « backend de stockage ».

**L'API publique ne bouge pas** : `from automatheque.suivi.journal import
StockageRepertoire` reste valide (c'est le chemin recommandé).

## Tests

Import via le nouveau chemin + test du `DeprecationWarning` du shim. Suite
`automatheque` verte (147), `ruff`/`format`/`mypy` verts.

## Note versioning

`automatheque` uniquement (changement interne + dépréciation ; pas de rupture
d'API publique).
