### PR TITLE
ci: dérive de src/* les listes de paquets de ci.yml et release.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Installe les paquets (editable) et les dépendances de test
+        # La liste des paquets est **dérivée de `src/*`**, comme
+        # `[tool.monas] packages` à la racine. Elle était auparavant codée en
+        # dur ici (et dans le job `qualite`) : un paquet ajouté à `src/`
+        # n'était alors ni testé ni publié, en silence. Cf. #106.
         run: |
           python -m pip install --upgrade pip
-          pip install -e src/automatheque -e src/automatheque.schema -e src/automatheque.factrice
+          pip install $(printf -- '-e %s ' src/*/)
           pip install pytest pytest-cov
 
       - name: Lance les tests avec couverture
@@ -119,7 +123,8 @@ jobs:
       - name: Installe les paquets et l'outillage qualité
         run: |
           python -m pip install --upgrade pip
-          pip install -e src/automatheque -e src/automatheque.schema -e src/automatheque.factrice
+          # Même dérivation de `src/*` que dans le job « tests ». Cf. #106.
+          pip install $(printf -- '-e %s ' src/*/)
           # ruff et mypy sont ÉPINGLÉS : sans version fixe, `pip install` récupère
           # la dernière (qui change les règles de lint/format d'un jour à l'autre)
           # et fait échouer des PR sans rapport. On bumpe délibérément.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,29 @@ on:
       - "[0-9]*"
 
 jobs:
+  matrice:
+    # La liste des paquets est **dérivée de `src/*`**, comme
+    # `[tool.monas] packages` à la racine. Elle était auparavant codée en dur
+    # dans `matrix.package` : une distribution ajoutée à `src/` n'était jamais
+    # publiée, en silence, sans message d'erreur. Cf. #106.
+    name: Recense les paquets de src/
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.recense.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Liste les répertoires de src/
+        id: recense
+        run: |
+          PACKAGES=$(ls -d src/*/ | xargs -n1 basename | jq -R . | jq -sc .)
+          echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
+          echo "::notice::paquets recensés : $PACKAGES"
+
   publish:
     name: Publie ${{ matrix.package }} sur PyPI
     runs-on: ubuntu-latest
+    needs: matrice
     # Trusted Publishing (OIDC) : aucun secret, GitHub s'authentifie auprès de
     # PyPI. Chaque projet PyPI doit déclarer un « trusted publisher » pointant
     # vers ce dépôt et ce workflow (release.yml).
@@ -23,10 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package:
-          - automatheque
-          - automatheque.schema
-          - automatheque.factrice
+        package: ${{ fromJSON(needs.matrice.outputs.packages) }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

**1/4 de la remontée du socle média** — cette PR est le **prérequis** des trois suivantes, à merger en premier.

La racine déclare déjà `packages = ["src/*"]` pour monas, mais deux listes de paquets étaient codées en dur :

* `.github/workflows/ci.yml` — le `pip install -e …`, **deux fois** (jobs `tests` et `qualite`) ;
* `.github/workflows/release.yml` — la `matrix.package` du job `publish`.

Un paquet ajouté à `src/` sans toucher ces fichiers n'était donc ni testé, ni jamais publié — en silence, sans message d'erreur. Le piège se déclenche exactement au moment où on est le moins attentif à l'outillage : à la création d'une distribution.

C'est reproductible : avec la liste codée en dur, `pytest src` collecte les tests d'une nouvelle distribution, ne la trouve pas installée, et s'interrompt à la collecte.

```
ModuleNotFoundError: No module named 'automatheque.decomposition'
Interrupted: 2 errors during collection
```

D'où l'ordre : sans cette PR, les PR 2 et 4 partent rouges.

## Ce que ça change

* `ci.yml` : `pip install $(printf -- '-e %s ' src/*/)` dans les deux jobs ;
* `release.yml` : un job `matrice` recense `src/*/` et alimente `matrix.package` via `fromJSON`. **La sémantique est inchangée** — seuls les paquets dont la version égale le tag sont publiés, les autres restent en `::notice::`.

Reste manuel, hors dépôt et non automatisable : déclarer un ***trusted publisher* PyPI** par nouveau projet, sinon la première publication échoue au tag. C'est documenté dans le README par la PR 4.

## Issues liées

Closes #106

Suite ouverte en préparant ce changement, non bloquante : #108 — le job `tests-plancher` dérive ses planchers du seul `pyproject` de `factrice`, c'est le même piège sur un troisième fichier.