### PR TITLE
feat(decomposition): nouvelle distribution automatheque.decomposition

### DIFF
--- a/src/automatheque.decomposition/.gitignore
+++ b/src/automatheque.decomposition/.gitignore
@@ -1,0 +1,5 @@
+**__pycache__
+**.venv
+**.pytest_cache
+**.egg-info
+log.json

--- a/src/automatheque.decomposition/CHANGELOG
+++ b/src/automatheque.decomposition/CHANGELOG
@@ -1,0 +1,54 @@
+# Changelog — automatheque.decomposition
+
+<!-- markdownlint-disable MD024 -->
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* Première version de la distribution. Le code provient de l'**ancien**
+  `automatheque` (`automatheque/lib/decomposeur.py`), d'avant le découpage en
+  paquets : `Decomposeur`, `Decomposeurs`, `Decomposable`, `Identificateur` et
+  les constantes `DECOMPOSE_*`. Cf. #43.
+* `exceptions` : `DecompositionEchecPatron` et `DecompositionEchecTousPatrons`,
+  qui vivaient dans les exceptions du cœur alors qu'elles ne concernent que la
+  décomposition. Elles héritent toujours de `AutomathequeBaseException`, donc
+  un `except` global continue de les attraper.
+
+### Fixed
+
+* `Decomposeur` : passer un `appel_source` explicite levait
+  systématiquement un `UnboundLocalError`. `__attrs_post_init__` définissait la
+  fonction par défaut dans une branche `if`, puis l'assignait **hors** de la
+  branche : quand l'appelant fournissait la sienne, le nom n'était pas lié.
+  Seul le cas par défaut fonctionnait donc.
+* `Identificateur` : la résolution des décomposeurs par défaut attrapait
+  `Exception` et la retraduisait en `ArgumentManquant`, ce qui masquait toute
+  erreur réelle du `_decomposeurs_par_defaut()` de l'appelant. Seuls
+  `AttributeError` et `NotImplementedError` sont désormais traduits.
+* `Identificateur` : un chemin d'import de décomposeurs introuvable donnait un
+  `TypeError: 'NoneType' object is not callable` (`pydoc.locate` renvoie
+  `None`) au lieu d'`ArgumentManquant`.
+* `Identificateur.identifie()` : `options_analyse` reçue sous forme de chaîne
+  était testée par `in`, soit une recherche de **sous-chaîne** et non une
+  appartenance. Les constantes livrées ne se contiennent pas l'une l'autre —
+  le résultat était donc correct par chance. La valeur est désormais
+  normalisée, et une collection de constantes est acceptée explicitement.
+
+### Removed
+
+* `Decomposeur.decomposer()` : méthode morte, dont le corps se réduisait à
+  `return None` sous une docstring décrivant ce qu'elle aurait dû faire.
+
+### Changed
+
+* Le calcul de score de `DECOMPOSE_RESULTAT_MAX_INFOS` passe d'une fonction
+  imbriquée à la méthode `Identificateur._score_max_infos()`. Le score est
+  inchangé — y compris son « bonus de longueur » calculé mais jamais ajouté à
+  la somme (variable morte relevée par ruff, documentée sur place : l'intégrer
+  changerait le classement des décompositions et relève d'un arbitrage à part).

--- a/src/automatheque.decomposition/MANIFEST.in
+++ b/src/automatheque.decomposition/MANIFEST.in
@@ -1,0 +1,1 @@
+include automatheque/decomposition/py.typed

--- a/src/automatheque.decomposition/README.md
+++ b/src/automatheque.decomposition/README.md
@@ -1,0 +1,105 @@
+# automatheque.decomposition
+
+Décomposition de chaînes et d'arborescences par patrons.
+
+## Détail
+
+Décomposer, c'est extraire des informations d'une chaîne — le plus souvent le
+chemin d'un fichier — en lui appliquant une série d'expressions rationnelles,
+puis reverser le résultat dans un objet.
+
+Typiquement : retrouver le nom d'une série et son numéro d'épisode dans
+`/media/series/Ma Serie/S01/E02.avi`, ou l'album et le lieu d'une photo dans
+son arborescence de rangement.
+
+Le paquet ne touche pas au système de fichiers : il ne manipule que des
+chaînes. Un chemin lui est donné, il en tire des informations ; c'est
+l'appelant qui décide ensuite quoi en faire — le déplacement du fichier est
+l'affaire de `automatheque.renommage`, l'opération symétrique.
+
+C'est aussi pourquoi les deux sont des distributions séparées : indexer ou
+étiqueter sans jamais déplacer un fichier est un usage courant, qui n'a pas à
+tirer les dépendances du renommage.
+
+## Les briques
+
+* **`Decomposeur`** — un patron : une expression rationnelle, un appel qui
+  fournit la chaîne à analyser, un appel qui reverse le résultat dans l'objet,
+  et un poids pour départager les patrons concurrents.
+* **`Decomposeurs`** — un jeu de patrons, itérable. À sous-classer pour
+  décrire une famille de médias (séries, films, photos…).
+* **`Decomposable`** — mixin à faire hériter par l'objet à décomposer. Il doit
+  exposer `basename` (la chaîne analysée par défaut) et `filename` (le chemin
+  complet, remonté niveau par niveau).
+* **`Identificateur`** — l'algorithme : il joue les patrons sur l'objet selon
+  les options demandées, et choisit la décomposition la plus pertinente.
+
+## Options
+
+Deux familles d'options se combinent.
+
+Ce qu'on garde du résultat :
+
+| Constante | Effet |
+|---|---|
+| `DECOMPOSE_RESULTAT_PREMIER_NON_NUL` | s'arrête au premier patron qui trouve quelque chose |
+| `DECOMPOSE_RESULTAT_CUMULE` | applique tous les patrons qui trouvent quelque chose |
+| `DECOMPOSE_RESULTAT_MAX_INFOS` | garde la décomposition qui remplit le plus l'objet |
+
+Ce qu'on analyse :
+
+| Constante | Effet |
+|---|---|
+| `DECOMPOSE_ANALYSE_ARBO_UN_NIVEAU` | le `basename` seul |
+| `DECOMPOSE_ANALYSE_ARBO_COMPLETE` | chaque niveau de l'arborescence, un par un |
+| `DECOMPOSE_ANALYSE_ARBO_CONCATENE` | les niveaux concaténés, de proche en proche |
+
+`Decomposable.auto_decompose()` essaie ces combinaisons de la plus riche à la
+plus simple, et s'arrête à la première qui aboutit.
+
+## Exemple
+
+```py
+import attr
+
+from automatheque.decomposition import Decomposable, Decomposeur, Decomposeurs
+
+
+def _remplit(obj, resultats):
+    obj.serie, obj.saison, obj.episode = resultats
+
+
+class SerieDecomposeurs(Decomposeurs):
+    def __attrs_post_init__(self):
+        self.decomposeurs = [
+            Decomposeur(r"(.+)[. ]S(\d{2})E(\d{2})", _remplit),
+        ]
+
+
+@attr.s
+class Episode(Decomposable):
+    filename = attr.ib(default="")
+    basename = attr.ib(default="")
+    serie = attr.ib(default=None)
+    saison = attr.ib(default=None)
+    episode = attr.ib(default=None)
+
+
+ep = Episode(filename="/media/Ma.Serie.S01E02.avi", basename="Ma.Serie.S01E02.avi")
+ep.decompose(decomposeurs=SerieDecomposeurs())
+# ep.serie == "Ma.Serie", ep.saison == "01", ep.episode == "02"
+```
+
+## Requirement
+
+Python >=3.9
+
+## Installation
+
+```bash
+pip install automatheque.decomposition
+```
+
+## License
+
+LGPLv3.0 ou ultérieure

--- a/src/automatheque.decomposition/automatheque/__init__.py
+++ b/src/automatheque.decomposition/automatheque/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/src/automatheque.decomposition/automatheque/decomposition/__init__.py
+++ b/src/automatheque.decomposition/automatheque/decomposition/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Décomposition de chaînes et d'arborescences par patrons."""
+
+from .decomposeur import (
+    DECOMPOSE_ANALYSE_ARBO_COMPLETE,
+    DECOMPOSE_ANALYSE_ARBO_CONCATENE,
+    DECOMPOSE_ANALYSE_ARBO_UN_NIVEAU,
+    DECOMPOSE_RESULTAT_CUMULE,
+    DECOMPOSE_RESULTAT_MAX_INFOS,
+    DECOMPOSE_RESULTAT_PREMIER_NON_NUL,
+    Decomposable,
+    Decomposeur,
+    Decomposeurs,
+    Identificateur,
+)
+from .exceptions import DecompositionEchecPatron, DecompositionEchecTousPatrons
+
+__all__ = [
+    "DECOMPOSE_ANALYSE_ARBO_COMPLETE",
+    "DECOMPOSE_ANALYSE_ARBO_CONCATENE",
+    "DECOMPOSE_ANALYSE_ARBO_UN_NIVEAU",
+    "DECOMPOSE_RESULTAT_CUMULE",
+    "DECOMPOSE_RESULTAT_MAX_INFOS",
+    "DECOMPOSE_RESULTAT_PREMIER_NON_NUL",
+    "Decomposable",
+    "Decomposeur",
+    "Decomposeurs",
+    "DecompositionEchecPatron",
+    "DecompositionEchecTousPatrons",
+    "Identificateur",
+]

--- a/src/automatheque.decomposition/automatheque/decomposition/decomposeur.py
+++ b/src/automatheque.decomposition/automatheque/decomposition/decomposeur.py
@@ -1,0 +1,407 @@
+# -*- coding: utf-8 -*-
+"""Décomposition de chaînes et d'arborescences par patrons.
+
+La décomposition consiste à extraire des informations d'une chaîne — le plus
+souvent le chemin d'un fichier — en lui appliquant une série d'expressions
+rationnelles, puis à reverser le résultat dans un objet.
+
+Le module ne touche pas au système de fichiers : il ne manipule que des
+chaînes. Un chemin lui est donné, il en tire des informations ; c'est
+l'appelant qui décide ensuite quoi en faire.
+"""
+
+import logging
+import pickle
+import re
+from copy import deepcopy
+
+import attr
+
+from automatheque.exceptions import ArgumentManquant
+from automatheque.util.repertoire import remonte_arborescence
+
+from .exceptions import DecompositionEchecPatron, DecompositionEchecTousPatrons
+
+LOGGER = logging.getLogger(__name__)
+
+#
+# Constantes pour déterminer le comportement de la décomposition.
+#
+# Le premier résultat non nul de la décomposition est renvoyé :
+DECOMPOSE_RESULTAT_PREMIER_NON_NUL = "resultat_premier_non_nul"
+# Tous les résultats trouvés par les decomposeurs sont renvoyés :
+DECOMPOSE_RESULTAT_CUMULE = "resultat_cumule"
+# On renvoie le resultat avec la taille de l'objet maximale :
+DECOMPOSE_RESULTAT_MAX_INFOS = "resultat_max_infos"
+
+#
+# Détermine si on modifie la chaîne à analyser et si on relance une analyse :
+#
+# Seul un niveau d'analyse est joué (généralement le nom de l'objet):
+DECOMPOSE_ANALYSE_ARBO_UN_NIVEAU = "analyse_un_niveau"
+# Tous les niveaux de l'arborescence sont analysés, un par un :
+DECOMPOSE_ANALYSE_ARBO_COMPLETE = "analyse_arbo_complete"
+# Tous les niveaux de l'arborescence sont concaténés pour former la chaîne à
+# analyser, ex: /media/series/ma serie S01/E02.avi => ma_serie_S01_E02.avi
+# étant donné une "racine" (ici /media/series, ou par défaut "/").
+# NB: cette analyse joue quand même les niveaux les uns après les autres :
+# ie : d'abord analyse de E02.avi avant ma_serie_S01_E02.avi.
+# Si on voulait analyser directement tout le chemin, il suffit de faire une
+# analyse simple en mettant dès le départ la chaîne complète dans la source.
+DECOMPOSE_ANALYSE_ARBO_CONCATENE = "analyse_arbo_concatene"
+
+
+def _appel_source_par_defaut(obj, valeur):
+    """Source de données par défaut : celle que l'objet décomposable prépare."""
+    return obj._prepare_decomposition(valeur)
+
+
+@attr.s
+class Decomposeur(object):
+    """Un patron de décomposition : une expression rationnelle et ses appels.
+
+    Les fonctions servent :
+
+    * pour obtenir la source des données (:attr:`appel_source`) ;
+    * pour traiter les données récupérées (:attr:`appel_en_retour`).
+
+    :param chaine: expression rationnelle appliquée à la source
+    :param appel_en_retour: appelé en `(obj, resultats)` pour reverser dans
+                            l'objet ce que le patron a trouvé
+    :param appel_source: appelé en `(obj, valeur)` pour obtenir la chaîne à
+                         analyser ; par défaut, délègue à
+                         `obj._prepare_decomposition(valeur)`
+    :param drapeaux: drapeaux passés à :func:`re.compile`
+    :param poids: priorité du patron, utilisée par
+                  :data:`DECOMPOSE_RESULTAT_MAX_INFOS`
+    """
+
+    chaine = attr.ib()
+    appel_en_retour = attr.ib()
+    appel_source = attr.ib(default=None)
+    drapeaux = attr.ib(default=0)
+    poids = attr.ib(default=1)
+    compile = attr.ib(init=False, default=None)
+
+    def __attrs_post_init__(self):
+        """Complète les propriétés déduites des autres."""
+        if self.appel_source is None:
+            self.appel_source = _appel_source_par_defaut
+        self.compile = re.compile(self.chaine, flags=self.drapeaux)
+
+    def _decomposer(self, obj, valeur=None, pos=None, endpos=None):
+        """Applique l'expression rationnelle sur la source des données.
+
+        :param valeur: si une valeur est donnée elle est passée à la fonction
+                       :attr:`appel_source` qui prépare les données à
+                       décomposer.
+        """
+        kwargs = {}
+        if pos and endpos:
+            kwargs = {"pos": pos, "endpos": endpos}
+        elif pos:
+            kwargs = {"pos": pos}
+
+        return self.compile.findall(self.appel_source(obj, valeur), **kwargs)
+
+
+@attr.s
+class Decomposeurs(object):
+    """Classe « abstraite » dont doivent hériter tous les jeux de patrons.
+
+    TODO: rendre la classe vraiment abstraite !
+    """
+
+    decomposeurs = attr.ib(init=False, factory=list)
+
+    def __iter__(self):
+        """Itère sur les décomposeurs."""
+        return iter(self.decomposeurs)
+
+
+class Decomposable(object):
+    """Les objets qui héritent de cette classe sont décomposables.
+
+    Il faut alors appeler :meth:`decompose` (ou :meth:`auto_decompose`).
+
+    L'objet doit exposer deux attributs, sur lesquels s'appuie la
+    décomposition :
+
+    * ``basename`` — la chaîne analysée par défaut ;
+    * ``filename`` — le chemin complet, remonté niveau par niveau par les
+      options :data:`DECOMPOSE_ANALYSE_ARBO_COMPLETE` et
+      :data:`DECOMPOSE_ANALYSE_ARBO_CONCATENE`.
+
+    TODO : on pourrait donner le nom de la propriété à l'initialisation de
+    Decomposable, si on veut en prendre une autre.
+    """
+
+    @classmethod
+    def _decomposeurs_par_defaut(cls):
+        """À surcharger par les descendants.
+
+        Renvoie une instance de :class:`Decomposeurs` ou le chemin vers la
+        classe.
+        """
+        raise NotImplementedError("pas de decomposeurs par défaut")
+
+    def _prepare_decomposition(self, valeur=None):
+        """Fonction par défaut pour récupérer la donnée à décomposer.
+
+        À surcharger si on veut normaliser la donnée.
+        Attention, si valeur est None, cette fonction doit renvoyer une donnée
+        malgré tout.
+
+        :param valeur:  valeur à préparer si présente, sinon basename par
+                        défaut
+        """
+        if valeur:
+            return valeur
+        return self.basename
+
+    def auto_decompose(self, racine=None, decomposeurs=None):
+        """Essaie les combinaisons d'options jusqu'à ce que l'une réussisse.
+
+        Les combinaisons sont parcourues de la plus riche à la plus simple.
+
+        :raise DecompositionEchecTousPatrons: si aucune combinaison n'aboutit
+        """
+        for options_resultat in [
+            DECOMPOSE_RESULTAT_MAX_INFOS,
+            DECOMPOSE_RESULTAT_CUMULE,
+            DECOMPOSE_RESULTAT_PREMIER_NON_NUL,
+        ]:
+            for option in [
+                DECOMPOSE_ANALYSE_ARBO_COMPLETE,
+                DECOMPOSE_ANALYSE_ARBO_CONCATENE,
+            ]:
+                try:
+                    self.decompose(
+                        decomposeurs=decomposeurs,
+                        racine=racine,
+                        options_analyse=option,
+                        options_resultat=options_resultat,
+                    )
+                except DecompositionEchecTousPatrons:
+                    pass
+                else:
+                    return
+        raise DecompositionEchecTousPatrons()
+
+    def decompose(
+        self,
+        decomposeurs=None,
+        racine=None,
+        options_resultat=DECOMPOSE_RESULTAT_PREMIER_NON_NUL,
+        options_analyse=DECOMPOSE_ANALYSE_ARBO_UN_NIVEAU,
+    ):
+        """Décompose l'objet suivant les decomposeurs donnés."""
+        identificateur = Identificateur(self, decomposeurs=decomposeurs)
+        return identificateur.identifie(
+            racine=racine,
+            options_resultat=options_resultat,
+            options_analyse=options_analyse,
+        )
+
+
+@attr.s
+class Identificateur(object):
+    """Identifie une chaîne grâce à une liste de décomposeurs.
+
+    Identificateur = algo d'utilisation des décomposeurs. Il permet de prendre
+    la décomposition la plus pertinente parmi celles que les patrons
+    proposent.
+
+    Utilisé en particulier pour déterminer le nom d'une série ou d'une chanson
+    à partir de son nom de fichier.
+
+    :param obj: l'objet que l'on veut identifier (un :class:`Decomposable`)
+    :param decomposeurs: instance de :class:`Decomposeurs`, ou la chaîne
+                         d'import correspondant à la classe, ex :
+                         ``"mon_paquet.decomposeurs_serie.SerieSaisonDecomposeurs"``.
+                         À défaut, ceux que l'objet renvoie par
+                         ``_decomposeurs_par_defaut()``.
+
+    TODO renommer DECOMPOSE_XX en IDENTIFIE_XXX
+    TODO : attr utiliser validator et converter
+    """
+
+    obj = attr.ib()
+    decomposeurs = attr.ib(default=None)
+
+    def __attrs_post_init__(self):
+        """Résout les décomposeurs et prend un témoin de l'objet d'origine."""
+        if not self.decomposeurs:
+            try:
+                self.decomposeurs = self.obj._decomposeurs_par_defaut()
+            except (AttributeError, NotImplementedError):
+                # L'objet n'est pas décomposable, ou ne propose pas de patrons
+                # par défaut : sans patron on ne peut rien identifier.
+                raise ArgumentManquant("decomposeurs")
+
+        if isinstance(self.decomposeurs, str):
+            # Cas où le decomposeur est donné par son chemin :
+            from pydoc import locate
+
+            classe = locate(self.decomposeurs)
+            if classe is None:
+                raise ArgumentManquant("decomposeurs")
+            self.decomposeurs = classe()
+
+        # Pour comparer RESULTAT_MAX_INFOS il faut un objet témoin :
+        self.obj_temoin = deepcopy(self.obj)
+
+    def _exec_decomposition(self, options_resultat, valeur=None):
+        """Joue tous les décomposeurs sur la valeur donnée.
+
+        :return: tuple `(decomposition_reussie, sortir)` où `sortir` porte le
+                 résultat à renvoyer immédiatement, ou False s'il faut
+                 continuer l'analyse.
+        """
+        decomposition_reussie = False
+        sortir = False
+        for decomposeur in self.decomposeurs:
+            LOGGER.debug(
+                "exec_decomposition : {} // {}".format(
+                    decomposeur.chaine, valeur or self.obj.basename
+                )
+            )
+            try:
+                resultats = decomposeur._decomposer(self.obj, valeur)
+                try:
+                    resultats = resultats[0]
+                except IndexError:
+                    raise DecompositionEchecPatron(decomposeur)
+                if options_resultat == DECOMPOSE_RESULTAT_PREMIER_NON_NUL:
+                    # Puis on appelle le callback pour remplir l'objet :
+                    decomposeur.appel_en_retour(self.obj, resultats)
+                    decomposition_reussie = True
+                    sortir = resultats
+                    # on s'arrête ici
+                    break
+                elif options_resultat == DECOMPOSE_RESULTAT_CUMULE:
+                    # Puis on appelle le callback pour remplir l'objet :
+                    decomposeur.appel_en_retour(self.obj, resultats)
+                    decomposition_reussie = True
+                    # mais on continue le traitement :
+                    continue
+                elif options_resultat == DECOMPOSE_RESULTAT_MAX_INFOS:
+                    obj_temoin = deepcopy(self.obj_temoin)
+                    decomposeur.appel_en_retour(obj_temoin, resultats)
+
+                    # On compare la taille des deux objets sérialisés, grosso
+                    # modo. On n'attribue un modificateur qu'à l'objet témoin
+                    # pour prendre en compte la « qualité » du décomposeur en
+                    # cours.
+                    temoin = self._score_max_infos(obj_temoin, decomposeur.poids)
+                    if temoin >= self._score_max_infos(self.obj):
+                        # Puis on appelle le callback pour remplir l'objet :
+                        decomposeur.appel_en_retour(self.obj, resultats)
+                        decomposition_reussie = True
+                    # mais on continue le traitement :
+                    continue
+            except DecompositionEchecPatron:
+                LOGGER.debug(
+                    "Echec de la décomposition: {} {}".format(
+                        valeur, decomposeur.chaine
+                    )
+                )
+            except Exception:
+                LOGGER.exception(
+                    "Echec durant la décomposition: {} {}".format(
+                        valeur, decomposeur.chaine
+                    )
+                )
+                continue
+
+        LOGGER.debug("exec decomposition obj resultant : {}".format(self.obj))
+        return (decomposition_reussie, sortir)
+
+    def _score_max_infos(self, obj, poids=None):
+        """Estime la quantité d'informations portée par un objet décomposé.
+
+        Algo :
+
+        * modificateur lié au poids du décomposeur en cours ; 2 pour l'objet
+          déjà décomposé, afin de favoriser les infos préexistantes ;
+        * nombre de champs non vides : bonus au plus rempli ;
+        * longueur des infos de l'objet relativement à l'objet témoin.
+
+        Ce qui rapporte le plus est le nombre de champs non vides.
+
+        TODO : le code d'origine calculait aussi un « bonus de longueur » (+1
+        si l'objet est plus gros que le témoin, pour éviter qu'un objet vide
+        soit mieux noté) mais **ne l'ajoutait jamais** à la somme — variable
+        morte relevée par ruff (F841) à la remontée. Le comportement est
+        conservé tel quel ici ; l'intégrer relève d'un arbitrage à part, car
+        cela change le classement des décompositions.
+
+        :param poids: poids du décomposeur, ou None pour l'objet déjà décomposé
+        """
+        modificateur = 2 if poids is None else poids
+
+        nb_champs_non_vides = 2 * len([k for k, v in obj.__dict__.items() if v])
+
+        longueur_relative = len(pickle.dumps(obj)) / len(pickle.dumps(self.obj_temoin))
+        return longueur_relative + modificateur + nb_champs_non_vides
+
+    def identifie(
+        self,
+        racine=None,
+        options_resultat=DECOMPOSE_RESULTAT_PREMIER_NON_NUL,
+        options_analyse=DECOMPOSE_ANALYSE_ARBO_UN_NIVEAU,
+    ):
+        """Identifie l'objet donné à partir des décomposeurs donnés.
+
+        Options de décomposition :
+
+        * premier non nul pour 1 niveau
+        * premier non nul pour plusieurs niveaux successifs
+        * plusieurs résultats pour 1 niveau
+        * plusieurs résultats pour tous les niveaux
+        * premier non nul pour la juxtaposition des niveaux
+
+        Reste : juxtaposition + successifs ? TODO ?
+
+        :param options_analyse: une constante `DECOMPOSE_ANALYSE_*`, ou une
+                                collection de constantes pour les cumuler
+        :raise DecompositionEchecTousPatrons: si aucun patron n'aboutit
+        """
+        # Une seule option est le cas courant ; on normalise pour que le test
+        # d'appartenance ci-dessous soit une vraie appartenance et non une
+        # recherche de sous-chaîne.
+        if isinstance(options_analyse, str):
+            options_analyse = (options_analyse,)
+
+        # Première décomposition :
+        succes, sortir = self._exec_decomposition(options_resultat=options_resultat)
+        if sortir:
+            return sortir
+
+        # TODO par défaut on prend self.obj.filename et basename comme valeurs
+        # on pourrait en prendre d'autres et/ou le rendre paramétrable
+        if DECOMPOSE_ANALYSE_ARBO_COMPLETE in options_analyse:
+            for parent in remonte_arborescence(self.obj.filename, racine):
+                succes_, sortir = self._exec_decomposition(
+                    options_resultat=options_resultat, valeur=parent.name
+                )
+                succes = succes if succes else succes_
+                if sortir:
+                    return sortir
+        if DECOMPOSE_ANALYSE_ARBO_CONCATENE in options_analyse:
+            valeur_orig = self.obj.basename
+            for parent in remonte_arborescence(self.obj.filename, racine):
+                valeur_orig = "{} {}".format(parent.name, valeur_orig)
+                succes_, sortir = self._exec_decomposition(
+                    options_resultat=options_resultat, valeur=valeur_orig
+                )
+                succes = succes if succes else succes_
+                if sortir:
+                    return sortir
+        # TODO comparer les infos trouvées et ne garder que la meilleure
+        # Pour l'instant on fait comme filebot : on s'arrête à la première.
+
+        # comme on attrape les exceptions, si on ne trouve rien on arrive ici
+        if not succes:
+            raise DecompositionEchecTousPatrons()
+        return None

--- a/src/automatheque.decomposition/automatheque/decomposition/exceptions.py
+++ b/src/automatheque.decomposition/automatheque/decomposition/exceptions.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Exceptions propres à la décomposition.
+
+Elles héritent de :class:`automatheque.exceptions.AutomathequeBaseException`
+afin que le code appelant puisse filtrer d'un seul `except` toutes les
+exceptions de l'automathèque.
+"""
+
+from automatheque.exceptions import AutomathequeBaseException
+
+
+class DecompositionEchecTousPatrons(AutomathequeBaseException):
+    """Aucun patron n'a permis de décomposer la source."""
+
+    def __init__(self, msg="Aucun patron trouvé."):
+        """Initialisation."""
+        self.msg = msg
+        super().__init__(self.msg)
+
+
+class DecompositionEchecPatron(AutomathequeBaseException):
+    """La décomposition a échoué pour le patron donné.
+
+    Levée pour *un* patron : c'est une étape normale de l'algorithme, qui
+    essaie les patrons les uns après les autres. Seule
+    :class:`DecompositionEchecTousPatrons` signale un échec définitif.
+    """
+
+    def __init__(self, patron):
+        """Initialisation."""
+        self.patron = patron
+        self.msg = "Décomposition échouée pour le patron '{}'.".format(patron)
+        super().__init__(self.msg)

--- a/src/automatheque.decomposition/pyproject.toml
+++ b/src/automatheque.decomposition/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "automatheque.decomposition"
+version = "0.19.0"
+description = "Décomposition de chaînes et d'arborescences par patrons"
+authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
+license = {text = "LGPL-3.0-or-later"}
+requires-python = ">=3.9"
+readme = "README.md"
+classifiers = [
+    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+dependencies = [
+    # >=0.19.0 : plancher aligné sur la version courante du cœur, dont ce
+    # paquet utilise `log.recup_logger`, `util.repertoire.remonte_arborescence`
+    # et `exceptions.AutomathequeBaseException`. Aucune de ces API n'est
+    # récente, mais rien ne justifie d'annoncer un plancher plus bas que ce que
+    # la CI éprouve réellement.
+    "automatheque>=0.19.0",
+    "attrs>=19.2",
+]
+
+[project.urls]
+Home = "https://github.com/jaegerbobomb/automatheque/tree/main/src/automatheque.decomposition/"
+Repository = "https://github.com/jaegerbobomb/automatheque.git"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+# Embarque le marqueur py.typed dans le wheel (typage exporté). Cf. #3.
+[tool.setuptools.package-data]
+"automatheque.decomposition" = ["py.typed"]

--- a/src/automatheque.decomposition/setup.py
+++ b/src/automatheque.decomposition/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup(name="automatheque.decomposition")

--- a/src/automatheque.decomposition/tests/test_decomposeur.py
+++ b/src/automatheque.decomposition/tests/test_decomposeur.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+"""Tests de la décomposition.
+
+L'ancien dépôt n'avait aucune couverture sur ce module : ces tests sont
+écrits à la remontée, et fixent le comportement que les consommateurs
+attendent.
+"""
+
+import re
+
+import attr
+import pytest
+from automatheque.decomposition import (
+    DECOMPOSE_ANALYSE_ARBO_COMPLETE,
+    DECOMPOSE_ANALYSE_ARBO_CONCATENE,
+    DECOMPOSE_RESULTAT_CUMULE,
+    DECOMPOSE_RESULTAT_MAX_INFOS,
+    DECOMPOSE_RESULTAT_PREMIER_NON_NUL,
+    Decomposable,
+    Decomposeur,
+    Decomposeurs,
+    DecompositionEchecTousPatrons,
+    Identificateur,
+)
+from automatheque.exceptions import ArgumentManquant
+
+
+def _remplit_serie(obj, resultats):
+    """Appel en retour : reverse le tuple trouvé dans l'objet."""
+    obj.serie, obj.saison, obj.episode = resultats
+
+
+def _remplit_annee(obj, resultats):
+    obj.annee = resultats
+
+
+@attr.s
+class SerieDecomposeurs(Decomposeurs):
+    """Un jeu de patrons pour les séries."""
+
+    def __attrs_post_init__(self):
+        self.decomposeurs = [
+            Decomposeur(r"(.+)[. ]S(\d{2})E(\d{2})", _remplit_serie, drapeaux=re.I),
+        ]
+
+
+@attr.s
+class Episode(Decomposable):
+    """Objet décomposable minimal."""
+
+    filename = attr.ib(default="")
+    basename = attr.ib(default="")
+    serie = attr.ib(default=None)
+    saison = attr.ib(default=None)
+    episode = attr.ib(default=None)
+    annee = attr.ib(default=None)
+
+
+@attr.s
+class EpisodeAvecDefaut(Episode):
+    """Décomposable qui sait fournir ses patrons par défaut."""
+
+    @classmethod
+    def _decomposeurs_par_defaut(cls):
+        return SerieDecomposeurs()
+
+
+def test_decompose_le_basename():
+    ep = Episode(filename="/media/Ma.Serie.S01E02.avi", basename="Ma.Serie.S01E02.avi")
+    ep.decompose(decomposeurs=SerieDecomposeurs())
+    assert (ep.serie, ep.saison, ep.episode) == ("Ma.Serie", "01", "02")
+
+
+def test_decompose_renvoie_le_resultat_du_premier_patron():
+    ep = Episode(basename="Ma.Serie.S01E02.avi")
+    assert ep.decompose(decomposeurs=SerieDecomposeurs()) == ("Ma.Serie", "01", "02")
+
+
+def test_decompose_sans_patron_applicable_leve_l_echec():
+    ep = Episode(basename="rien-a-decomposer.txt")
+    with pytest.raises(DecompositionEchecTousPatrons):
+        ep.decompose(decomposeurs=SerieDecomposeurs())
+
+
+def test_decomposeurs_par_defaut_utilises_si_non_precises():
+    ep = EpisodeAvecDefaut(basename="Ma.Serie.S01E02.avi")
+    ep.decompose()
+    assert ep.serie == "Ma.Serie"
+
+
+def test_sans_decomposeurs_ni_defaut_on_reclame_l_argument():
+    ep = Episode(basename="Ma.Serie.S01E02.avi")
+    with pytest.raises(ArgumentManquant):
+        ep.decompose()
+
+
+def test_decomposeurs_donnes_par_chemin_d_import():
+    ep = Episode(basename="Ma.Serie.S01E02.avi")
+    ep.decompose(decomposeurs="{}.SerieDecomposeurs".format(__name__))
+    assert ep.serie == "Ma.Serie"
+
+
+def test_chemin_d_import_introuvable_reclame_l_argument():
+    ep = Episode(basename="Ma.Serie.S01E02.avi")
+    with pytest.raises(ArgumentManquant):
+        Identificateur(ep, decomposeurs="paquet.inexistant.PasDeClasse")
+
+
+def test_appel_source_explicite_est_utilise():
+    """Régression : un `appel_source` fourni levait un `UnboundLocalError`."""
+
+    def source_figee(obj, valeur):
+        return "Autre.Serie.S03E04.avi"
+
+    decomposeurs = SerieDecomposeurs()
+    decomposeurs.decomposeurs = [
+        Decomposeur(
+            r"(.+)[. ]S(\d{2})E(\d{2})", _remplit_serie, appel_source=source_figee
+        )
+    ]
+
+    ep = Episode(basename="ignore.avi")
+    ep.decompose(decomposeurs=decomposeurs)
+    assert (ep.serie, ep.saison, ep.episode) == ("Autre.Serie", "03", "04")
+
+
+def test_analyse_arborescence_complete_remonte_les_niveaux():
+    """Le patron ne matche aucun niveau seul, mais matche un répertoire."""
+    ep = Episode(
+        filename="/media/series/Ma.Serie.S01E02/video.avi", basename="video.avi"
+    )
+    ep.decompose(
+        racine="/media",
+        decomposeurs=SerieDecomposeurs(),
+        options_analyse=DECOMPOSE_ANALYSE_ARBO_COMPLETE,
+    )
+    assert (ep.serie, ep.saison, ep.episode) == ("Ma.Serie", "01", "02")
+
+
+def test_analyse_arborescence_concatenee():
+    """Aucun niveau ne porte l'information complète, leur concaténation si."""
+    ep = Episode(filename="/media/series/Ma.Serie/S01E02.avi", basename="S01E02.avi")
+    ep.decompose(
+        racine="/media",
+        decomposeurs=SerieDecomposeurs(),
+        options_analyse=DECOMPOSE_ANALYSE_ARBO_CONCATENE,
+    )
+    assert (ep.serie, ep.saison, ep.episode) == ("Ma.Serie", "01", "02")
+
+
+def test_options_analyse_acceptent_une_collection():
+    ep = Episode(
+        filename="/media/series/Ma.Serie.S01E02/video.avi", basename="video.avi"
+    )
+    ep.decompose(
+        racine="/media",
+        decomposeurs=SerieDecomposeurs(),
+        options_analyse=[
+            DECOMPOSE_ANALYSE_ARBO_COMPLETE,
+            DECOMPOSE_ANALYSE_ARBO_CONCATENE,
+        ],
+    )
+    assert ep.serie == "Ma.Serie"
+
+
+def test_resultat_cumule_applique_tous_les_patrons():
+    decomposeurs = SerieDecomposeurs()
+    decomposeurs.decomposeurs.append(Decomposeur(r"\((\d{4})\)", _remplit_annee))
+
+    ep = Episode(basename="Ma.Serie.S01E02 (2019).avi")
+    ep.decompose(decomposeurs=decomposeurs, options_resultat=DECOMPOSE_RESULTAT_CUMULE)
+    assert ep.serie == "Ma.Serie"
+    assert ep.annee == "2019"
+
+
+def test_resultat_premier_non_nul_s_arrete_au_premier():
+    decomposeurs = SerieDecomposeurs()
+    decomposeurs.decomposeurs.append(Decomposeur(r"\((\d{4})\)", _remplit_annee))
+
+    ep = Episode(basename="Ma.Serie.S01E02 (2019).avi")
+    ep.decompose(
+        decomposeurs=decomposeurs,
+        options_resultat=DECOMPOSE_RESULTAT_PREMIER_NON_NUL,
+    )
+    assert ep.serie == "Ma.Serie"
+    assert ep.annee is None
+
+
+def test_resultat_max_infos_garde_la_decomposition_la_plus_riche():
+    """Deux patrons matchent ; celui qui remplit trois champs doit gagner."""
+
+    def _remplit_serie_seule(obj, resultats):
+        obj.serie = resultats
+
+    decomposeurs = SerieDecomposeurs()
+    # Le patron « pauvre » est joué en premier : sans le calcul de score, c'est
+    # lui qui resterait.
+    decomposeurs.decomposeurs.insert(
+        0, Decomposeur(r"^([^.]+)\.", _remplit_serie_seule)
+    )
+
+    ep = Episode(basename="Ma.Serie.S01E02.avi")
+    ep.decompose(
+        decomposeurs=decomposeurs, options_resultat=DECOMPOSE_RESULTAT_MAX_INFOS
+    )
+    assert (ep.serie, ep.saison, ep.episode) == ("Ma.Serie", "01", "02")
+
+
+def test_auto_decompose_trouve_une_combinaison_qui_marche():
+    ep = Episode(
+        filename="/media/series/Ma.Serie.S01E02/video.avi", basename="video.avi"
+    )
+    ep.auto_decompose(racine="/media", decomposeurs=SerieDecomposeurs())
+    assert ep.serie == "Ma.Serie"
+
+
+def test_auto_decompose_echoue_si_rien_ne_marche():
+    ep = Episode(filename="/media/series/rien/video.avi", basename="video.avi")
+    with pytest.raises(DecompositionEchecTousPatrons):
+        ep.auto_decompose(racine="/media", decomposeurs=SerieDecomposeurs())
+
+
+def test_prepare_decomposition_par_defaut_renvoie_le_basename():
+    ep = Episode(basename="video.avi")
+    assert ep._prepare_decomposition() == "video.avi"
+    assert ep._prepare_decomposition("autre") == "autre"
+
+
+def test_decomposeurs_est_iterable():
+    decomposeurs = SerieDecomposeurs()
+    assert len(list(decomposeurs)) == 1
+
+
+def test_decomposable_sans_surcharge_annonce_l_absence_de_defaut():
+    with pytest.raises(NotImplementedError):
+        Decomposable._decomposeurs_par_defaut()


### PR DESCRIPTION
## Description

**2/4 de la remontée du socle média** — le **pilote**. Basée sur #110, à merger après elle.

Remonte depuis l'**ancien** `automatheque` (d'avant le découpage en paquets) la brique de décomposition : extraire des informations d'une chaîne — le plus souvent un chemin de fichier — par une série d'expressions rationnelles, puis les reverser dans un objet. Typiquement retrouver la série et l'épisode dans `/media/series/Ma Serie/S01/E02.avi`.

Contenu : `Decomposeur`, `Decomposeurs`, `Decomposable`, `Identificateur`, les constantes `DECOMPOSE_*`, et les deux exceptions de décomposition qui vivaient dans les exceptions du cœur alors qu'elles ne concernent que ce domaine.

C'est volontairement le pilote : code pur, des expressions rationnelles, zéro I/O, zéro dépendance au-delà d'`attrs` et du cœur, déjà formaté. Si quelque chose coince, c'est la plomberie du monorepo — pas le code.

## Pourquoi une distribution séparée du renommage

Les deux modules ne s'importent pas l'un l'autre, et une asymétrie de nature les sépare : la décomposition ne fait rien au monde, le renommage mute le système de fichiers. Indexer ou étiqueter sans jamais déplacer un fichier est un usage concret, qui n'a pas à tirer les dépendances du renommage.

## Nettoyage à la remontée

Quatre bugs corrigés, chacun avec son test de régression — un `appel_source` explicite qui levait un `UnboundLocalError` (seul le cas par défaut fonctionnait), un `except Exception` qui masquait les erreurs de l'appelant, un chemin d'import introuvable mal signalé, et `options_analyse` testée par **sous-chaîne** au lieu d'appartenance. Une méthode morte retirée. Le détail est dans le CHANGELOG.

Le score de `DECOMPOSE_RESULTAT_MAX_INFOS` est **inchangé**, y compris son bonus de longueur calculé mais jamais ajouté à la somme (variable morte relevée par ruff). L'intégrer changerait le classement des décompositions : c'est un arbitrage à part, documenté sur place.

L'ancien dépôt n'avait aucun test sur ce module ; **19 tests** sont écrits à la remontée.

## Issues liées

cf. #43 — la distribution est créée et le code réhébergé, mais le **registre de presets** et le **monteur dict → instance** évoqués dans l'issue restent à faire. L'issue ne se ferme donc pas.

Le paquet ne dépend pas d'`automatheque.schema`, contrairement à ce que #43 envisageait : rien dans ce code ne manipule de modèle de domaine, et déclarer une dépendance inutilisée serait un mauvais signal.