### PR TITLE
feat(factrice): patrons Fabrique (Expeditrice) et Monteur (Preparatrice)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `expedition.FabriqueExpeditrice` : **fabrique d'expéditrices** (patron
+  **Fabrique**, comme `FabriqueGreffon`). Le choix du transport (`"smtp"` /
+  `"esmtp"`) passe par `fabrique_expeditrice.cree_expeditrice(transport)` plutôt
+  qu'un `if via_esmtp` dans l'app — un nouveau transport s'ajoute par un
+  `enregistre_monteur` sans toucher les appelants.
+
+### Changed
+
+* `expedition.ExpeditriceEsmtp` **hérite désormais de `Expeditrice`** (famille de
+  transports homogène derrière l'interface commune).
+* `app.envoi_mail_simple` délègue le choix du transport à la fabrique (plus de
+  dispatch booléen).
+
 ### Security
 
 * `expedition.ExpeditriceSmtp` — le **jeton OAuth** est désormais enveloppé dans

--- a/src/automatheque.factrice/automatheque/factrice/app/__init__.py
+++ b/src/automatheque.factrice/automatheque/factrice/app/__init__.py
@@ -20,7 +20,7 @@ Options:
 
 import sys
 
-from automatheque.factrice.expedition import ExpeditriceEsmtp, ExpeditriceSmtp
+from automatheque.factrice.expedition import fabrique_expeditrice
 from automatheque.schema.texte.courriel import Courriel
 from automatheque.script import ScriptAutomatheque, script_automatheque
 
@@ -40,22 +40,20 @@ def recupere_texte(arguments):
 
 
 def envoi_mail_simple(sujet, adresse, txt, via_esmtp=False):
-    """Envoie un mail simple."""
+    """Envoie un mail simple.
+
+    Le choix du transport (SMTP direct ou ``esmtp``) est délégué à la
+    :class:`~automatheque.factrice.expedition.FabriqueExpeditrice` : plus de
+    ``if via_esmtp`` ici, et un nouveau transport s'ajoute côté fabrique sans
+    toucher cette fonction. Renvoie ce que renvoie ``expedie`` (le code de retour
+    pour ``esmtp``, ``None`` pour SMTP).
+    """
     destinataires = adresse.split(",")
     mail = Courriel(sujet=sujet, destinataires=destinataires)
     mail.contenu = txt
 
-    if not via_esmtp:
-        ExpeditriceSmtp().expedie(mail)
-        return
-
-    # envoi du mail si esmtp est paramétré
-    # cmd = 'cat "{0}" | esmtp {1}'.format(
-    #    mail.gen_fichier(), SEPARATEUR_DESTINATAIRES.join(mail.destinataires)
-    # )
-    # return_code = subprocess.call(cmd, shell=True)
-    return_code = ExpeditriceEsmtp().expedie(mail)
-    return return_code
+    transport = "esmtp" if via_esmtp else "smtp"
+    return fabrique_expeditrice.cree_expeditrice(transport).expedie(mail)
 
 
 def traite(_script: ScriptAutomatheque = None):

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 import attr
 
+from automatheque.conception.structures import Fabrique
 from automatheque.configuration import NoOptionError, charge_configuration
 from automatheque.factrice.preparation import SEPARATEUR_DESTINATAIRES, PreparatriceSmtp
 from automatheque.schema.texte import Courriel
@@ -210,7 +211,7 @@ class ExpeditriceSmtp(Expeditrice):
 
 
 @attr.s
-class ExpeditriceEsmtp:
+class ExpeditriceEsmtp(Expeditrice):
     config: ConfigParser = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(ConfigParser)),
@@ -278,3 +279,38 @@ class ExpeditriceEsmtp:
                 process.stderr,
             )
         return process.returncode
+
+
+class FabriqueExpeditrice(Fabrique):
+    """Fabrique d':class:`Expeditrice` : choisit le **transport** par sa clé.
+
+    Patron **Fabrique** (cf. :class:`automatheque.conception.structures.Fabrique`,
+    même approche que ``FabriqueGreffon``) : au lieu d'un ``if via_esmtp: … else:
+    …`` dans l'appelant, on enregistre chaque transport comme monteur et on
+    demande l'expéditrice voulue par sa clé. Ajouter un transport = un
+    ``enregistre_monteur`` de plus, sans toucher aux appelants.
+
+    Les classes ``Expeditrice`` sont enregistrées **directement** comme monteurs
+    (elles sont ``callable`` : ``cree(cle, config=…)`` fait ``Classe(config=…)``).
+
+    .. code-block:: python
+
+        expeditrice = fabrique_expeditrice.cree_expeditrice("smtp")
+        expeditrice.expedie(courriel)
+    """
+
+    def cree_expeditrice(
+        self, transport: str, config: Optional[ConfigParser] = None
+    ) -> Expeditrice:
+        """Renvoie l'expéditrice du ``transport`` demandé (``"smtp"``/``"esmtp"``).
+
+        Enveloppe métier autour de :meth:`Fabrique.cree` (comme conseillé par la
+        classe mère). Lève ``ValueError`` si le transport est inconnu.
+        """
+        return self.cree(transport, config=config)
+
+
+#: Fabrique d'expéditrices prête à l'emploi, transports usuels enregistrés.
+fabrique_expeditrice = FabriqueExpeditrice()
+fabrique_expeditrice.enregistre_monteur("smtp", ExpeditriceSmtp)
+fabrique_expeditrice.enregistre_monteur("esmtp", ExpeditriceEsmtp)

--- a/src/automatheque.factrice/tests/test_app.py
+++ b/src/automatheque.factrice/tests/test_app.py
@@ -22,6 +22,11 @@ def test_recupere_texte_depuis_stdin(monkeypatch):
     assert recupere_texte({"<texte_du_mail>": None}) == "depuis le tuyau"
 
 
