### PR TITLE
release: 0.20.0 (automatheque + factrice)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.19.0"
+version = "0.20.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-30
+
 ### Added
 
 * `expedition.FabriqueExpeditrice` : **fabrique d'expéditrices** (patron

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.factrice"
-version = "0.19.0"
+version = "0.20.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-30
+
 ### Added
 
 * `secret` / `log` — **caviardage des logs** (cf. #15) :

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.19.0"
+version = "0.20.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
## Co-release `0.20.0`

Un seul tag `0.20.0` publie **`automatheque`** et **`automatheque.factrice`**
(lockstep monas : les deux paquets modifiés prennent la version globale ;
`monas.version == max == 0.20.0` ; `automatheque.schema` reste en `0.15.0`, non
republié).

### `automatheque` `0.19.0 → 0.20.0`
* **Caviardage des logs** (`FiltreCaviardage`) + `Secret` sur le patron **Registre
  d'instances faibles** (#15).
* Résolveurs de secret par défaut via une **`FabriqueGreffon` locale** (patron
  **Fabrique**) au lieu d'un cache maison.
* **`suivi/adaptateurs` → `suivi/stockage`** (+ shim de dépréciation).

### `automatheque.factrice` `0.19.0 → 0.20.0`
* **Jeton OAuth** enveloppé dans un `Secret` (#15).
* **`FabriqueExpeditrice`** (patron **Fabrique**) pour le choix du transport.
* **`Preparatrice` devient un `Monteur`** (patron **Monteur**).
* `ExpeditriceEsmtp` / `PreparatriceSmtp` héritent de leur interface (incohérences
  corrigées).

CHANGELOG des deux paquets : `[Unreleased] → [0.20.0] - 2026-07-30`.

## Après merge

Pousser le tag **`0.20.0`** → le workflow publie `automatheque 0.20.0` **et**
`factrice 0.20.0` (pas `schema`).

## Contrôles

Suites `automatheque` (153) et `factrice` (29) vertes ; `ruff`/`format`/`mypy`
(cœur) verts. Invariant lockstep respecté.
