### PR TITLE
feat(factrice): Preparatrice devient un Monteur (patron Monteur)

### DIFF
--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* `preparation.Preparatrice` est désormais un **`Monteur`** (patron **Monteur**) :
+  la construction de la représentation transportable d'un `Courriel` (message MIME)
+  passe par `PreparatriceSmtp().construit(courriel)` (auparavant la *classmethod*
+  `prepare`). `PreparatriceSmtp` **hérite** maintenant de `Preparatrice`.
 * `expedition.ExpeditriceEsmtp` **hérite désormais de `Expeditrice`** (famille de
   transports homogène derrière l'interface commune).
 * `app.envoi_mail_simple` délègue le choix du transport à la fabrique (plus de

--- a/src/automatheque.factrice/automatheque/factrice/expedition.py
+++ b/src/automatheque.factrice/automatheque/factrice/expedition.py
@@ -76,7 +76,7 @@ class ExpeditriceSmtp(Expeditrice):
         validator=attr.validators.optional(attr.validators.instance_of(ConfigParser)),
     )
     s: smtplib.SMTP = attr.ib(init=False)
-    preparatrice = attr.ib(init=False, default=PreparatriceSmtp)
+    preparatrice = attr.ib(init=False, factory=PreparatriceSmtp)
 
     def __attrs_post_init__(self):
         self.config: ConfigParser = (
@@ -203,7 +203,7 @@ class ExpeditriceSmtp(Expeditrice):
         res = self.s.sendmail(
             courriel.emetteur,
             courriel.destinataires,
-            self.preparatrice.prepare(courriel).as_string(),
+            self.preparatrice.construit(courriel).as_string(),
         )
         if res:
             LOGGER.warning(res)
@@ -241,7 +241,7 @@ class ExpeditriceEsmtp(Expeditrice):
                 "factrice.esmtp", "emetteur", fallback="osuser@localhost"
             )
 
-        contenu = PreparatriceSmtp().prepare(courriel).as_string()
+        contenu = PreparatriceSmtp().construit(courriel).as_string()
 
         if fichier_sortie is not None:
             fic = Path(fichier_sortie)

--- a/src/automatheque.factrice/automatheque/factrice/preparation.py
+++ b/src/automatheque.factrice/automatheque/factrice/preparation.py
@@ -4,22 +4,30 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
+from automatheque.conception.structures import Monteur
 from automatheque.schema.texte import Courriel
 
 SEPARATEUR_DESTINATAIRES = ", "
 
 
-class Preparatrice:
-    @classmethod
-    def prepare(cls, courriel: Courriel):
-        """Prépare le courriel pour le rendre expedit"able" ?"""
+class Preparatrice(Monteur):
+    """**Monteur** de la représentation transportable d'un :class:`Courriel`.
+
+    Patron **Monteur** (cf. :class:`automatheque.conception.structures.Monteur`) :
+    la construction du message (sujet, expéditeur, date, corps, pièces jointes —
+    beaucoup de champs optionnels, cas d'usage type du Monteur) est séparée de sa
+    représentation. Une sous-classe concrète implémente :meth:`construit` pour un
+    format donné (ici MIME multipart pour SMTP).
+    """
+
+    def construit(self, courriel: Courriel):
+        """Construit la représentation transportable du courriel."""
         raise NotImplementedError
 
 
-class PreparatriceSmtp:
-    @classmethod
-    def prepare(cls, courriel: Courriel):
-        """Construit l'objet Multipart à envoyer et le retourne."""
+class PreparatriceSmtp(Preparatrice):
+    def construit(self, courriel: Courriel):
+        """Construit l'objet Multipart (MIME) à envoyer et le retourne."""
         _msg = MIMEMultipart()
         _msg["Subject"] = courriel.sujet
         _msg["From"] = courriel.emetteur

--- a/src/automatheque.factrice/tests/test_preparation.py
+++ b/src/automatheque.factrice/tests/test_preparation.py
@@ -28,7 +28,7 @@ def _courriel(**kwargs):
 def test_preparatrice_base_non_implementee():
     """La classe de base ne sait rien préparer."""
     with pytest.raises(NotImplementedError):
-        Preparatrice.prepare(_courriel())
+        Preparatrice().construit(_courriel())
 
 
 def test_prepare_construit_entetes():
@@ -36,7 +36,7 @@ def test_prepare_construit_entetes():
     c = _courriel()
     c.ajouter_destinataire("Toto <toto@tld.com>")
 
-    msg = PreparatriceSmtp.prepare(c)
+    msg = PreparatriceSmtp().construit(c)
 
     assert isinstance(msg, Message)
     assert msg["Subject"] == "Sujet du mail"
@@ -52,7 +52,7 @@ def test_prepare_corps_texte_plain():
     c = _courriel()
     c.contenu = "Bonjour"
 
-    msg = PreparatriceSmtp.prepare(c)
+    msg = PreparatriceSmtp().construit(c)
 
     parties = msg.get_payload()
     assert parties[0].get_content_type() == "text/plain"
@@ -64,7 +64,7 @@ def test_prepare_corps_html():
     c = _courriel()
     c.contenu = "<html><body>Salut</body></html>"
 
-    msg = PreparatriceSmtp.prepare(c)
+    msg = PreparatriceSmtp().construit(c)
 
     partie = msg.get_payload()[0]
     assert partie.get_content_type() == "text/html"
@@ -79,7 +79,7 @@ def test_prepare_avec_piece_jointe(tmp_path):
     c.contenu = "Voir pièce jointe"
     c.ajouter_piece_jointe(fichier)
 
-    msg = PreparatriceSmtp.prepare(c)
+    msg = PreparatriceSmtp().construit(c)
 
     parties = msg.get_payload()
     assert len(parties) == 2  # corps + 1 pièce jointe


### PR DESCRIPTION
> Le volet **Fabrique** (`FabriqueExpeditrice`) a déjà été mergé dans `main` via #102. Cette PR ne porte plus que le volet **Monteur** (le second commit, qui n'était pas encore visible côté GitHub au moment du merge de #102).

## Description

Dogfoode le patron **Monteur** (`automatheque.conception.structures.Monteur`)
pour la construction du message transportable depuis un `Courriel`.

* **`Preparatrice(Monteur)`** : la construction de la représentation (MIME
  multipart — beaucoup de champs optionnels : sujet, from, date, corps, pièces
  jointes ⇒ cas d'usage type du Monteur) passe par **`construit(courriel)`**
  (auparavant la *classmethod* `prepare`).
* **`PreparatriceSmtp` hérite maintenant de `Preparatrice`** (corrige une
  incohérence, comme pour `ExpeditriceEsmtp` dans #102).
* `expedition` : `self.preparatrice.construit(...)` (l'attribut est désormais une
  instance via `factory`) et `PreparatriceSmtp().construit(...)`.

## Comportement

Inchangé : le message MIME produit est identique.

## Tests

Tests de préparation mis à jour (instance + `construit`). Suites `factrice` (29)
et `automatheque` (153) vertes ; `ruff`/`format` verts.

## Versioning

`automatheque.factrice` uniquement — fera partie de la **co-release 0.20.0**.