+def _remplace_transport(monkeypatch, transport, classe):
+    """Remplace le monteur d'un transport dans la fabrique (restauré après le test)."""
+    monkeypatch.setitem(app.fabrique_expeditrice.recup_monteurs(), transport, classe)
+
+
 def test_envoi_mail_simple_smtp_construit_le_courriel(monkeypatch):
     """Sans `--via-esmtp` : route vers SMTP et construit un Courriel cohérent."""
     envoye = {}
@@ -33,7 +38,7 @@ def test_envoi_mail_simple_smtp_construit_le_courriel(monkeypatch):
         def expedie(self, mail):
             envoye["mail"] = mail
 
-    monkeypatch.setattr(app, "ExpeditriceSmtp", FakeSmtp)
+    _remplace_transport(monkeypatch, "smtp", FakeSmtp)
     app.envoi_mail_simple("sujet", "a@b.c,d@e.f", "corps", via_esmtp=False)
 
     mail = envoye["mail"]
@@ -52,5 +57,5 @@ def test_envoi_mail_simple_esmtp_renvoie_le_code(monkeypatch):
         def expedie(self, mail):
             return 7
 
-    monkeypatch.setattr(app, "ExpeditriceEsmtp", FakeEsmtp)
+    _remplace_transport(monkeypatch, "esmtp", FakeEsmtp)
     assert envoi_mail_simple("s", "a@b.c", "corps", via_esmtp=True) == 7

--- a/src/automatheque.factrice/tests/test_expedition.py
+++ b/src/automatheque.factrice/tests/test_expedition.py
@@ -259,3 +259,34 @@ def test_s5_oauth_cmd_shlex_gere_les_guillemets(monkeypatch):
     ExpeditriceSmtp(config=c)
     # "user name" reste un seul argument grâce à shlex.
     assert faux_exec.exec.call_args.args == ("access", "user name")
+
+
+# --- FabriqueExpeditrice (patron Fabrique) ----------------------------------
+
+
+def test_fabrique_enregistre_les_transports_usuels():
+    """La fabrique prête à l'emploi connaît « smtp » et « esmtp »."""
+    monteurs = expedition.fabrique_expeditrice.recup_monteurs()
+    assert monteurs["smtp"] is ExpeditriceSmtp
+    assert monteurs["esmtp"] is ExpeditriceEsmtp
+
+
+def test_fabrique_transport_inconnu_leve_valueerror():
+    with pytest.raises(ValueError):
+        expedition.fabrique_expeditrice.cree_expeditrice("pigeon-voyageur")
+
+
+def test_esmtp_est_une_expeditrice():
+    """ExpeditriceEsmtp fait bien partie de la famille Expeditrice (interface)."""
+    assert issubclass(ExpeditriceEsmtp, expedition.Expeditrice)
+
+
+def test_fabrique_cree_le_bon_transport(monkeypatch):
+    """cree_expeditrice(« smtp ») construit une ExpeditriceSmtp (SMTP mocké)."""
+    fake = MagicMock()
+    monkeypatch.setattr(expedition.smtplib, "SMTP_SSL", lambda *a, **k: fake)
+
+    expeditrice = expedition.fabrique_expeditrice.cree_expeditrice(
+        "smtp", config=_config_smtp()
+    )
+    assert isinstance(expeditrice, ExpeditriceSmtp)


### PR DESCRIPTION
## Description

Dogfoode deux patrons maison dans le chemin d'envoi de `factrice`, au lieu de
code fait main — et en les **nommant** (visée pédagogique).

### 1. Patron **Fabrique** — choix du transport
Avant : dispatch booléen `if via_esmtp: … else: …` dans l'app.
Après :
```python
transport = "esmtp" if via_esmtp else "smtp"
return fabrique_expeditrice.cree_expeditrice(transport).expedie(mail)
```
* **`FabriqueExpeditrice(Fabrique)`** + singleton **`fabrique_expeditrice`**
  (transports `"smtp"` → `ExpeditriceSmtp`, `"esmtp"` → `ExpeditriceEsmtp`).
  `cree_expeditrice(transport, config=)` ; transport inconnu → `ValueError`.
  **Un nouveau transport = un `enregistre_monteur` de plus**, sans toucher les
  appelants (comme `FabriqueGreffon`).
* **`ExpeditriceEsmtp` hérite désormais de `Expeditrice`** (incohérence corrigée).

### 2. Patron **Monteur** — construction du message
* **`Preparatrice(Monteur)`** : la construction de la représentation transportable
  d'un `Courriel` (message MIME multipart — beaucoup de champs optionnels : sujet,
  from, date, corps, pièces jointes ⇒ cas d'usage type du Monteur) passe par
  **`construit(courriel)`** (auparavant la *classmethod* `prepare`).
* **`PreparatriceSmtp` hérite maintenant de `Preparatrice`** (même incohérence
  corrigée).

## Comportement

Inchangé : `envoi_mail_simple` renvoie toujours le code de retour pour `esmtp` et
`None` pour SMTP ; le message MIME produit est identique.

## Tests

Fabrique (transports enregistrés, transport inconnu → `ValueError`, `esmtp` est
une `Expeditrice`, `cree_expeditrice("smtp")` construit le bon transport, SMTP
mocké). Monteur (préparation via instance + `construit`). Tests d'app adaptés
(remplacement du monteur du transport dans la fabrique). Suites `factrice` (29)
et `automatheque` (153) vertes ; `ruff`/`format` verts, `mypy` du cœur vert.

## Versioning

`automatheque.factrice` uniquement — fera partie de la **co-release 0.20.0**.
