### PR TITLE
feat(renommage): nouvelle distribution automatheque.renommage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 | [`automatheque`](https://pypi.org/project/automatheque/) | [![PyPI](https://img.shields.io/pypi/v/automatheque.svg)](https://pypi.org/project/automatheque/) | ![Python](https://img.shields.io/pypi/pyversions/automatheque.svg) |
 | [`automatheque.factrice`](https://pypi.org/project/automatheque.factrice/) | [![PyPI](https://img.shields.io/pypi/v/automatheque.factrice.svg)](https://pypi.org/project/automatheque.factrice/) | ![Python](https://img.shields.io/pypi/pyversions/automatheque.factrice.svg) |
 | [`automatheque.schema`](https://pypi.org/project/automatheque.schema/) | [![PyPI](https://img.shields.io/pypi/v/automatheque.schema.svg)](https://pypi.org/project/automatheque.schema/) | ![Python](https://img.shields.io/pypi/pyversions/automatheque.schema.svg) |
+| [`automatheque.decomposition`](https://pypi.org/project/automatheque.decomposition/) | [![PyPI](https://img.shields.io/pypi/v/automatheque.decomposition.svg)](https://pypi.org/project/automatheque.decomposition/) | ![Python](https://img.shields.io/pypi/pyversions/automatheque.decomposition.svg) |
+| [`automatheque.renommage`](https://pypi.org/project/automatheque.renommage/) | [![PyPI](https://img.shields.io/pypi/v/automatheque.renommage.svg)](https://pypi.org/project/automatheque.renommage/) | ![Python](https://img.shields.io/pypi/pyversions/automatheque.renommage.svg) |
 
 > Le badge de couverture est un **snapshot** (mis à jour à la main). On peut le
 > rendre *vivant* via Codecov si besoin — cf. PR.
@@ -28,6 +30,25 @@ Nous essayons dans un mono répo de gérer des sous-paquets python, pour
 avoir un unique namespace "automatheque" et pouvoir publier les sous paquets "automatheque.schema" etc.
 
 Voir (https://packaging.python.org/en/latest/guides/packaging-namespace-packages/) pour plus d'informations.
+
+### Ajouter une distribution
+
+Un nouveau répertoire sous `src/` suffit : `monas` le voit
+(`packages = ["src/*"]`), et la CI comme la publication **dérivent la même
+liste** — un paquet ajouté est donc testé et publié d'office.
+
+Le squelette se copie depuis un paquet existant : `pyproject.toml`,
+`setup.py` (deux lignes), `MANIFEST.in`, `README.md`, `CHANGELOG`, `tests/`,
+un `automatheque/__init__.py` portant `pkgutil.extend_path`, et le marqueur
+`py.typed`.
+
+Reste **une** étape manuelle, hors dépôt : déclarer sur PyPI un *trusted
+publisher* pour le nouveau projet, pointant ce dépôt et `release.yml`. Sans
+lui, la première publication échoue au tag.
+
+Enfin, `release.yml` ne publie que les paquets dont la version **égale le
+tag** : livrer plusieurs paquets ensemble suppose de les bumper à la même
+version avant de taguer.
 
 ## Nomenclature que l'on essaie de respecter
 

--- a/src/automatheque.renommage/.gitignore
+++ b/src/automatheque.renommage/.gitignore
@@ -1,0 +1,5 @@
+**__pycache__
+**.venv
+**.pytest_cache
+**.egg-info
+log.json

--- a/src/automatheque.renommage/CHANGELOG
+++ b/src/automatheque.renommage/CHANGELOG
@@ -1,0 +1,85 @@
+# Changelog — automatheque.renommage
+
+<!-- markdownlint-disable MD024 -->
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* Première version de la distribution. Le code provient de l'**ancien**
+  `automatheque` (`automatheque/lib/renommeur.py`), d'avant le découpage en
+  paquets : `Gabarit`, `Gabarits`, `Renommable` et `Renommeur`.
+* `Gabarits.depuis_configuration(config, section)` : construit les gabarits
+  depuis un objet de type `ConfigParser`, au format historique
+  `r1 = [squelette, condition, ordre]`. Le triplet est lu avec
+  `ast.literal_eval` et non `eval` — un fichier de configuration décrit des
+  données, il n'a pas à pouvoir exécuter du code.
+* Des exceptions nommées, là où le module levait des `ValueError` avec un
+  message : `AucunGabaritApplicable`, `GabaritInapplicable`,
+  `ConditionInvalide`, `TransfertIncomplet`, sous une base commune
+  `RenommageEchec`. Les trois premières héritent aussi de `ValueError`, donc
+  un appelant qui l'attrapait continue de fonctionner.
+
+### Changed
+
+* **La configuration est reçue, plus cherchée.** `Renommeur` appelait
+  `charge_configuration()` lui-même — une localisation de service : le
+  renommage dépendait d'un fichier de configuration présent au bon endroit, et
+  n'était pas testable sans lui. Il reçoit désormais ses gabarits
+  (`Renommeur(obj, gabarits=…)`), et retombe sur `obj._gabarits_par_defaut()`
+  s'il n'en reçoit pas. C'est à l'appelant de décider d'où ils viennent.
+* `renomme()` renvoie le chemin cible, et ne le renvoie plus par un détour :
+  le paramètre `cumule_gabarits` disparaît avec `_remplir_gabarits()`, la
+  composition d'un jeu de gabarits se faisant maintenant côté appelant.
+* Les noms internes perdent leur préfixe hongrois (`v_rep_cible` →
+  `rep_cible`, `v_nomfic` → `nom_fichier`).
+* `mkdir_p` (déprécié dans le cœur en 0.19.0) laisse place à
+  `Path.mkdir(parents=True, exist_ok=True)`.
+
+### Removed
+
+* **L'écriture d'attributs étendus.** `Renommeur._renomme()` posait
+  `user.automatheque.fichier_orig` et `user.automatheque.modele.classe` dans
+  les xattr du fichier, à chaque renommage, sans que ce soit annoncé nulle
+  part. Les xattr ne survivent ni à la plupart des copies, ni aux archives, ni
+  aux transferts réseau : c'est le plus fragile des supports pour de la
+  provenance, et conserver le nom d'origine relève de l'application. Cela
+  supprime du même coup la dépendance `xattr`, sensible à la plateforme et au
+  système de fichiers.
+
+### Fixed
+
+* **Injection de code par les métadonnées des fichiers traités.** La condition
+  d'un gabarit était formatée avec les champs de l'objet — un album, une
+  ville, une description, c'est-à-dire des chaînes venues des fichiers
+  eux-mêmes — puis passée à `eval()`. Un fichier soigneusement nommé suffisait
+  donc à faire exécuter du code arbitraire par un simple rangement de photos.
+  L'évaluation se fait désormais sur l'arbre syntaxique, avec une liste
+  blanche : littéraux, `and` / `or` / `not`, comparaisons. Rien d'autre. La
+  syntaxe des conditions existantes est inchangée ; au pire une chaîne
+  malveillante rend la condition fausse.
+* `_renomme()` affectait `self.obj.filename` avec le chemin cible **avant**
+  la copie, et sans revenir en arrière si rien ne bougeait. Après un appel en
+  `debug`, ou sur une cible déjà occupée, l'objet se croyait donc à un endroit
+  où son fichier n'était pas. L'objet ne déménage plus qu'une fois la cible
+  vérifiée.
+* La comparaison de taille qui valide le transfert n'était faite que dans la
+  branche `else` d'un `try`, après un `except OSError` qui laissait passer
+  `ENOTSUP` — mais le commentaire d'origine disait bien qu'il fallait
+  « le tester ensuite ». Elle est désormais faite dans tous les cas, et un
+  écart lève `TransfertIncomplet` **en laissant l'original en place**.
+* `Gabarits.gabarits_valides()` renvoyait `False` — une valeur, depuis un
+  générateur — quand une condition levait une exception, ce qui interrompait
+  silencieusement le parcours et écartait les gabarits suivants, y compris
+  celui sans condition qui sert de filet. Une condition qui ne s'évalue pas
+  est maintenant simplement fausse.
+* `Gabarits.choisit_gabarit()` attrapait `Exception` autour d'un `next()` :
+  n'importe quelle erreur d'évaluation ressortait en « pas de gabarit ». Seul
+  l'épuisement du générateur (`StopIteration`) est désormais traduit.
+* Import `filecmp` inutilisé, hérité d'une vérification d'intégrité
+  abandonnée (« filecmp marche pas sur mon serveur O_O »).

--- a/src/automatheque.renommage/MANIFEST.in
+++ b/src/automatheque.renommage/MANIFEST.in
@@ -1,0 +1,1 @@
+include automatheque/renommage/py.typed

--- a/src/automatheque.renommage/README.md
+++ b/src/automatheque.renommage/README.md
@@ -1,0 +1,116 @@
+# automatheque.renommage
+
+Renommage et rangement de fichiers par gabarits.
+
+## Détail
+
+Un **gabarit** est un squelette de chemin — `{date:%Y}/{album}/{nom}` —
+assorti d'une condition qui dit quand il s'applique et d'un ordre qui le
+priorise. Le **renommeur** choisit le premier gabarit applicable, en déduit un
+nouveau chemin, et y déplace le fichier.
+
+C'est l'opération symétrique de `automatheque.decomposition` : là où celle-ci
+tire des métadonnées d'un chemin, celle-ci construit un chemin à partir de
+métadonnées. Les deux sont des distributions séparées parce que seule
+celle-ci écrit sur le disque : un consommateur qui indexe sans jamais déplacer
+n'a pas à en dépendre.
+
+## Les briques
+
+* **`Gabarit`** — un squelette, une condition, un ordre.
+* **`Gabarits`** — la liste des gabarits, et l'algorithme de choix : d'abord
+  ceux dont la condition est vérifiée, classés par ordre, puis ceux qui n'ont
+  pas de condition. Un gabarit sans condition est donc un filet de sécurité,
+  pas un concurrent.
+* **`Renommable`** — mixin à faire hériter par l'objet à ranger. Il expose
+  `filename` et surcharge `_gabarits_par_defaut()` et `_liste_champs_dispo()`.
+* **`Renommeur`** — le déplacement lui-même.
+
+## Exemple
+
+```py
+import attr
+
+from automatheque.renommage import Gabarit, Gabarits, Renommable
+
+
+@attr.s
+class Photo(Renommable):
+    album = attr.ib(default="", kw_only=True)
+    annee = attr.ib(default="", kw_only=True)
+
+    @classmethod
+    def _gabarits_par_defaut(cls):
+        return Gabarits(
+            [
+                Gabarit(
+                    squelette="{annee}/{album}/{nom}", condition='"{album}"', ordre=1
+                ),
+                Gabarit(squelette="a-trier/{nom}", ordre=9),
+            ]
+        )
+
+    def _liste_champs_dispo(self):
+        return {"album": self.album, "annee": self.annee, "nom": ...}
+
+
+photo = Photo(filename="/entree/DSC_0001.jpg", album="Japon", annee="2013")
+photo.renomme("/photos")
+# /photos/2013/Japon/DSC_0001.jpg
+```
+
+## La configuration est reçue, pas cherchée
+
+Les gabarits vivent souvent dans un fichier de configuration :
+
+```ini
+[renommage]
+r1 = ['{annee}/{album}/{nom}', '"{album}"', 1]
+r2 = ['a-trier/{nom}', '', 9]
+```
+
+`Gabarits.depuis_configuration(config, section)` les en tire, et le résultat
+est **passé** au renommeur :
+
+```py
+gabarits = Gabarits.depuis_configuration(charge_configuration(), "renommage")
+Renommeur(photo, gabarits=gabarits).renomme("/photos")
+```
+
+Le renommeur ne consulte aucun état global : c'est l'appelant qui décide d'où
+viennent ses gabarits. Le code d'origine appelait `charge_configuration()`
+lui-même — une localisation de service, qui rendait le renommage dépendant
+d'un fichier de configuration présent au bon endroit, et intestable sans lui.
+
+## Ce que le renommage ne fait pas
+
+* **Il n'écrit pas d'attributs étendus.** Le code d'origine posait
+  discrètement `user.automatheque.fichier_orig` et
+  `user.automatheque.modele.classe` dans les xattr du fichier, à chaque
+  renommage. Les xattr ne survivent ni à la plupart des copies, ni aux
+  archives, ni aux transferts réseau : c'est le plus fragile des supports pour
+  de la provenance. Conserver le nom d'origine relève de l'application, qui
+  sait où elle range ses métadonnées.
+* **Il ne modifie pas le contenu du fichier.** Écrire des étiquettes dans une
+  image est l'affaire d'un adaptateur.
+
+## Transfert
+
+Le déplacement est une copie, suivie d'une vérification de taille, suivie de
+la suppression de l'original. `shutil.move` seul ne dirait pas si la copie
+s'est mal passée d'un système de fichiers à l'autre ; ici, une cible qui ne
+correspond pas lève `TransfertIncomplet` **et laisse l'original en place**.
+
+## Requirement
+
+Python >=3.9
+
+## Installation
+
+```bash
+pip install automatheque.renommage
+```
+
+## License
+
+LGPLv3.0 ou ultérieure

--- a/src/automatheque.renommage/automatheque/__init__.py
+++ b/src/automatheque.renommage/automatheque/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/src/automatheque.renommage/automatheque/renommage/__init__.py
+++ b/src/automatheque.renommage/automatheque/renommage/__init__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Renommage et rangement de fichiers par gabarits."""
+
+from .condition import evalue_condition
+from .exceptions import (
+    AucunGabaritApplicable,
+    ConditionInvalide,
+    GabaritInapplicable,
+    RenommageEchec,
+    TransfertIncomplet,
+)
+from .renommeur import (
+    SECTION_CONFIG_PAR_DEFAUT,
+    Gabarit,
+    Gabarits,
+    Renommable,
+    Renommeur,
+)
+
+__all__ = [
+    "SECTION_CONFIG_PAR_DEFAUT",
+    "AucunGabaritApplicable",
+    "ConditionInvalide",
+    "Gabarit",
+    "Gabarits",
+    "GabaritInapplicable",
+    "RenommageEchec",
+    "Renommable",
+    "Renommeur",
+    "TransfertIncomplet",
+    "evalue_condition",
+]

--- a/src/automatheque.renommage/automatheque/renommage/condition.py
+++ b/src/automatheque.renommage/automatheque/renommage/condition.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""Évaluation des conditions de gabarit.
+
+Une condition est une expression booléenne écrite dans la configuration,
+formatée avec les champs de l'objet à renommer avant d'être évaluée :
+
+```ini
+r5 = ['{date.year}/{date:%%Y-%%m-%%d} @{ville} {pays}/{nom}',
+      '"{date}" and "{ville}" and "{pays}" != "FR"', 3]
+```
+
+Une fois formatée, la condition ci-dessus devient
+``'"2013-03-17" and "Osaka" and "JP" != "FR"'``.
+
+Le code d'origine passait cette chaîne à `eval()`. Or les champs qui y sont
+injectés viennent des **métadonnées des fichiers traités** — un album, un nom
+de ville, une description. Un fichier soigneusement nommé suffisait donc à
+faire exécuter du code arbitraire par un simple rangement de photos.
+
+L'évaluation est ici faite sur l'arbre syntaxique, avec une liste blanche de
+nœuds : des littéraux, `and` / `or` / `not`, et des comparaisons. Rien
+d'autre. La syntaxe des conditions existantes est inchangée ; au pire, une
+chaîne malveillante fait maintenant échouer la condition au lieu de sortir de
+son bac à sable.
+"""
+
+import ast
+from typing import Any
+
+from .exceptions import ConditionInvalide
+
+# Nœuds acceptés dans une condition. Tout ce qui appelle, importe, indexe,
+# accède à un attribut ou nomme une variable en est absent — volontairement.
+_NOEUDS_AUTORISES = (
+    ast.Expression,
+    ast.BoolOp,
+    ast.And,
+    ast.Or,
+    ast.UnaryOp,
+    ast.Not,
+    ast.Compare,
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+    ast.In,
+    ast.NotIn,
+    ast.Constant,
+    ast.Tuple,
+    ast.List,
+    ast.Load,
+)
+
+
+def evalue_condition(condition: str) -> Any:
+    """Évalue une condition déjà formatée, sans jamais exécuter de code.
+
+    :param condition: expression booléenne composée de littéraux
+    :raise ConditionInvalide: si l'expression est mal formée, ou si elle
+                              contient autre chose que des littéraux, des
+                              opérateurs booléens et des comparaisons
+    """
+    try:
+        arbre = ast.parse(condition, mode="eval")
+    except SyntaxError as exc:
+        raise ConditionInvalide(condition, "expression mal formée") from exc
+
+    for noeud in ast.walk(arbre):
+        if not isinstance(noeud, _NOEUDS_AUTORISES):
+            raise ConditionInvalide(
+                condition,
+                "{} n'est pas autorisé dans une condition".format(type(noeud).__name__),
+            )
+
+    # À ce stade l'arbre ne contient que des littéraux et des opérateurs :
+    # `eval` n'a plus rien à se mettre sous la dent.
+    return eval(compile(arbre, "<condition>", "eval"), {"__builtins__": {}}, {})

--- a/src/automatheque.renommage/automatheque/renommage/exceptions.py
+++ b/src/automatheque.renommage/automatheque/renommage/exceptions.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Exceptions propres au renommage.
+
+Elles héritent de :class:`automatheque.exceptions.AutomathequeBaseException`
+afin que le code appelant puisse filtrer d'un seul `except` toutes les
+exceptions de l'automathèque.
+"""
+
+from automatheque.exceptions import AutomathequeBaseException
+
+
+class RenommageEchec(AutomathequeBaseException):
+    """Le renommage n'a pas abouti."""
+
+    def __init__(self, msg="Renommage échoué."):
+        """Initialisation."""
+        self.msg = msg
+        super().__init__(self.msg)
+
+
+class AucunGabaritApplicable(RenommageEchec, ValueError):
+    """Aucun gabarit ne s'applique à l'objet à renommer.
+
+    Hérite aussi de :class:`ValueError`, que levait le code d'origine : un
+    appelant qui l'attrapait continue de fonctionner.
+    """
+
+    def __init__(self, msg="Aucun gabarit applicable."):
+        """Initialisation."""
+        super().__init__(msg)
+
+
+class GabaritInapplicable(RenommageEchec, ValueError):
+    """Le gabarit choisi n'a pas pu produire un nom de fichier.
+
+    En pratique : son squelette référence un champ que l'objet ne fournit pas.
+    """
+
+    def __init__(self, squelette, raison=""):
+        """Initialisation."""
+        self.squelette = squelette
+        super().__init__(
+            "Le squelette '{}' n'a pas pu être formaté. {}".format(squelette, raison)
+        )
+
+
+class ConditionInvalide(RenommageEchec, ValueError):
+    """La condition d'un gabarit n'est pas une expression évaluable.
+
+    Soit elle est mal formée, soit elle contient autre chose que des
+    littéraux, des opérateurs booléens et des comparaisons.
+    """
+
+    def __init__(self, condition, raison=""):
+        """Initialisation."""
+        self.condition = condition
+        super().__init__("Condition invalide : '{}'. {}".format(condition, raison))
+
+
+class TransfertIncomplet(RenommageEchec):
+    """La copie vers la cible n'a pas produit un fichier identique.
+
+    L'original est conservé : le supprimer perdrait des données.
+    """
+
+    def __init__(self, source, cible):
+        """Initialisation."""
+        self.source = source
+        self.cible = cible
+        super().__init__(
+            "Les deux fichiers sont différents {} -> {}".format(source, cible)
+        )

--- a/src/automatheque.renommage/automatheque/renommage/renommeur.py
+++ b/src/automatheque.renommage/automatheque/renommage/renommeur.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+"""Renommage et rangement de fichiers par gabarits.
+
+Un **gabarit** est un squelette de chemin — `{date:%Y}/{album}/{nom}` — assorti
+d'une condition qui dit quand il s'applique et d'un ordre qui le priorise. Le
+**renommeur** choisit le premier gabarit applicable, en déduit un nouveau
+chemin, et y déplace le fichier.
+
+C'est l'opération symétrique de `automatheque.decomposition` : là où celle-ci
+tire des métadonnées d'un chemin, celle-ci construit un chemin à partir de
+métadonnées.
+"""
+
+import ast
+import errno
+import logging
+import os
+import shutil
+from operator import attrgetter
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+import attr
+
+from .condition import evalue_condition
+from .exceptions import (
+    AucunGabaritApplicable,
+    GabaritInapplicable,
+    TransfertIncomplet,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+# Section de configuration lue par défaut par `Gabarits.depuis_configuration`.
+SECTION_CONFIG_PAR_DEFAUT = "renommage"
+
+
+@attr.s
+class Gabarit:
+    """Gabarit à appliquer sur les objets `Renommable`.
+
+    Un gabarit consiste en :
+
+    * un **squelette** qui sera utilisé pour formatter l'objet `Renommable` à
+      partir de ses champs disponibles et en déduire un nouveau nom ;
+    * une **condition** qui détermine si le squelette est applicable ; un
+      gabarit sans condition s'applique toujours ;
+    * un **ordre** de traitement pour prioriser certains gabarits, le plus
+      petit d'abord.
+    """
+
+    squelette: str = attr.ib(default="")
+    condition: str = attr.ib(default="")
+    ordre: int = attr.ib(default=0)
+
+
+class Gabarits:
+    """La liste des gabarits utilisables pour un renommage."""
+
+    def __init__(self, gabarits: Optional[List[Gabarit]] = None):
+        """Initialisation."""
+        self._gabarits: List[Gabarit] = list(gabarits or [])
+        self.gabarit_choisi: Optional[Gabarit] = None
+
+    def __iter__(self) -> Iterator[Gabarit]:
+        """Itère sur les gabarits, dans l'ordre où ils ont été ajoutés."""
+        return iter(self._gabarits)
+
+    def __len__(self) -> int:
+        """Nombre de gabarits."""
+        return len(self._gabarits)
+
+    def __json__(self):
+        """Pour pouvoir afficher les objets en JSON."""
+        return [attr.asdict(g) for g in self._gabarits]
+
+    def append(self, gabarit: Gabarit) -> None:
+        """Ajoute un gabarit à la liste."""
+        self._gabarits.append(gabarit)
+
+    @classmethod
+    def depuis_configuration(
+        cls, config, section: str = SECTION_CONFIG_PAR_DEFAUT
+    ) -> "Gabarits":
+        """Construit les gabarits depuis une configuration de type `ConfigParser`.
+
+        Chaque option de la section porte un triplet
+        `[squelette, condition, ordre]`, écrit comme un littéral Python :
+
+        ```ini
+        [renommage]
+        r1 = ['{date:%%Y}/{album}/{nom}', '"{album}"', 1]
+        r2 = ['a-trier/{nom}', '', 9]
+        ```
+
+        Le triplet est lu avec `ast.literal_eval` et non `eval` : un fichier de
+        configuration décrit des données, il n'a pas à pouvoir exécuter du code.
+
+        :param config: objet exposant `options(section)` et `get(section, option)`
+        :param section: section à lire
+        :raise ValueError: si une option n'est pas un triplet lisible
+        """
+        gabarits = cls()
+        for option in config.options(section):
+            brut = config.get(section, option)
+            try:
+                squelette, condition, ordre = ast.literal_eval(brut)
+            except (ValueError, SyntaxError) as exc:
+                raise ValueError(
+                    "[{}] {} : attendu [squelette, condition, ordre], lu {!r}".format(
+                        section, option, brut
+                    )
+                ) from exc
+            gabarits.append(
+                Gabarit(squelette=squelette, condition=condition, ordre=ordre)
+            )
+        return gabarits
+
+    def gabarits_valides(self, obj) -> Iterator[Gabarit]:
+        """Génère les gabarits applicables à l'objet, dans l'ordre.
+
+        D'abord ceux dont la condition est vérifiée, puis ceux qui n'ont pas de
+        condition — les uns comme les autres classés par `ordre`. Un gabarit
+        sans condition est donc un filet de sécurité, pas un concurrent.
+        """
+        avec_condition = [g for g in self._gabarits if g.condition]
+        for gabarit in sorted(avec_condition, key=attrgetter("ordre")):
+            if self.teste_condition(obj, gabarit.condition):
+                yield gabarit
+
+        sans_condition = [g for g in self._gabarits if not g.condition]
+        for gabarit in sorted(sans_condition, key=attrgetter("ordre")):
+            yield gabarit
+
+    def choisit_gabarit(self, obj) -> Gabarit:
+        """Retient le premier gabarit applicable, et le renvoie.
+
+        :raise AucunGabaritApplicable: si aucun ne convient
+        """
+        try:
+            self.gabarit_choisi = next(self.gabarits_valides(obj))
+        except StopIteration:
+            raise AucunGabaritApplicable()
+        return self.gabarit_choisi
+
+    @classmethod
+    def teste_condition(cls, obj, condition: str) -> bool:
+        """Teste la condition d'un gabarit sur l'objet donné.
+
+        La condition est formatée avec les champs de l'objet, puis évaluée —
+        `'"{album}" == "Meteora"'` avec les mêmes champs que le squelette.
+
+        Une condition qui ne s'évalue pas — champ absent, expression mal
+        formée — est **fausse**, pas fatale : le gabarit suivant est essayé.
+        """
+        try:
+            formatee = condition.format(**obj._liste_champs_dispo())
+            return bool(evalue_condition(formatee))
+        except Exception:
+            LOGGER.exception("Erreur durant le test de la condition.")
+            return False
+
+
+@attr.s
+class Renommable:
+    """Classe à hériter/surcharger pour être facilement renommable.
+
+    L'objet doit exposer `filename`, le chemin du fichier à déplacer, et
+    surcharger les deux méthodes ci-dessous.
+
+    TODO : `filename` fait doublon avec `source` de `automatheque.schema.media`
+    quand les deux sont mêlées par sous-classage — les deux noms désignent le
+    même fichier et peuvent diverger après un renommage. À arbitrer.
+    """
+
+    filename: str = attr.ib(default="")  # TODO nom_fichier au lieu de filename
+
+    @classmethod
+    def _gabarits_par_defaut(cls) -> Gabarits:
+        """Renvoie les gabarits à utiliser faute de mieux. À surcharger."""
+        raise NotImplementedError
+
+    def _liste_champs_dispo(self) -> dict:
+        """Champs disponibles pour formater squelettes et conditions.
+
+        À surcharger : c'est la projection des métadonnées de l'objet vers le
+        vocabulaire des gabarits, et elle est propre à chaque application.
+
+        TODO : on peut même gérer plusieurs langues !
+        """
+        raise NotImplementedError
+
+    def renomme(self, rep_cible, gabarits=None, debug=False, force=False, copier=False):
+        """Enveloppe de `Renommeur.renomme` pour le cas courant."""
+        return Renommeur(self, gabarits=gabarits).renomme(
+            rep_cible, debug=debug, force=force, copier=copier
+        )
+
+
+class Renommeur:
+    """Gère le renommage de l'objet `Renommable` donné.
+
+    Le renommage est effectué à partir de gabarits spécifiques, que l'on peut
+    écrire soi-même.
+    """
+
+    def __init__(self, obj: Renommable, gabarits: Optional[Gabarits] = None):
+        """Initialisation.
+
+        La configuration n'est plus **cherchée** ici : elle est **reçue**. Un
+        appelant qui range ses gabarits dans un fichier de configuration les
+        construit avec `Gabarits.depuis_configuration(config, section)` et les
+        passe ici. Le renommeur, lui, ne consulte aucun état global — ce qui le
+        rend testable et prévisible.
+
+        :param obj: doit être un objet `Renommable`
+        :param gabarits: gabarits à appliquer ; à défaut, ceux que l'objet
+                         renvoie par `_gabarits_par_defaut()`
+        """
+        if not isinstance(obj, Renommable):
+            raise ValueError("obj doit etre une instance de Renommable")
+        self.obj = obj
+        self.gabarits = gabarits if gabarits is not None else obj._gabarits_par_defaut()
+
+    def _construire_nouveau_nom(self) -> str:
+        """Construit le nouveau nom de l'objet à renommer.
+
+        :raise AucunGabaritApplicable: si aucun gabarit ne convient
+        :raise GabaritInapplicable: si le squelette retenu ne peut être formaté
+        """
+        champs = self.obj._liste_champs_dispo()
+        gabarit = self.gabarits.choisit_gabarit(self.obj)
+        LOGGER.debug("Gabarit choisi : %s", gabarit)
+        try:
+            return gabarit.squelette.format(**champs)
+        except (KeyError, IndexError, ValueError, AttributeError, TypeError) as exc:
+            raise GabaritInapplicable(gabarit.squelette, str(exc)) from exc
+
+    def _renomme(self, rep_cible, nom_fichier, debug=False, force=False, copier=False):
+        """Déplace le fichier vers `rep_cible/nom_fichier`.
+
+        Le transfert est une copie suivie d'une vérification de taille, puis de
+        la suppression de l'original — `shutil.move` ne dirait pas si la copie
+        s'est mal passée entre deux systèmes de fichiers.
+
+        :returns: le chemin cible, qu'il ait été atteint ou non
+        """
+        fichier_cible = os.path.join(rep_cible, nom_fichier)
+        fichier_orig = self.obj.filename
+
+        if debug or (os.path.exists(fichier_cible) and not force):
+            LOGGER.warning(
+                "Pas de deplacement : %s", "debug" if debug else "fichier existe"
+            )
+            return fichier_cible
+
+        # Creation du répertoire parent si besoin :
+        Path(os.path.dirname(fichier_cible)).mkdir(parents=True, exist_ok=True)
+
+        LOGGER.debug("Déplacement vers cible : %s", fichier_cible)
+        try:
+            # Attention, si le fichier cible existe il est écrasé.
+            # Pour changer ce fonctionnement voir ici :
+            # https://gist.github.com/alexwlchan/c2adbb8ee782f460e5ec
+            shutil.copy(fichier_orig, fichier_cible)
+        except OSError as exc:
+            if exc.errno != errno.ENOTSUP:
+                LOGGER.error(
+                    "[E] Echec shutil.copy(%s, %s) : %s",
+                    fichier_orig,
+                    fichier_cible,
+                    exc,
+                )
+                raise
+            # ENOTSUP remonte lorsque l'on ne peut pas changer les droits ou
+            # les attributs d'un fichier. Le transfert s'est peut-être bien
+            # passé malgré tout : on le vérifie juste après.
+
+        if os.path.getsize(fichier_cible) != os.path.getsize(fichier_orig):
+            raise TransfertIncomplet(fichier_orig, fichier_cible)
+
+        # La cible est bonne : c'est seulement maintenant que l'objet déménage.
+        self.obj.filename = fichier_cible
+        if not copier:
+            os.remove(fichier_orig)
+        return fichier_cible
+
+    def renomme(self, rep_cible, debug=False, force=False, copier=False):
+        """Range le fichier dans `rep_cible`, sous le nom que dictent les gabarits.
+
+        :param rep_cible: répertoire cible du déplacement
+        :param debug: calcule le chemin cible sans rien déplacer
+        :param force: écrase un fichier cible existant
+        :param copier: conserve l'original au lieu de le supprimer
+        :returns: le chemin cible
+        """
+        nom_fichier = self._construire_nouveau_nom()
+        return self._renomme(
+            rep_cible, nom_fichier, debug=debug, force=force, copier=copier
+        )

--- a/src/automatheque.renommage/pyproject.toml
+++ b/src/automatheque.renommage/pyproject.toml
@@ -1,0 +1,42 @@
+[project]
+name = "automatheque.renommage"
+version = "0.19.0"
+description = "Renommage et rangement de fichiers par gabarits"
+authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
+license = {text = "LGPL-3.0-or-later"}
+requires-python = ">=3.9"
+readme = "README.md"
+classifiers = [
+    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+dependencies = [
+    # >=0.19.0 : plancher aligné sur la version courante du cœur, dont ce
+    # paquet utilise `exceptions.AutomathequeBaseException`. Le cœur ne sert
+    # plus qu'à ça ici : la configuration est désormais *reçue* et non chargée,
+    # et `mkdir_p` — déprécié en 0.19.0 — a laissé place à `Path.mkdir`.
+    "automatheque>=0.19.0",
+    "attrs>=19.2",
+]
+
+[project.urls]
+Home = "https://github.com/jaegerbobomb/automatheque/tree/main/src/automatheque.renommage/"
+Repository = "https://github.com/jaegerbobomb/automatheque.git"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+# Embarque le marqueur py.typed dans le wheel (typage exporté). Cf. #3.
+[tool.setuptools.package-data]
+"automatheque.renommage" = ["py.typed"]

--- a/src/automatheque.renommage/setup.py
+++ b/src/automatheque.renommage/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup(name="automatheque.renommage")

--- a/src/automatheque.renommage/tests/test_renommeur.py
+++ b/src/automatheque.renommage/tests/test_renommeur.py
@@ -1,0 +1,341 @@
+# -*- coding: utf-8 -*-
+"""Tests du renommage.
+
+L'ancien dépôt n'avait aucune couverture sur ce module, alors que c'est
+précisément son comportement de rangement que les applications doivent
+préserver. Ces tests sont écrits à la remontée.
+"""
+
+import configparser
+import os
+
+import attr
+import pytest
+from automatheque.renommage import (
+    AucunGabaritApplicable,
+    ConditionInvalide,
+    Gabarit,
+    GabaritInapplicable,
+    Gabarits,
+    Renommable,
+    Renommeur,
+    TransfertIncomplet,
+    evalue_condition,
+)
+
+
+@attr.s
+class Photo(Renommable):
+    """Un renommable minimal."""
+
+    album = attr.ib(default="", kw_only=True)
+    annee = attr.ib(default="", kw_only=True)
+    pays = attr.ib(default="", kw_only=True)
+
+    @classmethod
+    def _gabarits_par_defaut(cls):
+        return Gabarits(
+            [
+                Gabarit(squelette="{annee}/{album}/{nom}", condition='"{album}"'),
+                Gabarit(squelette="a-trier/{nom}", ordre=9),
+            ]
+        )
+
+    def _liste_champs_dispo(self):
+        return {
+            "album": self.album,
+            "annee": self.annee,
+            "pays": self.pays,
+            "nom": os.path.basename(self.filename),
+        }
+
+
+@pytest.fixture
+def photo(tmp_path):
+    """Une photo posée sur le disque, prête à être rangée."""
+    fichier = tmp_path / "source" / "DSC_0001.jpg"
+    fichier.parent.mkdir()
+    fichier.write_bytes(b"des octets de photo")
+    return Photo(filename=str(fichier), album="Japon", annee="2013")
+
+
+#
+# Gabarits
+#
+
+
+def test_gabarit_sans_condition_s_applique_toujours():
+    gabarits = Gabarits([Gabarit(squelette="a-trier/{nom}")])
+    assert gabarits.choisit_gabarit(Photo()).squelette == "a-trier/{nom}"
+
+
+def test_gabarit_avec_condition_vraie_passe_avant_celui_sans_condition():
+    photo = Photo(filename="/a/b.jpg", album="Japon", annee="2013")
+    assert (
+        photo._gabarits_par_defaut()
+        .choisit_gabarit(photo)
+        .squelette.startswith("{annee}")
+    )
+
+
+def test_gabarit_avec_condition_fausse_est_ecarte():
+    photo = Photo(filename="/a/b.jpg", album="", annee="2013")
+    assert (
+        photo._gabarits_par_defaut().choisit_gabarit(photo).squelette == "a-trier/{nom}"
+    )
+
+
+def test_les_conditions_vraies_sont_classees_par_ordre():
+    gabarits = Gabarits(
+        [
+            Gabarit(squelette="tard", condition='"oui"', ordre=5),
+            Gabarit(squelette="tot", condition='"oui"', ordre=1),
+        ]
+    )
+    assert gabarits.choisit_gabarit(Photo()).squelette == "tot"
+
+
+def test_sans_aucun_gabarit_applicable():
+    gabarits = Gabarits([Gabarit(squelette="jamais", condition='"" and "x"')])
+    with pytest.raises(AucunGabaritApplicable):
+        gabarits.choisit_gabarit(Photo())
+
+
+def test_aucun_gabarit_applicable_reste_un_value_error():
+    """Rétro-compat : le code d'origine levait un `ValueError` nu."""
+    assert issubclass(AucunGabaritApplicable, ValueError)
+
+
+def test_condition_referencant_un_champ_absent_est_fausse():
+    """Elle n'interrompt pas le choix : le gabarit suivant est essayé."""
+    gabarits = Gabarits(
+        [
+            Gabarit(squelette="jamais", condition='"{champ_inconnu}"'),
+            Gabarit(squelette="filet", ordre=9),
+        ]
+    )
+    assert gabarits.choisit_gabarit(Photo()).squelette == "filet"
+
+
+def test_gabarits_est_iterable_et_mesurable():
+    gabarits = Gabarits()
+    gabarits.append(Gabarit(squelette="a"))
+    gabarits.append(Gabarit(squelette="b"))
+    assert len(gabarits) == 2
+    assert [g.squelette for g in gabarits] == ["a", "b"]
+
+
+def test_json_expose_les_gabarits():
+    gabarits = Gabarits([Gabarit(squelette="a", condition="", ordre=3)])
+    assert gabarits.__json__() == [{"squelette": "a", "condition": "", "ordre": 3}]
+
+
+#
+# Conditions
+#
+
+
+def test_evalue_condition_litteraux_et_operateurs():
+    assert evalue_condition('"Osaka" and "JP"')
+    assert not evalue_condition('"" and "JP"')
+    assert evalue_condition('"JP" != "FR"')
+    assert not evalue_condition('"FR" != "FR"')
+    assert evalue_condition('not ""')
+    assert evalue_condition('"a" or ""')
+
+
+def test_evalue_condition_refuse_un_appel():
+    """Régression : les champs viennent des métadonnées des fichiers traités.
+
+    Le code d'origine passait la condition formatée à `eval()` : un fichier
+    dont l'album portait le bon texte faisait exécuter du code arbitraire.
+    """
+    with pytest.raises(ConditionInvalide):
+        evalue_condition('__import__("os").system("echo compromis")')
+
+
+def test_evalue_condition_refuse_un_nom():
+    with pytest.raises(ConditionInvalide):
+        evalue_condition("open")
+
+
+def test_evalue_condition_refuse_un_acces_attribut():
+    with pytest.raises(ConditionInvalide):
+        evalue_condition('"".__class__')
+
+
+def test_evalue_condition_refuse_une_expression_mal_formee():
+    with pytest.raises(ConditionInvalide):
+        evalue_condition('"Osaka" and and')
+
+
+def test_injection_par_les_metadonnees_ne_s_execute_pas():
+    """Bout en bout : un album malveillant ne fait qu'invalider la condition."""
+    photo = Photo(filename="/a/b.jpg", album='" and __import__("os").getcwd() and "')
+    gabarits = Gabarits(
+        [
+            Gabarit(squelette="dangereux", condition='"{album}"'),
+            Gabarit(squelette="filet", ordre=9),
+        ]
+    )
+    assert gabarits.choisit_gabarit(photo).squelette == "filet"
+
+
+#
+# Configuration reçue, et non chargée
+#
+
+
+def _config(texte):
+    config = configparser.ConfigParser()
+    config.read_string(texte)
+    return config
+
+
+def test_gabarits_depuis_configuration():
+    config = _config(
+        "[renommage]\n"
+        "r1 = ['{annee}/{album}/{nom}', '\"{album}\"', 1]\n"
+        "r2 = ['a-trier/{nom}', '', 9]\n"
+    )
+    gabarits = Gabarits.depuis_configuration(config)
+    assert len(gabarits) == 2
+    assert [g.ordre for g in gabarits] == [1, 9]
+    assert list(gabarits)[0].squelette == "{annee}/{album}/{nom}"
+
+
+def test_gabarits_depuis_configuration_section_choisie():
+    config = _config("[rangement_photos]\nr1 = ['{nom}', '', 1]\n")
+    assert len(Gabarits.depuis_configuration(config, "rangement_photos")) == 1
+
+
+def test_gabarits_depuis_configuration_option_illisible():
+    config = _config("[renommage]\nr1 = pas un triplet\n")
+    with pytest.raises(ValueError):
+        Gabarits.depuis_configuration(config)
+
+
+def test_configuration_n_execute_pas_de_code():
+    """`literal_eval`, pas `eval` : un fichier de conf décrit des données."""
+    config = _config('[renommage]\nr1 = __import__("os").getcwd()\n')
+    with pytest.raises(ValueError):
+        Gabarits.depuis_configuration(config)
+
+
+def test_renommeur_ne_consulte_aucune_configuration_globale(photo, tmp_path):
+    """Les gabarits fournis explicitement sont les seuls utilisés."""
+    gabarits = Gabarits([Gabarit(squelette="explicite/{nom}")])
+    cible = Renommeur(photo, gabarits=gabarits).renomme(str(tmp_path / "cible"))
+    assert cible.endswith(os.path.join("explicite", "DSC_0001.jpg"))
+
+
+def test_renommeur_retombe_sur_les_gabarits_par_defaut(photo, tmp_path):
+    cible = Renommeur(photo).renomme(str(tmp_path / "cible"))
+    assert cible.endswith(os.path.join("2013", "Japon", "DSC_0001.jpg"))
+
+
+def test_renommeur_refuse_un_objet_non_renommable():
+    with pytest.raises(ValueError):
+        Renommeur(object())
+
+
+#
+# Déplacement
+#
+
+
+def test_renomme_deplace_le_fichier(photo, tmp_path):
+    origine = photo.filename
+    cible = photo.renomme(str(tmp_path / "cible"))
+
+    assert os.path.exists(cible)
+    assert not os.path.exists(origine)
+    assert photo.filename == cible
+    assert open(cible, "rb").read() == b"des octets de photo"
+
+
+def test_renomme_cree_l_arborescence(photo, tmp_path):
+    cible = photo.renomme(str(tmp_path / "cible"))
+    assert cible == str(tmp_path / "cible" / "2013" / "Japon" / "DSC_0001.jpg")
+
+
+def test_renomme_en_copiant_conserve_l_original(photo, tmp_path):
+    origine = photo.filename
+    cible = photo.renomme(str(tmp_path / "cible"), copier=True)
+    assert os.path.exists(origine)
+    assert os.path.exists(cible)
+
+
+def test_debug_ne_deplace_rien_mais_annonce_la_cible(photo, tmp_path):
+    origine = photo.filename
+    cible = photo.renomme(str(tmp_path / "cible"), debug=True)
+
+    assert cible.endswith(os.path.join("2013", "Japon", "DSC_0001.jpg"))
+    assert not os.path.exists(cible)
+    assert os.path.exists(origine)
+
+
+def test_debug_ne_deplace_pas_l_objet_non_plus(photo, tmp_path):
+    """Régression : `filename` était réaffecté avant même la copie."""
+    origine = photo.filename
+    photo.renomme(str(tmp_path / "cible"), debug=True)
+    assert photo.filename == origine
+
+
+def test_cible_existante_n_est_pas_ecrasee(photo, tmp_path):
+    existant = tmp_path / "cible" / "2013" / "Japon" / "DSC_0001.jpg"
+    existant.parent.mkdir(parents=True)
+    existant.write_bytes(b"deja la")
+
+    origine = photo.filename
+    photo.renomme(str(tmp_path / "cible"))
+
+    assert existant.read_bytes() == b"deja la"
+    assert os.path.exists(origine)
+    assert photo.filename == origine
+
+
+def test_force_ecrase_la_cible_existante(photo, tmp_path):
+    existant = tmp_path / "cible" / "2013" / "Japon" / "DSC_0001.jpg"
+    existant.parent.mkdir(parents=True)
+    existant.write_bytes(b"deja la")
+
+    photo.renomme(str(tmp_path / "cible"), force=True)
+    assert existant.read_bytes() == b"des octets de photo"
+
+
+def test_transfert_incomplet_conserve_l_original(photo, tmp_path, monkeypatch):
+    """Si la copie tronque, on ne supprime surtout pas la source."""
+
+    def copie_tronquee(source, cible):
+        with open(cible, "wb") as f:
+            f.write(b"tronque")
+
+    monkeypatch.setattr("shutil.copy", copie_tronquee)
+
+    origine = photo.filename
+    with pytest.raises(TransfertIncomplet):
+        photo.renomme(str(tmp_path / "cible"))
+    assert os.path.exists(origine)
+
+
+def test_squelette_referencant_un_champ_absent(photo, tmp_path):
+    gabarits = Gabarits([Gabarit(squelette="{champ_inconnu}/{nom}")])
+    with pytest.raises(GabaritInapplicable):
+        photo.renomme(str(tmp_path / "cible"), gabarits=gabarits)
+
+
+def test_renommable_sans_surcharge_annonce_ce_qui_manque():
+    with pytest.raises(NotImplementedError):
+        Renommable._gabarits_par_defaut()
+    with pytest.raises(NotImplementedError):
+        Renommable()._liste_champs_dispo()
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "listxattr"), reason="attributs étendus absents de la plateforme"
+)
+def test_aucun_attribut_etendu_n_est_ecrit(photo, tmp_path):
+    """Le renommage n'écrit plus de xattr : la provenance va ailleurs."""
+    cible = photo.renomme(str(tmp_path / "cible"))
+    assert not os.listxattr(cible)


### PR DESCRIPTION
## Description

**4/4 de la remontée du socle média** — la plus invasive, en dernier comme prévu. Basée sur #112, à merger après elle.

Remonte la brique de rangement : `Gabarit`, `Gabarits`, `Renommable`, `Renommeur`. Un gabarit est un squelette de chemin assorti d'une condition et d'un ordre ; le renommeur choisit le premier applicable et y déplace le fichier. C'est l'opération symétrique de #111 — là où la décomposition tire des métadonnées d'un chemin, celle-ci construit un chemin à partir de métadonnées.

Le second commit ajoute au README racine les deux nouvelles distributions et la marche à suivre pour en ajouter une — la seule étape restée manuelle après #110 étant le *trusted publisher* PyPI, qui n'était documentée nulle part.

## Trois changements de fond

**La configuration est reçue, plus cherchée.** `Renommeur` appelait `charge_configuration()` lui-même — une localisation de service : le renommage dépendait d'un fichier présent au bon endroit, et n'était pas testable sans lui. Il reçoit désormais ses gabarits, et retombe sur ceux de l'objet à défaut. `Gabarits.depuis_configuration(config, section)` couvre le cas du fichier de conf, **au format historique** (`r1 = [squelette, condition, ordre]`).

**Plus d'écriture d'attributs étendus.** Le renommage posait `user.automatheque.fichier_orig` et `user.automatheque.modele.classe` dans les xattr à chaque passage, sans que ce soit annoncé nulle part. Les xattr ne survivent ni à la plupart des copies, ni aux archives, ni aux transferts réseau : c'est le plus fragile des supports pour de la provenance. Cela supprime du même coup la dépendance `xattr`, sensible à la plateforme et au système de fichiers.

**Une injection de code fermée.** La condition d'un gabarit est formatée avec les champs de l'objet — album, ville, description, soit des chaînes **venues des fichiers traités** — puis évaluée. Le code d'origine passait le résultat à `eval()` : un fichier soigneusement nommé suffisait à faire exécuter du code arbitraire par un simple rangement de photos. L'évaluation se fait maintenant sur l'arbre syntaxique, avec une liste blanche — littéraux, `and`/`or`/`not`, comparaisons, rien d'autre. La syntaxe des conditions existantes est inchangée ; au pire une chaîne malveillante rend la condition fausse. Le triplet lu dans la configuration passe de même par `ast.literal_eval`.

## Quatre corrections

L'objet ne déménage plus qu'une fois la cible vérifiée (un appel en `debug` le laissait croire qu'il était ailleurs). La vérification de taille qui valide le transfert était sautée quand la copie avait remonté un `ENOTSUP`, alors que le commentaire d'origine disait qu'il fallait « le tester ensuite » ; un écart lève désormais `TransfertIncomplet` **en laissant l'original en place**. Un générateur renvoyait `False` au lieu de continuer, écartant du même coup le gabarit sans condition qui sert de filet. `choisit_gabarit` traduisait n'importe quelle erreur en « pas de gabarit ».

## Ce que ça change pour les appelants

`Renommeur(obj, config_section=…)` → `Renommeur(obj, gabarits=…)`. Le paramètre `cumule_gabarits` disparaît : la composition d'un jeu de gabarits se fait côté appelant.

**33 tests**, écrits à la remontée — l'ancien dépôt n'en avait aucun ici, alors que c'est ce comportement de rangement que les applications doivent préserver.

## Avant de taguer

Les deux nouvelles distributions (celle-ci et #111) ont besoin d'un ***trusted publisher* PyPI** déclaré, pointant ce dépôt et `release.yml`. Rappel de `release.yml` : seuls les paquets dont la version égale le tag sont publiés — les livrer ensemble suppose de les bumper à la même version.

## Issues liées

Aucune issue ouverte ne couvrait cette distribution — au contraire de #43 pour la décomposition. Elle est décrite par l'ADR-0004 et la story S010 de `nestor/photos`.