### PR TITLE
chore: verse dans main la fin de la pile (schema, renommage, docs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install $(printf -- '-e %s ' src/*/)
-          pip install pytest pytest-cov
+          # vobject : extra `automatheque.schema[calendrier]`. Les extras ne
+          # s'installent pas avec `-e src/…`, et sans lui les tests de
+          # conversion iCalendar se sauteraient silencieusement
+          # (`pytest.importorskip`).
+          pip install pytest pytest-cov vobject
 
       - name: Lance les tests avec couverture
         run: pytest src --cov=automatheque --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 | [`automatheque`](https://pypi.org/project/automatheque/) | [![PyPI](https://img.shields.io/pypi/v/automatheque.svg)](https://pypi.org/project/automatheque/) | ![Python](https://img.shields.io/pypi/pyversions/automatheque.svg) |
 | [`automatheque.factrice`](https://pypi.org/project/automatheque.factrice/) | [![PyPI](https://img.shields.io/pypi/v/automatheque.factrice.svg)](https://pypi.org/project/automatheque.factrice/) | ![Python](https://img.shields.io/pypi/pyversions/automatheque.factrice.svg) |
 | [`automatheque.schema`](https://pypi.org/project/automatheque.schema/) | [![PyPI](https://img.shields.io/pypi/v/automatheque.schema.svg)](https://pypi.org/project/automatheque.schema/) | ![Python](https://img.shields.io/pypi/pyversions/automatheque.schema.svg) |
+| [`automatheque.decomposition`](https://pypi.org/project/automatheque.decomposition/) | [![PyPI](https://img.shields.io/pypi/v/automatheque.decomposition.svg)](https://pypi.org/project/automatheque.decomposition/) | ![Python](https://img.shields.io/pypi/pyversions/automatheque.decomposition.svg) |
+| [`automatheque.renommage`](https://pypi.org/project/automatheque.renommage/) | [![PyPI](https://img.shields.io/pypi/v/automatheque.renommage.svg)](https://pypi.org/project/automatheque.renommage/) | ![Python](https://img.shields.io/pypi/pyversions/automatheque.renommage.svg) |
 
 > Le badge de couverture est un **snapshot** (mis à jour à la main). On peut le
 > rendre *vivant* via Codecov si besoin — cf. PR.
@@ -28,6 +30,25 @@ Nous essayons dans un mono répo de gérer des sous-paquets python, pour
 avoir un unique namespace "automatheque" et pouvoir publier les sous paquets "automatheque.schema" etc.
 
 Voir (https://packaging.python.org/en/latest/guides/packaging-namespace-packages/) pour plus d'informations.
+
+### Ajouter une distribution
+
+Un nouveau répertoire sous `src/` suffit : `monas` le voit
+(`packages = ["src/*"]`), et la CI comme la publication **dérivent la même
+liste** — un paquet ajouté est donc testé et publié d'office.
+
+Le squelette se copie depuis un paquet existant : `pyproject.toml`,
+`setup.py` (deux lignes), `MANIFEST.in`, `README.md`, `CHANGELOG`, `tests/`,
+un `automatheque/__init__.py` portant `pkgutil.extend_path`, et le marqueur
+`py.typed`.
+
+Reste **une** étape manuelle, hors dépôt : déclarer sur PyPI un *trusted
+publisher* pour le nouveau projet, pointant ce dépôt et `release.yml`. Sans
+lui, la première publication échoue au tag.
+
+Enfin, `release.yml` ne publie que les paquets dont la version **égale le
+tag** : livrer plusieurs paquets ensemble suppose de les bumper à la même
+version avant de taguer.
 
 ## Nomenclature que l'on essaie de respecter
 

--- a/src/automatheque.renommage/.gitignore
+++ b/src/automatheque.renommage/.gitignore
@@ -1,0 +1,5 @@
+**__pycache__
+**.venv
+**.pytest_cache
+**.egg-info
+log.json

--- a/src/automatheque.renommage/CHANGELOG
+++ b/src/automatheque.renommage/CHANGELOG
@@ -1,0 +1,85 @@
+# Changelog — automatheque.renommage
+
+<!-- markdownlint-disable MD024 -->
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* Première version de la distribution. Le code provient de l'**ancien**
+  `automatheque` (`automatheque/lib/renommeur.py`), d'avant le découpage en
+  paquets : `Gabarit`, `Gabarits`, `Renommable` et `Renommeur`.
+* `Gabarits.depuis_configuration(config, section)` : construit les gabarits
+  depuis un objet de type `ConfigParser`, au format historique
+  `r1 = [squelette, condition, ordre]`. Le triplet est lu avec
+  `ast.literal_eval` et non `eval` — un fichier de configuration décrit des
+  données, il n'a pas à pouvoir exécuter du code.
+* Des exceptions nommées, là où le module levait des `ValueError` avec un
+  message : `AucunGabaritApplicable`, `GabaritInapplicable`,
+  `ConditionInvalide`, `TransfertIncomplet`, sous une base commune
+  `RenommageEchec`. Les trois premières héritent aussi de `ValueError`, donc
+  un appelant qui l'attrapait continue de fonctionner.
+
+### Changed
+
+* **La configuration est reçue, plus cherchée.** `Renommeur` appelait
+  `charge_configuration()` lui-même — une localisation de service : le
+  renommage dépendait d'un fichier de configuration présent au bon endroit, et
+  n'était pas testable sans lui. Il reçoit désormais ses gabarits
+  (`Renommeur(obj, gabarits=…)`), et retombe sur `obj._gabarits_par_defaut()`
+  s'il n'en reçoit pas. C'est à l'appelant de décider d'où ils viennent.
+* `renomme()` renvoie le chemin cible, et ne le renvoie plus par un détour :
+  le paramètre `cumule_gabarits` disparaît avec `_remplir_gabarits()`, la
+  composition d'un jeu de gabarits se faisant maintenant côté appelant.
+* Les noms internes perdent leur préfixe hongrois (`v_rep_cible` →
+  `rep_cible`, `v_nomfic` → `nom_fichier`).
+* `mkdir_p` (déprécié dans le cœur en 0.19.0) laisse place à
+  `Path.mkdir(parents=True, exist_ok=True)`.
+
+### Removed
+
+* **L'écriture d'attributs étendus.** `Renommeur._renomme()` posait
+  `user.automatheque.fichier_orig` et `user.automatheque.modele.classe` dans
+  les xattr du fichier, à chaque renommage, sans que ce soit annoncé nulle
+  part. Les xattr ne survivent ni à la plupart des copies, ni aux archives, ni
+  aux transferts réseau : c'est le plus fragile des supports pour de la
+  provenance, et conserver le nom d'origine relève de l'application. Cela
+  supprime du même coup la dépendance `xattr`, sensible à la plateforme et au
+  système de fichiers.
+
+### Fixed
+
+* **Injection de code par les métadonnées des fichiers traités.** La condition
+  d'un gabarit était formatée avec les champs de l'objet — un album, une
+  ville, une description, c'est-à-dire des chaînes venues des fichiers
+  eux-mêmes — puis passée à `eval()`. Un fichier soigneusement nommé suffisait
+  donc à faire exécuter du code arbitraire par un simple rangement de photos.
+  L'évaluation se fait désormais sur l'arbre syntaxique, avec une liste
+  blanche : littéraux, `and` / `or` / `not`, comparaisons. Rien d'autre. La
+  syntaxe des conditions existantes est inchangée ; au pire une chaîne
+  malveillante rend la condition fausse.
+* `_renomme()` affectait `self.obj.filename` avec le chemin cible **avant**
+  la copie, et sans revenir en arrière si rien ne bougeait. Après un appel en
+  `debug`, ou sur une cible déjà occupée, l'objet se croyait donc à un endroit
+  où son fichier n'était pas. L'objet ne déménage plus qu'une fois la cible
+  vérifiée.
+* La comparaison de taille qui valide le transfert n'était faite que dans la
+  branche `else` d'un `try`, après un `except OSError` qui laissait passer
+  `ENOTSUP` — mais le commentaire d'origine disait bien qu'il fallait
+  « le tester ensuite ». Elle est désormais faite dans tous les cas, et un
+  écart lève `TransfertIncomplet` **en laissant l'original en place**.
+* `Gabarits.gabarits_valides()` renvoyait `False` — une valeur, depuis un
+  générateur — quand une condition levait une exception, ce qui interrompait
+  silencieusement le parcours et écartait les gabarits suivants, y compris
+  celui sans condition qui sert de filet. Une condition qui ne s'évalue pas
+  est maintenant simplement fausse.
+* `Gabarits.choisit_gabarit()` attrapait `Exception` autour d'un `next()` :
+  n'importe quelle erreur d'évaluation ressortait en « pas de gabarit ». Seul
+  l'épuisement du générateur (`StopIteration`) est désormais traduit.
+* Import `filecmp` inutilisé, hérité d'une vérification d'intégrité
+  abandonnée (« filecmp marche pas sur mon serveur O_O »).

--- a/src/automatheque.renommage/MANIFEST.in
+++ b/src/automatheque.renommage/MANIFEST.in
@@ -1,0 +1,1 @@
+include automatheque/renommage/py.typed

--- a/src/automatheque.renommage/README.md
+++ b/src/automatheque.renommage/README.md
@@ -1,0 +1,116 @@
+# automatheque.renommage
+
+Renommage et rangement de fichiers par gabarits.
+
+## Détail
+
+Un **gabarit** est un squelette de chemin — `{date:%Y}/{album}/{nom}` —
+assorti d'une condition qui dit quand il s'applique et d'un ordre qui le
+priorise. Le **renommeur** choisit le premier gabarit applicable, en déduit un
+nouveau chemin, et y déplace le fichier.
+
+C'est l'opération symétrique de `automatheque.decomposition` : là où celle-ci
+tire des métadonnées d'un chemin, celle-ci construit un chemin à partir de
+métadonnées. Les deux sont des distributions séparées parce que seule
+celle-ci écrit sur le disque : un consommateur qui indexe sans jamais déplacer
+n'a pas à en dépendre.
+
+## Les briques
+
+* **`Gabarit`** — un squelette, une condition, un ordre.
+* **`Gabarits`** — la liste des gabarits, et l'algorithme de choix : d'abord
+  ceux dont la condition est vérifiée, classés par ordre, puis ceux qui n'ont
+  pas de condition. Un gabarit sans condition est donc un filet de sécurité,
+  pas un concurrent.
+* **`Renommable`** — mixin à faire hériter par l'objet à ranger. Il expose
+  `filename` et surcharge `_gabarits_par_defaut()` et `_liste_champs_dispo()`.
+* **`Renommeur`** — le déplacement lui-même.
+
+## Exemple
+
+```py
+import attr
+
+from automatheque.renommage import Gabarit, Gabarits, Renommable
+
+
+@attr.s
+class Photo(Renommable):
+    album = attr.ib(default="", kw_only=True)
+    annee = attr.ib(default="", kw_only=True)
+
+    @classmethod
+    def _gabarits_par_defaut(cls):
+        return Gabarits(
+            [
+                Gabarit(
+                    squelette="{annee}/{album}/{nom}", condition='"{album}"', ordre=1
+                ),
+                Gabarit(squelette="a-trier/{nom}", ordre=9),
+            ]
+        )
+
+    def _liste_champs_dispo(self):
+        return {"album": self.album, "annee": self.annee, "nom": ...}
+
+
+photo = Photo(filename="/entree/DSC_0001.jpg", album="Japon", annee="2013")
+photo.renomme("/photos")
+# /photos/2013/Japon/DSC_0001.jpg
+```
+
+## La configuration est reçue, pas cherchée
+
+Les gabarits vivent souvent dans un fichier de configuration :
+
+```ini
+[renommage]
+r1 = ['{annee}/{album}/{nom}', '"{album}"', 1]
+r2 = ['a-trier/{nom}', '', 9]
+```
+
+`Gabarits.depuis_configuration(config, section)` les en tire, et le résultat
+est **passé** au renommeur :
+
+```py
+gabarits = Gabarits.depuis_configuration(charge_configuration(), "renommage")
+Renommeur(photo, gabarits=gabarits).renomme("/photos")
+```
+
+Le renommeur ne consulte aucun état global : c'est l'appelant qui décide d'où
+viennent ses gabarits. Le code d'origine appelait `charge_configuration()`
+lui-même — une localisation de service, qui rendait le renommage dépendant
+d'un fichier de configuration présent au bon endroit, et intestable sans lui.
+
+## Ce que le renommage ne fait pas
+
+* **Il n'écrit pas d'attributs étendus.** Le code d'origine posait
+  discrètement `user.automatheque.fichier_orig` et
+  `user.automatheque.modele.classe` dans les xattr du fichier, à chaque
+  renommage. Les xattr ne survivent ni à la plupart des copies, ni aux
+  archives, ni aux transferts réseau : c'est le plus fragile des supports pour
+  de la provenance. Conserver le nom d'origine relève de l'application, qui
+  sait où elle range ses métadonnées.
+* **Il ne modifie pas le contenu du fichier.** Écrire des étiquettes dans une
+  image est l'affaire d'un adaptateur.
+
+## Transfert
+
+Le déplacement est une copie, suivie d'une vérification de taille, suivie de
+la suppression de l'original. `shutil.move` seul ne dirait pas si la copie
+s'est mal passée d'un système de fichiers à l'autre ; ici, une cible qui ne
+correspond pas lève `TransfertIncomplet` **et laisse l'original en place**.
+
+## Requirement
+
+Python >=3.9
+
+## Installation
+
+```bash
+pip install automatheque.renommage
+```
+
+## License
+
+LGPLv3.0 ou ultérieure

--- a/src/automatheque.renommage/automatheque/__init__.py
+++ b/src/automatheque.renommage/automatheque/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/src/automatheque.renommage/automatheque/renommage/__init__.py
+++ b/src/automatheque.renommage/automatheque/renommage/__init__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Renommage et rangement de fichiers par gabarits."""
+
+from .condition import evalue_condition
+from .exceptions import (
+    AucunGabaritApplicable,
+    ConditionInvalide,
+    GabaritInapplicable,
+    RenommageEchec,
+    TransfertIncomplet,
+)
+from .renommeur import (
+    SECTION_CONFIG_PAR_DEFAUT,
+    Gabarit,
+    Gabarits,
+    Renommable,
+    Renommeur,
+)
+
+__all__ = [
+    "SECTION_CONFIG_PAR_DEFAUT",
+    "AucunGabaritApplicable",
+    "ConditionInvalide",
+    "Gabarit",
+    "Gabarits",
+    "GabaritInapplicable",
+    "RenommageEchec",
+    "Renommable",
+    "Renommeur",
+    "TransfertIncomplet",
+    "evalue_condition",
+]

--- a/src/automatheque.renommage/automatheque/renommage/condition.py
+++ b/src/automatheque.renommage/automatheque/renommage/condition.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""Évaluation des conditions de gabarit.
+
+Une condition est une expression booléenne écrite dans la configuration,
+formatée avec les champs de l'objet à renommer avant d'être évaluée :
+
+```ini
+r5 = ['{date.year}/{date:%%Y-%%m-%%d} @{ville} {pays}/{nom}',
+      '"{date}" and "{ville}" and "{pays}" != "FR"', 3]
+```
+
+Une fois formatée, la condition ci-dessus devient
+``'"2013-03-17" and "Osaka" and "JP" != "FR"'``.
+
+Le code d'origine passait cette chaîne à `eval()`. Or les champs qui y sont
+injectés viennent des **métadonnées des fichiers traités** — un album, un nom
+de ville, une description. Un fichier soigneusement nommé suffisait donc à
+faire exécuter du code arbitraire par un simple rangement de photos.
+
+L'évaluation est ici faite sur l'arbre syntaxique, avec une liste blanche de
+nœuds : des littéraux, `and` / `or` / `not`, et des comparaisons. Rien
+d'autre. La syntaxe des conditions existantes est inchangée ; au pire, une
+chaîne malveillante fait maintenant échouer la condition au lieu de sortir de
+son bac à sable.
+"""
+
+import ast
+from typing import Any
+
+from .exceptions import ConditionInvalide
+
+# Nœuds acceptés dans une condition. Tout ce qui appelle, importe, indexe,
+# accède à un attribut ou nomme une variable en est absent — volontairement.
+_NOEUDS_AUTORISES = (
+    ast.Expression,
+    ast.BoolOp,
+    ast.And,
+    ast.Or,
+    ast.UnaryOp,
+    ast.Not,
+    ast.Compare,
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+    ast.In,
+    ast.NotIn,
+    ast.Constant,
+    ast.Tuple,
+    ast.List,
+    ast.Load,
+)
+
+
+def evalue_condition(condition: str) -> Any:
+    """Évalue une condition déjà formatée, sans jamais exécuter de code.
+
+    :param condition: expression booléenne composée de littéraux
+    :raise ConditionInvalide: si l'expression est mal formée, ou si elle
+                              contient autre chose que des littéraux, des
+                              opérateurs booléens et des comparaisons
+    """
+    try:
+        arbre = ast.parse(condition, mode="eval")
+    except SyntaxError as exc:
+        raise ConditionInvalide(condition, "expression mal formée") from exc
+
+    for noeud in ast.walk(arbre):
+        if not isinstance(noeud, _NOEUDS_AUTORISES):
+            raise ConditionInvalide(
+                condition,
+                "{} n'est pas autorisé dans une condition".format(type(noeud).__name__),
+            )
+
+    # À ce stade l'arbre ne contient que des littéraux et des opérateurs :
+    # `eval` n'a plus rien à se mettre sous la dent.
+    return eval(compile(arbre, "<condition>", "eval"), {"__builtins__": {}}, {})

--- a/src/automatheque.renommage/automatheque/renommage/exceptions.py
+++ b/src/automatheque.renommage/automatheque/renommage/exceptions.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Exceptions propres au renommage.
+
+Elles héritent de :class:`automatheque.exceptions.AutomathequeBaseException`
+afin que le code appelant puisse filtrer d'un seul `except` toutes les
+exceptions de l'automathèque.
+"""
+
+from automatheque.exceptions import AutomathequeBaseException
+
+
+class RenommageEchec(AutomathequeBaseException):
+    """Le renommage n'a pas abouti."""
+
+    def __init__(self, msg="Renommage échoué."):
+        """Initialisation."""
+        self.msg = msg
+        super().__init__(self.msg)
+
+
+class AucunGabaritApplicable(RenommageEchec, ValueError):
+    """Aucun gabarit ne s'applique à l'objet à renommer.
+
+    Hérite aussi de :class:`ValueError`, que levait le code d'origine : un
+    appelant qui l'attrapait continue de fonctionner.
+    """
+
+    def __init__(self, msg="Aucun gabarit applicable."):
+        """Initialisation."""
+        super().__init__(msg)
+
+
+class GabaritInapplicable(RenommageEchec, ValueError):
+    """Le gabarit choisi n'a pas pu produire un nom de fichier.
+
+    En pratique : son squelette référence un champ que l'objet ne fournit pas.
+    """
+
+    def __init__(self, squelette, raison=""):
+        """Initialisation."""
+        self.squelette = squelette
+        super().__init__(
+            "Le squelette '{}' n'a pas pu être formaté. {}".format(squelette, raison)
+        )
+
+
+class ConditionInvalide(RenommageEchec, ValueError):
+    """La condition d'un gabarit n'est pas une expression évaluable.
+
+    Soit elle est mal formée, soit elle contient autre chose que des
+    littéraux, des opérateurs booléens et des comparaisons.
+    """
+
+    def __init__(self, condition, raison=""):
+        """Initialisation."""
+        self.condition = condition
+        super().__init__("Condition invalide : '{}'. {}".format(condition, raison))
+
+
+class TransfertIncomplet(RenommageEchec):
+    """La copie vers la cible n'a pas produit un fichier identique.
+
+    L'original est conservé : le supprimer perdrait des données.
+    """
+
+    def __init__(self, source, cible):
+        """Initialisation."""
+        self.source = source
+        self.cible = cible
+        super().__init__(
+            "Les deux fichiers sont différents {} -> {}".format(source, cible)
+        )

--- a/src/automatheque.renommage/automatheque/renommage/renommeur.py
+++ b/src/automatheque.renommage/automatheque/renommage/renommeur.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+"""Renommage et rangement de fichiers par gabarits.
+
+Un **gabarit** est un squelette de chemin — `{date:%Y}/{album}/{nom}` — assorti
+d'une condition qui dit quand il s'applique et d'un ordre qui le priorise. Le
+**renommeur** choisit le premier gabarit applicable, en déduit un nouveau
+chemin, et y déplace le fichier.
+
+C'est l'opération symétrique de `automatheque.decomposition` : là où celle-ci
+tire des métadonnées d'un chemin, celle-ci construit un chemin à partir de
+métadonnées.
+"""
+
+import ast
+import errno
+import logging
+import os
+import shutil
+from operator import attrgetter
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+import attr
+
+from .condition import evalue_condition
+from .exceptions import (
+    AucunGabaritApplicable,
+    GabaritInapplicable,
+    TransfertIncomplet,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+# Section de configuration lue par défaut par `Gabarits.depuis_configuration`.
+SECTION_CONFIG_PAR_DEFAUT = "renommage"
+
+
+@attr.s
+class Gabarit:
+    """Gabarit à appliquer sur les objets `Renommable`.
+
+    Un gabarit consiste en :
+
+    * un **squelette** qui sera utilisé pour formatter l'objet `Renommable` à
+      partir de ses champs disponibles et en déduire un nouveau nom ;
+    * une **condition** qui détermine si le squelette est applicable ; un
+      gabarit sans condition s'applique toujours ;
+    * un **ordre** de traitement pour prioriser certains gabarits, le plus
+      petit d'abord.
+    """
+
+    squelette: str = attr.ib(default="")
+    condition: str = attr.ib(default="")
+    ordre: int = attr.ib(default=0)
+
+
+class Gabarits:
+    """La liste des gabarits utilisables pour un renommage."""
+
+    def __init__(self, gabarits: Optional[List[Gabarit]] = None):
+        """Initialisation."""
+        self._gabarits: List[Gabarit] = list(gabarits or [])
+        self.gabarit_choisi: Optional[Gabarit] = None
+
+    def __iter__(self) -> Iterator[Gabarit]:
+        """Itère sur les gabarits, dans l'ordre où ils ont été ajoutés."""
+        return iter(self._gabarits)
+
+    def __len__(self) -> int:
+        """Nombre de gabarits."""
+        return len(self._gabarits)
+
+    def __json__(self):
+        """Pour pouvoir afficher les objets en JSON."""
+        return [attr.asdict(g) for g in self._gabarits]
+
+    def append(self, gabarit: Gabarit) -> None:
+        """Ajoute un gabarit à la liste."""
+        self._gabarits.append(gabarit)
+
+    @classmethod
+    def depuis_configuration(
+        cls, config, section: str = SECTION_CONFIG_PAR_DEFAUT
+    ) -> "Gabarits":
+        """Construit les gabarits depuis une configuration de type `ConfigParser`.
+
+        Chaque option de la section porte un triplet
+        `[squelette, condition, ordre]`, écrit comme un littéral Python :
+
+        ```ini
+        [renommage]
+        r1 = ['{date:%%Y}/{album}/{nom}', '"{album}"', 1]
+        r2 = ['a-trier/{nom}', '', 9]
+        ```
+
+        Le triplet est lu avec `ast.literal_eval` et non `eval` : un fichier de
+        configuration décrit des données, il n'a pas à pouvoir exécuter du code.
+
+        :param config: objet exposant `options(section)` et `get(section, option)`
+        :param section: section à lire
+        :raise ValueError: si une option n'est pas un triplet lisible
+        """
+        gabarits = cls()
+        for option in config.options(section):
+            brut = config.get(section, option)
+            try:
+                squelette, condition, ordre = ast.literal_eval(brut)
+            except (ValueError, SyntaxError) as exc:
+                raise ValueError(
+                    "[{}] {} : attendu [squelette, condition, ordre], lu {!r}".format(
+                        section, option, brut
+                    )
+                ) from exc
+            gabarits.append(
+                Gabarit(squelette=squelette, condition=condition, ordre=ordre)
+            )
+        return gabarits
+
+    def gabarits_valides(self, obj) -> Iterator[Gabarit]:
+        """Génère les gabarits applicables à l'objet, dans l'ordre.
+
+        D'abord ceux dont la condition est vérifiée, puis ceux qui n'ont pas de
+        condition — les uns comme les autres classés par `ordre`. Un gabarit
+        sans condition est donc un filet de sécurité, pas un concurrent.
+        """
+        avec_condition = [g for g in self._gabarits if g.condition]
+        for gabarit in sorted(avec_condition, key=attrgetter("ordre")):
+            if self.teste_condition(obj, gabarit.condition):
+                yield gabarit
+
+        sans_condition = [g for g in self._gabarits if not g.condition]
+        for gabarit in sorted(sans_condition, key=attrgetter("ordre")):
+            yield gabarit
+
+    def choisit_gabarit(self, obj) -> Gabarit:
+        """Retient le premier gabarit applicable, et le renvoie.
+
+        :raise AucunGabaritApplicable: si aucun ne convient
+        """
+        try:
+            self.gabarit_choisi = next(self.gabarits_valides(obj))
+        except StopIteration:
+            raise AucunGabaritApplicable()
+        return self.gabarit_choisi
+
+    @classmethod
+    def teste_condition(cls, obj, condition: str) -> bool:
+        """Teste la condition d'un gabarit sur l'objet donné.
+
+        La condition est formatée avec les champs de l'objet, puis évaluée —
+        `'"{album}" == "Meteora"'` avec les mêmes champs que le squelette.
+
+        Une condition qui ne s'évalue pas — champ absent, expression mal
+        formée — est **fausse**, pas fatale : le gabarit suivant est essayé.
+        """
+        try:
+            formatee = condition.format(**obj._liste_champs_dispo())
+            return bool(evalue_condition(formatee))
+        except Exception:
+            LOGGER.exception("Erreur durant le test de la condition.")
+            return False
+
+
+@attr.s
+class Renommable:
+    """Classe à hériter/surcharger pour être facilement renommable.
+
+    L'objet doit exposer `filename`, le chemin du fichier à déplacer, et
+    surcharger les deux méthodes ci-dessous.
+
+    TODO : `filename` fait doublon avec `source` de `automatheque.schema.media`
+    quand les deux sont mêlées par sous-classage — les deux noms désignent le
+    même fichier et peuvent diverger après un renommage. À arbitrer.
+    """
+
+    filename: str = attr.ib(default="")  # TODO nom_fichier au lieu de filename
+
+    @classmethod
+    def _gabarits_par_defaut(cls) -> Gabarits:
+        """Renvoie les gabarits à utiliser faute de mieux. À surcharger."""
+        raise NotImplementedError
+
+    def _liste_champs_dispo(self) -> dict:
+        """Champs disponibles pour formater squelettes et conditions.
+
+        À surcharger : c'est la projection des métadonnées de l'objet vers le
+        vocabulaire des gabarits, et elle est propre à chaque application.
+
+        TODO : on peut même gérer plusieurs langues !
+        """
+        raise NotImplementedError
+
+    def renomme(self, rep_cible, gabarits=None, debug=False, force=False, copier=False):
+        """Enveloppe de `Renommeur.renomme` pour le cas courant."""
+        return Renommeur(self, gabarits=gabarits).renomme(
+            rep_cible, debug=debug, force=force, copier=copier
+        )
+
+
+class Renommeur:
+    """Gère le renommage de l'objet `Renommable` donné.
+
+    Le renommage est effectué à partir de gabarits spécifiques, que l'on peut
+    écrire soi-même.
+    """
+
+    def __init__(self, obj: Renommable, gabarits: Optional[Gabarits] = None):
+        """Initialisation.
+
+        La configuration n'est plus **cherchée** ici : elle est **reçue**. Un
+        appelant qui range ses gabarits dans un fichier de configuration les
+        construit avec `Gabarits.depuis_configuration(config, section)` et les
+        passe ici. Le renommeur, lui, ne consulte aucun état global — ce qui le
+        rend testable et prévisible.
+
+        :param obj: doit être un objet `Renommable`
+        :param gabarits: gabarits à appliquer ; à défaut, ceux que l'objet
+                         renvoie par `_gabarits_par_defaut()`
+        """
+        if not isinstance(obj, Renommable):
+            raise ValueError("obj doit etre une instance de Renommable")
+        self.obj = obj
+        self.gabarits = gabarits if gabarits is not None else obj._gabarits_par_defaut()
+
+    def _construire_nouveau_nom(self) -> str:
+        """Construit le nouveau nom de l'objet à renommer.
+
+        :raise AucunGabaritApplicable: si aucun gabarit ne convient
+        :raise GabaritInapplicable: si le squelette retenu ne peut être formaté
+        """
+        champs = self.obj._liste_champs_dispo()
+        gabarit = self.gabarits.choisit_gabarit(self.obj)
+        LOGGER.debug("Gabarit choisi : %s", gabarit)
+        try:
+            return gabarit.squelette.format(**champs)
+        except (KeyError, IndexError, ValueError, AttributeError, TypeError) as exc:
+            raise GabaritInapplicable(gabarit.squelette, str(exc)) from exc
+
+    def _renomme(self, rep_cible, nom_fichier, debug=False, force=False, copier=False):
+        """Déplace le fichier vers `rep_cible/nom_fichier`.
+
+        Le transfert est une copie suivie d'une vérification de taille, puis de
+        la suppression de l'original — `shutil.move` ne dirait pas si la copie
+        s'est mal passée entre deux systèmes de fichiers.
+
+        :returns: le chemin cible, qu'il ait été atteint ou non
+        """
+        fichier_cible = os.path.join(rep_cible, nom_fichier)
+        fichier_orig = self.obj.filename
+
+        if debug or (os.path.exists(fichier_cible) and not force):
+            LOGGER.warning(
+                "Pas de deplacement : %s", "debug" if debug else "fichier existe"
+            )
+            return fichier_cible
+
+        # Creation du répertoire parent si besoin :
+        Path(os.path.dirname(fichier_cible)).mkdir(parents=True, exist_ok=True)
+
+        LOGGER.debug("Déplacement vers cible : %s", fichier_cible)
+        try:
+            # Attention, si le fichier cible existe il est écrasé.
+            # Pour changer ce fonctionnement voir ici :
+            # https://gist.github.com/alexwlchan/c2adbb8ee782f460e5ec
+            shutil.copy(fichier_orig, fichier_cible)
+        except OSError as exc:
+            if exc.errno != errno.ENOTSUP:
+                LOGGER.error(
+                    "[E] Echec shutil.copy(%s, %s) : %s",
+                    fichier_orig,
+                    fichier_cible,
+                    exc,
+                )
+                raise
+            # ENOTSUP remonte lorsque l'on ne peut pas changer les droits ou
+            # les attributs d'un fichier. Le transfert s'est peut-être bien
+            # passé malgré tout : on le vérifie juste après.
+
+        if os.path.getsize(fichier_cible) != os.path.getsize(fichier_orig):
+            raise TransfertIncomplet(fichier_orig, fichier_cible)
+
+        # La cible est bonne : c'est seulement maintenant que l'objet déménage.
+        self.obj.filename = fichier_cible
+        if not copier:
+            os.remove(fichier_orig)
+        return fichier_cible
+
+    def renomme(self, rep_cible, debug=False, force=False, copier=False):
+        """Range le fichier dans `rep_cible`, sous le nom que dictent les gabarits.
+
+        :param rep_cible: répertoire cible du déplacement
+        :param debug: calcule le chemin cible sans rien déplacer
+        :param force: écrase un fichier cible existant
+        :param copier: conserve l'original au lieu de le supprimer
+        :returns: le chemin cible
+        """
+        nom_fichier = self._construire_nouveau_nom()
+        return self._renomme(
+            rep_cible, nom_fichier, debug=debug, force=force, copier=copier
+        )

--- a/src/automatheque.renommage/pyproject.toml
+++ b/src/automatheque.renommage/pyproject.toml
@@ -1,0 +1,42 @@
+[project]
+name = "automatheque.renommage"
+version = "0.19.0"
+description = "Renommage et rangement de fichiers par gabarits"
+authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
+license = {text = "LGPL-3.0-or-later"}
+requires-python = ">=3.9"
+readme = "README.md"
+classifiers = [
+    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+dependencies = [
+    # >=0.19.0 : plancher aligné sur la version courante du cœur, dont ce
+    # paquet utilise `exceptions.AutomathequeBaseException`. Le cœur ne sert
+    # plus qu'à ça ici : la configuration est désormais *reçue* et non chargée,
+    # et `mkdir_p` — déprécié en 0.19.0 — a laissé place à `Path.mkdir`.
+    "automatheque>=0.19.0",
+    "attrs>=19.2",
+]
+
+[project.urls]
+Home = "https://github.com/jaegerbobomb/automatheque/tree/main/src/automatheque.renommage/"
+Repository = "https://github.com/jaegerbobomb/automatheque.git"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+# Embarque le marqueur py.typed dans le wheel (typage exporté). Cf. #3.
+[tool.setuptools.package-data]
+"automatheque.renommage" = ["py.typed"]

--- a/src/automatheque.renommage/setup.py
+++ b/src/automatheque.renommage/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup(name="automatheque.renommage")

--- a/src/automatheque.renommage/tests/test_renommeur.py
+++ b/src/automatheque.renommage/tests/test_renommeur.py
@@ -1,0 +1,341 @@
+# -*- coding: utf-8 -*-
+"""Tests du renommage.
+
+L'ancien dépôt n'avait aucune couverture sur ce module, alors que c'est
+précisément son comportement de rangement que les applications doivent
+préserver. Ces tests sont écrits à la remontée.
+"""
+
+import configparser
+import os
+
+import attr
+import pytest
+from automatheque.renommage import (
+    AucunGabaritApplicable,
+    ConditionInvalide,
+    Gabarit,
+    GabaritInapplicable,
+    Gabarits,
+    Renommable,
+    Renommeur,
+    TransfertIncomplet,
+    evalue_condition,
+)
+
+
+@attr.s
+class Photo(Renommable):
+    """Un renommable minimal."""
+
+    album = attr.ib(default="", kw_only=True)
+    annee = attr.ib(default="", kw_only=True)
+    pays = attr.ib(default="", kw_only=True)
+
+    @classmethod
+    def _gabarits_par_defaut(cls):
+        return Gabarits(
+            [
+                Gabarit(squelette="{annee}/{album}/{nom}", condition='"{album}"'),
+                Gabarit(squelette="a-trier/{nom}", ordre=9),
+            ]
+        )
+
+    def _liste_champs_dispo(self):
+        return {
+            "album": self.album,
+            "annee": self.annee,
+            "pays": self.pays,
+            "nom": os.path.basename(self.filename),
+        }
+
+
+@pytest.fixture
+def photo(tmp_path):
+    """Une photo posée sur le disque, prête à être rangée."""
+    fichier = tmp_path / "source" / "DSC_0001.jpg"
+    fichier.parent.mkdir()
+    fichier.write_bytes(b"des octets de photo")
+    return Photo(filename=str(fichier), album="Japon", annee="2013")
+
+
+#
+# Gabarits
+#
+
+
+def test_gabarit_sans_condition_s_applique_toujours():
+    gabarits = Gabarits([Gabarit(squelette="a-trier/{nom}")])
+    assert gabarits.choisit_gabarit(Photo()).squelette == "a-trier/{nom}"
+
+
+def test_gabarit_avec_condition_vraie_passe_avant_celui_sans_condition():
+    photo = Photo(filename="/a/b.jpg", album="Japon", annee="2013")
+    assert (
+        photo._gabarits_par_defaut()
+        .choisit_gabarit(photo)
+        .squelette.startswith("{annee}")
+    )
+
+
+def test_gabarit_avec_condition_fausse_est_ecarte():
+    photo = Photo(filename="/a/b.jpg", album="", annee="2013")
+    assert (
+        photo._gabarits_par_defaut().choisit_gabarit(photo).squelette == "a-trier/{nom}"
+    )
+
+
+def test_les_conditions_vraies_sont_classees_par_ordre():
+    gabarits = Gabarits(
+        [
+            Gabarit(squelette="tard", condition='"oui"', ordre=5),
+            Gabarit(squelette="tot", condition='"oui"', ordre=1),
+        ]
+    )
+    assert gabarits.choisit_gabarit(Photo()).squelette == "tot"
+
+
+def test_sans_aucun_gabarit_applicable():
+    gabarits = Gabarits([Gabarit(squelette="jamais", condition='"" and "x"')])
+    with pytest.raises(AucunGabaritApplicable):
+        gabarits.choisit_gabarit(Photo())
+
+
+def test_aucun_gabarit_applicable_reste_un_value_error():
+    """Rétro-compat : le code d'origine levait un `ValueError` nu."""
+    assert issubclass(AucunGabaritApplicable, ValueError)
+
+
+def test_condition_referencant_un_champ_absent_est_fausse():
+    """Elle n'interrompt pas le choix : le gabarit suivant est essayé."""
+    gabarits = Gabarits(
+        [
+            Gabarit(squelette="jamais", condition='"{champ_inconnu}"'),
+            Gabarit(squelette="filet", ordre=9),
+        ]
+    )
+    assert gabarits.choisit_gabarit(Photo()).squelette == "filet"
+
+
+def test_gabarits_est_iterable_et_mesurable():
+    gabarits = Gabarits()
+    gabarits.append(Gabarit(squelette="a"))
+    gabarits.append(Gabarit(squelette="b"))
+    assert len(gabarits) == 2
+    assert [g.squelette for g in gabarits] == ["a", "b"]
+
+
+def test_json_expose_les_gabarits():
+    gabarits = Gabarits([Gabarit(squelette="a", condition="", ordre=3)])
+    assert gabarits.__json__() == [{"squelette": "a", "condition": "", "ordre": 3}]
+
+
+#
+# Conditions
+#
+
+
+def test_evalue_condition_litteraux_et_operateurs():
+    assert evalue_condition('"Osaka" and "JP"')
+    assert not evalue_condition('"" and "JP"')
+    assert evalue_condition('"JP" != "FR"')
+    assert not evalue_condition('"FR" != "FR"')
+    assert evalue_condition('not ""')
+    assert evalue_condition('"a" or ""')
+
+
+def test_evalue_condition_refuse_un_appel():
+    """Régression : les champs viennent des métadonnées des fichiers traités.
+
+    Le code d'origine passait la condition formatée à `eval()` : un fichier
+    dont l'album portait le bon texte faisait exécuter du code arbitraire.
+    """
+    with pytest.raises(ConditionInvalide):
+        evalue_condition('__import__("os").system("echo compromis")')
+
+
+def test_evalue_condition_refuse_un_nom():
+    with pytest.raises(ConditionInvalide):
+        evalue_condition("open")
+
+
+def test_evalue_condition_refuse_un_acces_attribut():
+    with pytest.raises(ConditionInvalide):
+        evalue_condition('"".__class__')
+
+
+def test_evalue_condition_refuse_une_expression_mal_formee():
+    with pytest.raises(ConditionInvalide):
+        evalue_condition('"Osaka" and and')
+
+
+def test_injection_par_les_metadonnees_ne_s_execute_pas():
+    """Bout en bout : un album malveillant ne fait qu'invalider la condition."""
+    photo = Photo(filename="/a/b.jpg", album='" and __import__("os").getcwd() and "')
+    gabarits = Gabarits(
+        [
+            Gabarit(squelette="dangereux", condition='"{album}"'),
+            Gabarit(squelette="filet", ordre=9),
+        ]
+    )
+    assert gabarits.choisit_gabarit(photo).squelette == "filet"
+
+
+#
+# Configuration reçue, et non chargée
+#
+
+
+def _config(texte):
+    config = configparser.ConfigParser()
+    config.read_string(texte)
+    return config
+
+
+def test_gabarits_depuis_configuration():
+    config = _config(
+        "[renommage]\n"
+        "r1 = ['{annee}/{album}/{nom}', '\"{album}\"', 1]\n"
+        "r2 = ['a-trier/{nom}', '', 9]\n"
+    )
+    gabarits = Gabarits.depuis_configuration(config)
+    assert len(gabarits) == 2
+    assert [g.ordre for g in gabarits] == [1, 9]
+    assert list(gabarits)[0].squelette == "{annee}/{album}/{nom}"
+
+
+def test_gabarits_depuis_configuration_section_choisie():
+    config = _config("[rangement_photos]\nr1 = ['{nom}', '', 1]\n")
+    assert len(Gabarits.depuis_configuration(config, "rangement_photos")) == 1
+
+
+def test_gabarits_depuis_configuration_option_illisible():
+    config = _config("[renommage]\nr1 = pas un triplet\n")
+    with pytest.raises(ValueError):
+        Gabarits.depuis_configuration(config)
+
+
+def test_configuration_n_execute_pas_de_code():
+    """`literal_eval`, pas `eval` : un fichier de conf décrit des données."""
+    config = _config('[renommage]\nr1 = __import__("os").getcwd()\n')
+    with pytest.raises(ValueError):
+        Gabarits.depuis_configuration(config)
+
+
+def test_renommeur_ne_consulte_aucune_configuration_globale(photo, tmp_path):
+    """Les gabarits fournis explicitement sont les seuls utilisés."""
+    gabarits = Gabarits([Gabarit(squelette="explicite/{nom}")])
+    cible = Renommeur(photo, gabarits=gabarits).renomme(str(tmp_path / "cible"))
+    assert cible.endswith(os.path.join("explicite", "DSC_0001.jpg"))
+
+
+def test_renommeur_retombe_sur_les_gabarits_par_defaut(photo, tmp_path):
+    cible = Renommeur(photo).renomme(str(tmp_path / "cible"))
+    assert cible.endswith(os.path.join("2013", "Japon", "DSC_0001.jpg"))
+
+
+def test_renommeur_refuse_un_objet_non_renommable():
+    with pytest.raises(ValueError):
+        Renommeur(object())
+
+
+#
+# Déplacement
+#
+
+
+def test_renomme_deplace_le_fichier(photo, tmp_path):
+    origine = photo.filename
+    cible = photo.renomme(str(tmp_path / "cible"))
+
+    assert os.path.exists(cible)
+    assert not os.path.exists(origine)
+    assert photo.filename == cible
+    assert open(cible, "rb").read() == b"des octets de photo"
+
+
+def test_renomme_cree_l_arborescence(photo, tmp_path):
+    cible = photo.renomme(str(tmp_path / "cible"))
+    assert cible == str(tmp_path / "cible" / "2013" / "Japon" / "DSC_0001.jpg")
+
+
+def test_renomme_en_copiant_conserve_l_original(photo, tmp_path):
+    origine = photo.filename
+    cible = photo.renomme(str(tmp_path / "cible"), copier=True)
+    assert os.path.exists(origine)
+    assert os.path.exists(cible)
+
+
+def test_debug_ne_deplace_rien_mais_annonce_la_cible(photo, tmp_path):
+    origine = photo.filename
+    cible = photo.renomme(str(tmp_path / "cible"), debug=True)
+
+    assert cible.endswith(os.path.join("2013", "Japon", "DSC_0001.jpg"))
+    assert not os.path.exists(cible)
+    assert os.path.exists(origine)
+
+
+def test_debug_ne_deplace_pas_l_objet_non_plus(photo, tmp_path):
+    """Régression : `filename` était réaffecté avant même la copie."""
+    origine = photo.filename
+    photo.renomme(str(tmp_path / "cible"), debug=True)
+    assert photo.filename == origine
+
+
+def test_cible_existante_n_est_pas_ecrasee(photo, tmp_path):
+    existant = tmp_path / "cible" / "2013" / "Japon" / "DSC_0001.jpg"
+    existant.parent.mkdir(parents=True)
+    existant.write_bytes(b"deja la")
+
+    origine = photo.filename
+    photo.renomme(str(tmp_path / "cible"))
+
+    assert existant.read_bytes() == b"deja la"
+    assert os.path.exists(origine)
+    assert photo.filename == origine
+
+
+def test_force_ecrase_la_cible_existante(photo, tmp_path):
+    existant = tmp_path / "cible" / "2013" / "Japon" / "DSC_0001.jpg"
+    existant.parent.mkdir(parents=True)
+    existant.write_bytes(b"deja la")
+
+    photo.renomme(str(tmp_path / "cible"), force=True)
+    assert existant.read_bytes() == b"des octets de photo"
+
+
+def test_transfert_incomplet_conserve_l_original(photo, tmp_path, monkeypatch):
+    """Si la copie tronque, on ne supprime surtout pas la source."""
+
+    def copie_tronquee(source, cible):
+        with open(cible, "wb") as f:
+            f.write(b"tronque")
+
+    monkeypatch.setattr("shutil.copy", copie_tronquee)
+
+    origine = photo.filename
+    with pytest.raises(TransfertIncomplet):
+        photo.renomme(str(tmp_path / "cible"))
+    assert os.path.exists(origine)
+
+
+def test_squelette_referencant_un_champ_absent(photo, tmp_path):
+    gabarits = Gabarits([Gabarit(squelette="{champ_inconnu}/{nom}")])
+    with pytest.raises(GabaritInapplicable):
+        photo.renomme(str(tmp_path / "cible"), gabarits=gabarits)
+
+
+def test_renommable_sans_surcharge_annonce_ce_qui_manque():
+    with pytest.raises(NotImplementedError):
+        Renommable._gabarits_par_defaut()
+    with pytest.raises(NotImplementedError):
+        Renommable()._liste_champs_dispo()
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "listxattr"), reason="attributs étendus absents de la plateforme"
+)
+def test_aucun_attribut_etendu_n_est_ecrit(photo, tmp_path):
+    """Le renommage n'écrit plus de xattr : la provenance va ailleurs."""
+    cible = photo.renomme(str(tmp_path / "cible"))
+    assert not os.listxattr(cible)

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -28,9 +28,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Evenement.date_fin_abregee` : les composantes de la date de fin qui
   diffèrent de la date de début (ex. `[4, 12]` pour un événement du 2018-03-14
   au 2018-04-12), pour abréger l'affichage d'une période.
+* `schema.media` : classe **`Media`**, socle commun des familles `image`,
+  `video`, `audio` et `texte`. Elle porte le chemin du fichier, son empreinte,
+  et ce qu'on peut dire de lui **sans l'ouvrir** — extension, type MIME
+  deviné, appartenance à la famille. Même origine, nettoyée. Cf. #42.
+* `schema.image` : **`BaseTags`** (le vocabulaire des étiquettes d'une image —
+  20 attributs : quoi, quand, où, avec quel appareil) et **`Photo`** réduite au
+  vocabulaire (extensions reconnues, étiquettes, validité).
 
 ### Fixed
 
+* `Media` : `is_valid()` et `get_mimetype()` lisaient `self.filename`, un
+  attribut que la classe **ne définit pas** — elle a `source`. Les deux
+  méthodes levaient donc systématiquement `AttributeError` sur un `Media` ;
+  seules les sous-classes qui apportaient un `filename` par ailleurs (via
+  `Renommable`) fonctionnaient.
+* `Media.__attr_post_init__` : le point d'entrée d'attrs s'écrit
+  `__attrs_post_init__` (avec un `s`). La méthode n'a jamais été appelée. Son
+  corps se réduisait à `raz_cache()`, dont le corps était entièrement commenté
+  — les deux sont retirées.
+* `BaseTags` : chaque étiquette était déclarée **deux fois**, en `attr.ib(
+  init=False)` puis en `@property` renvoyant `self._album` — 22 redéfinitions
+  (ruff F811). Le motif n'existait que pour forcer le passage par le
+  `__getattr__` de l'adaptateur exiftool ; il masquait les valeurs dans le
+  `repr` (d'où un `_pprint()` maison) et empêchait toute construction directe.
+  Les étiquettes sont désormais de simples attributs `attrs` ; un adaptateur
+  les surcharge en sous-classe, ce qui marche aussi bien sans le détour.
 * `Emplacement.decimal_en_dms()` : la conversion en degrés / minutes /
   secondes ne pouvait pas fonctionner — les deux `divmod` avaient disparu, il
   restait `minutes, seconds = (decimal_abs * 3600 / 60)`, soit le dépaquetage
@@ -57,11 +80,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Migration : `Evenement(etag=…, url=…, vevent=…)` devient
   `Evenement.depuis_vevent(vevent, etag=…, url=…)`, et `ev.vevent.serialize()`
   devient `ev.vers_vevent().serialize()`.
+* `Media` : `is_valid()` devient `valide()` — comme `Emplacement.valide()` — et
+  `get_mimetype()` devient la propriété `mimetype`. C'étaient les derniers noms
+  anglais de la classe.
+* `Photo` : plus d'héritage de `Renommable` ni de `Decomposable`. Le README de
+  `schema` le demandait explicitement (« qu'on ne va plus intégrer ici => encourager
+  le sous-classage ») : ces comportements s'ajoutent côté application, par
+  `class PhotoRangeable(Photo, Renommable, Decomposable)`. Restent donc chez
+  l'application les gabarits de renommage par défaut, la projection des
+  étiquettes vers les champs de gabarit, et les identificateurs de
+  décomposition — autant de politiques produit, pas de vocabulaire.
+* `Photo.basename` devient une propriété dérivée de `source`, au lieu d'un
+  attribut rempli à l'initialisation.
 
 ### Removed
 
 * `Emplacement.depuis_decimal()` : fabrique morte, qui ignorait son argument
   et renvoyait un `Emplacement()` vide sous une docstring « TODO ».
+* `Media.get_metadata()` : n'avait jamais pu s'exécuter. Il appelait
+  `self.tags.coordonnees("latitude")` puis `self.tags.get_coordinate("longitude")`
+  — deux API différentes, dont une n'existe pas — ainsi que
+  `self.tags.get_original_name()`, absente de `BaseTags`, et lisait un cache
+  `self.metadata` jamais initialisé. Le reprendre aurait été reprendre un bug.
+* `Photo.is_valid()` ne s'appuie plus sur `imghdr`, retiré de Python 3.13, et
+  ne lit donc plus le fichier : `valide()` contrôle l'extension. Reconnaître un
+  contenu réel relève d'un adaptateur.
+* `BaseTags._pprint()` : contournement du `repr` masqué par le motif
+  `attr.ib` + `@property` (« fonction sale en attendant que attr puisse
+  utiliser des callables »). Le motif ayant disparu, le `repr` généré par
+  `attrs` montre de nouveau les valeurs.
 * Les fonctions de conversion d'un export **Google Calendar** en vobject
   (`json_en_vobject`, `decompose_un`, `decompose_date`) ne sont pas reprises :
   ce sont des adaptateurs vers une source précise, pas du vocabulaire. Elles

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -12,6 +12,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `schema.geolocalisation` : classe **`Emplacement`**, qui relie une position
+  GPS et une adresse — *value object* universel, avec un second consommateur
+  déjà là (`localisation_gps`). Récupérée de l'**ancien** `automatheque`
+  (d'avant le découpage en paquets), nettoyée. Cf. #42.
+* `schema.calendrier` : classe **`Evenement`**, même origine. Elle porte le
+  titre, les dates, le lieu, la description, l'`uid`, plus l'`etag` et l'`url`
+  que CalDAV attache à la ressource.
+* `Evenement.depuis_vevent()` / `.vers_vevent()` : conversion iCalendar **à la
+  frontière**, avec `vobject` importé au moment de l'appel seulement. La
+  dépendance est donc un extra (`pip install "automatheque.schema[calendrier]"`)
+  et `schema` reste installable sans rien de plus qu'`attrs`.
+* `Evenement.date_fin_abregee` : les composantes de la date de fin qui
+  diffèrent de la date de début (ex. `[4, 12]` pour un événement du 2018-03-14
+  au 2018-04-12), pour abréger l'affichage d'une période.
+
+### Fixed
+
+* `Emplacement.decimal_en_dms()` : la conversion en degrés / minutes /
+  secondes ne pouvait pas fonctionner — les deux `divmod` avaient disparu, il
+  restait `minutes, seconds = (decimal_abs * 3600 / 60)`, soit le dépaquetage
+  d'un flottant (`TypeError` à tous les coups). Le code n'avait jamais été
+  exécuté.
+* `Emplacement.dms_en_chaine()` : aucune branche `else` ne couvrait un axe
+  autre que `latitude`/`longitude` ; `direction` restait alors non liée, pour
+  un `UnboundLocalError` au formatage. Lève désormais un `ValueError`
+  explicite.
+
+### Changed
+
+* `Emplacement` : les trois convertisseurs, seuls noms anglais du module,
+  suivent le reste du vocabulaire — `decimal_to_dms` → `decimal_en_dms`,
+  `dms_to_decimal` → `dms_en_decimal`, `dms_string` → `dms_en_chaine` (dont le
+  paramètre `type`, qui masquait la primitive, devient `axe`). Aucun
+  consommateur connu ne les appelait : ils ne fonctionnaient pas.
+* `Evenement` est une **structure pure**, là où l'ancienne classe enveloppait
+  un `VEVENT` vobject et lisait ses propriétés à travers lui
+  (`self.vevent.dtstart.value`). C'est la règle posée pour `schema` : des
+  structures `attrs`, aucun IO, aucune dépendance intra-dépôt, la conversion
+  aux frontières. Les dates sont normalisées en `datetime` tz-aware — une
+  `date` nue d'événement « journée entière » est placée à minuit UTC.
+  Migration : `Evenement(etag=…, url=…, vevent=…)` devient
+  `Evenement.depuis_vevent(vevent, etag=…, url=…)`, et `ev.vevent.serialize()`
+  devient `ev.vers_vevent().serialize()`.
+
+### Removed
+
+* `Emplacement.depuis_decimal()` : fabrique morte, qui ignorait son argument
+  et renvoyait un `Emplacement()` vide sous une docstring « TODO ».
+* Les fonctions de conversion d'un export **Google Calendar** en vobject
+  (`json_en_vobject`, `decompose_un`, `decompose_date`) ne sont pas reprises :
+  ce sont des adaptateurs vers une source précise, pas du vocabulaire. Elles
+  restent disponibles dans l'ancien dépôt pour qui en aurait besoin.
+
 ## [0.15.0] - 2026-07-22
 
 ### Fixed

--- a/src/automatheque.schema/README.md
+++ b/src/automatheque.schema/README.md
@@ -13,11 +13,14 @@ Le paquet est découpé par famille de média, comme l'était l'ancien `modele/`
 
 | Espace | Contenu |
 |---|---|
+| `schema.media` | `Media` — le socle commun aux familles |
 | `schema.texte` | `Courriel` |
+| `schema.image` | `BaseTags` (les étiquettes d'une image), `Photo` |
 | `schema.geolocalisation` | `Emplacement` — une position GPS et/ou une adresse |
 | `schema.calendrier` | `Evenement` — ce qui a eu lieu, quand, et où |
 
-`schema.video` et `schema.audio` viendront s'y ajouter.
+`schema.video` et `schema.audio` viendront s'y ajouter. `schema.media` est
+réservé à ce qui est **commun** aux familles.
 
 ## Ce qui entre ici, et ce qui n'y entre pas
 
@@ -48,24 +51,43 @@ Classe "StockageMedium" de base = classe avec un nom_fichier éventuel pour la s
 L'idée c'est d'avoir un autre module automatheque pour gérer les xattrs , les extensions
 et la sauvegarde en fichier par ex., deviner le type de media (même pour meta données ou étiquettes, qui peuvent être enregistrées dans un fichier) ...
 
-## TODO
+## Sous-classage : ajouter des comportements
 
-donner des exemples pour l'héritage de renommable etc. qu'on ne va plus intégrer ici
+Les *comportements* — se renommer, se décomposer — n'entrent pas ici : ce sont
+des grammaires d'application, pas du vocabulaire, et les cuire dans les classes
+de schéma reviendrait à imposer à tous les consommateurs l'arborescence de
+rangement d'un seul.
 
-=> encourager le sous classage :
+La classe utilisable se compose donc **chez l'appelant**, par sous-classage :
 
 ```py
-class ChansonRenommable(Chanson, Renommable):
-    def liste_champs():
-        pass
+from automatheque.decomposition import Decomposable
+from automatheque.renommage import Gabarit, Gabarits, Renommable
+from automatheque.schema.image import Photo
 
-    def gabarits():
-        pass
+
+class PhotoRangeable(Photo, Renommable, Decomposable):
+    @classmethod
+    def _gabarits_par_defaut(cls):
+        """L'arborescence que *cette* application veut."""
+        gabarits = Gabarits()
+        gabarits.append(
+            Gabarit(squelette="{date:%Y}/{date:%Y-%m-%d} {album}/{nom_fichier}")
+        )
+        return gabarits
+
+    def _liste_champs_dispo(self):
+        """La projection des étiquettes vers les champs des gabarits."""
+        return {
+            "date": self.tags.date_prise_de_vue,
+            "album": self.tags.album or "",
+            "nom_fichier": self.basename,
+        }
 ```
 
 ## Requirement
 
-Python >=3.8
+Python >=3.9
 
 ## Installation
 
@@ -75,4 +97,4 @@ pip install automatheque.schema
 
 ## License
 
-GPLv3.0
+LGPLv3.0 ou ultérieure

--- a/src/automatheque.schema/README.md
+++ b/src/automatheque.schema/README.md
@@ -7,6 +7,40 @@ Objectifs :
 * partager des structures de données
 * metadonnées ou etiquettes et adaptateurs faciles
 
+## Les familles
+
+Le paquet est découpé par famille de média, comme l'était l'ancien `modele/` :
+
+| Espace | Contenu |
+|---|---|
+| `schema.texte` | `Courriel` |
+| `schema.geolocalisation` | `Emplacement` — une position GPS et/ou une adresse |
+| `schema.calendrier` | `Evenement` — ce qui a eu lieu, quand, et où |
+
+`schema.video` et `schema.audio` viendront s'y ajouter.
+
+## Ce qui entre ici, et ce qui n'y entre pas
+
+`schema` est le **vocabulaire** : ce que les choses *sont*, pour circuler
+d'une application à l'autre. Trois règles en découlent.
+
+* **Des structures pures.** Des classes `attrs`, aucune entrée/sortie, aucune
+  expression rationnelle. Interroger un service de géocodage, lire les EXIF
+  d'un fichier, parler à un serveur CalDAV : autant d'adaptateurs, qui vivent
+  ailleurs.
+* **Feuille du graphe de dépendances.** `schema` ne dépend d'aucun autre
+  paquet du dépôt — c'est lui qu'on consomme. Ses seules dépendances externes
+  au-delà d'`attrs` sont des **extras**, réclamés à la conversion et
+  facultatifs à l'installation.
+* **La conversion se fait aux frontières.** `Evenement` ne *contient* pas un
+  `VEVENT` iCalendar : il sait en venir et y retourner, par
+  `depuis_vevent()` / `vers_vevent()`, qui n'importent `vobject` qu'à
+  l'appel.
+
+```bash
+pip install "automatheque.schema[calendrier]"   # + vobject, pour l'iCalendar
+```
+
 ## Réfléchir
 
 Classe "StockageMedium" de base = classe avec un nom_fichier éventuel pour la sauvegarde ou url si dans le cloud etc.

--- a/src/automatheque.schema/automatheque/schema/calendrier/__init__.py
+++ b/src/automatheque.schema/automatheque/schema/calendrier/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Package destiné à situer les choses dans le temps."""
+
+from .evenement import Evenement
+
+__all__ = ["Evenement"]

--- a/src/automatheque.schema/automatheque/schema/calendrier/evenement.py
+++ b/src/automatheque.schema/automatheque/schema/calendrier/evenement.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+"""Evenement : ce qui a eu lieu, quand, et où.
+
+La classe est une **structure pure** : elle ne parle ni à un serveur CalDAV,
+ni à un fichier iCalendar. La conversion depuis et vers un `VEVENT` iCalendar
+se fait à la frontière, par :meth:`Evenement.depuis_vevent` et
+:meth:`Evenement.vers_vevent`, qui n'importent `vobject` qu'au moment de
+l'appel. Le paquet reste donc installable — et `Evenement` utilisable — sans
+`vobject`.
+
+Pour disposer de la conversion :
+
+```bash
+pip install "automatheque.schema[calendrier]"
+```
+"""
+
+from datetime import date, datetime, time, timezone
+from typing import List, Optional
+
+import attr
+
+# Champs iCalendar repris tels quels dans la structure. L'ordre est celui du
+# VEVENT, pour que la correspondance se lise d'un coup d'œil.
+_CHAMPS_VEVENT = (
+    ("uid", "uid"),
+    ("summary", "titre"),
+    ("location", "lieu"),
+    ("description", "description"),
+)
+
+
+def _en_datetime(valeur):
+    """Ramène une date iCalendar à un `datetime` tz-aware.
+
+    Un `VEVENT` « journée entière » porte une `date` nue : on la place à
+    minuit UTC pour qu'elle reste comparable aux événements horodatés. Une
+    `datetime` naïve est supposée UTC, faute de mieux — c'est déjà ce que
+    faisait le code d'origine.
+    """
+    if valeur is None:
+        return None
+    if not isinstance(valeur, datetime) and isinstance(valeur, date):
+        valeur = datetime.combine(valeur, time(0, 0, 0))
+    if valeur.tzinfo is None:
+        valeur = valeur.replace(tzinfo=timezone.utc)
+    return valeur
+
+
+@attr.s
+class Evenement:
+    """Un événement de calendrier.
+
+    `etag` et `url` sont les deux attributs que CalDAV attache à la ressource
+    (respectivement sa version et son adresse). Ils n'ont pas de sens hors
+    d'un serveur, mais les transporter ici évite de trimballer un couple
+    (événement, métadonnées de transport) dans tout le code appelant.
+    """
+
+    titre: Optional[str] = attr.ib(default=None, kw_only=True)
+    date_debut: Optional[datetime] = attr.ib(
+        default=None, kw_only=True, converter=_en_datetime
+    )
+    date_fin: Optional[datetime] = attr.ib(
+        default=None, kw_only=True, converter=_en_datetime
+    )
+    lieu: Optional[str] = attr.ib(default=None, kw_only=True)
+    description: Optional[str] = attr.ib(default=None, kw_only=True)
+    uid: Optional[str] = attr.ib(default=None, kw_only=True)
+
+    # Attributs spécifiques à CalDAV :
+    etag: Optional[str] = attr.ib(default=None, kw_only=True)
+    url: Optional[str] = attr.ib(default=None, kw_only=True)
+
+    @property
+    def date_fin_abregee(self) -> List[int]:
+        """Ce qui distingue la date de fin de la date de début.
+
+        Renvoie la liste des composantes — année, mois, jour — qui diffèrent
+        entre le début et la fin. Ex : `[4, 12]` pour un événement du
+        2018-03-14 au 2018-04-12, dont on n'a besoin d'écrire que « 04-12 ».
+
+        Sert à abréger l'affichage d'une période : on pourrait le faire avec
+        des règles de renommage, mais l'avoir ici simplifie les gabarits.
+        Renvoie une liste vide si l'une des deux dates manque.
+        """
+        if not self.date_debut or not self.date_fin:
+            return []
+
+        abrege = []
+        if self.date_debut.year != self.date_fin.year:
+            abrege.append(self.date_fin.year)
+        if self.date_debut.month != self.date_fin.month:
+            abrege.append(self.date_fin.month)
+        if self.date_debut.day != self.date_fin.day:
+            abrege.append(self.date_fin.day)
+        return abrege
+
+    @classmethod
+    def depuis_vevent(cls, vevent, etag=None, url=None) -> "Evenement":
+        """Construit un `Evenement` depuis un `VEVENT` iCalendar.
+
+        :param vevent: composant `VEVENT` de vobject, ou sa forme sérialisée
+        :param etag: version de la ressource CalDAV, si elle vient d'un serveur
+        :param url: adresse de la ressource CalDAV, idem
+        :raise ImportError: si `vobject` n'est pas installé et qu'une chaîne
+                            est passée (extra `calendrier`)
+        """
+        if isinstance(vevent, (str, bytes)):
+            vevent = _lit_vobject(vevent)
+            # `readOne` sur un VCALENDAR complet renvoie l'enveloppe : on
+            # descend au premier VEVENT qu'elle contient.
+            vevent = getattr(vevent, "vevent", vevent)
+
+        champs = {
+            nom: getattr(vevent, cle).value
+            for cle, nom in _CHAMPS_VEVENT
+            if hasattr(vevent, cle)
+        }
+
+        date_fin = None
+        if hasattr(vevent, "dtend"):
+            date_fin = vevent.dtend.value
+        elif hasattr(vevent, "duration"):
+            # TODO il nous faut un exemple et on calculera la date de fin
+            # à partir de la date de début et la durée.
+            # Reste le cas des événements récurrents ... :thinking_face:
+            raise NotImplementedError(
+                "VEVENT avec DURATION sans DTEND : pas encore géré"
+            )
+
+        return cls(
+            date_debut=vevent.dtstart.value if hasattr(vevent, "dtstart") else None,
+            date_fin=date_fin,
+            etag=etag,
+            url=url,
+            **champs,
+        )
+
+    def vers_vevent(self):
+        """Renvoie le `VEVENT` vobject correspondant à cet événement.
+
+        Les champs vides ne sont pas écrits : un `VEVENT` ne porte que ce
+        qu'on lui a donné.
+
+        :raise ImportError: si `vobject` n'est pas installé (extra
+                            `calendrier`)
+        """
+        vobject = _importe_vobject()
+        vevent = vobject.newFromBehavior("vevent")
+        for cle, nom in _CHAMPS_VEVENT:
+            valeur = getattr(self, nom)
+            if valeur is not None:
+                vevent.add(cle).value = valeur
+        if self.date_debut is not None:
+            vevent.add("dtstart").value = _pour_vobject(self.date_debut)
+        if self.date_fin is not None:
+            vevent.add("dtend").value = _pour_vobject(self.date_fin)
+        return vevent
+
+
+def _importe_vobject():
+    """Importe `vobject` en expliquant quoi installer s'il manque."""
+    try:
+        import vobject
+    except ImportError as exc:  # pragma: no cover - dépend de l'installation
+        raise ImportError(
+            "La conversion iCalendar réclame vobject : "
+            'pip install "automatheque.schema[calendrier]"'
+        ) from exc
+    return vobject
+
+
+def _lit_vobject(serialise):
+    """Dé-sérialise un composant iCalendar."""
+    return _importe_vobject().readOne(serialise)
+
+
+def _pour_vobject(valeur: datetime) -> datetime:
+    """Rend une datetime sérialisable par vobject.
+
+    vobject doit nommer le fuseau d'une datetime pour écrire son `TZID`, et
+    ne sait pas le faire pour les décalages fixes de la bibliothèque standard
+    (`datetime.timezone`) : il lève `Unable to guess TZID`. Or c'est
+    précisément ce que pose le convertisseur d'`Evenement`. On ramène donc ces
+    dates à l'UTC de vobject, qu'il sérialise en `Z` — même instant, notation
+    sans ambiguïté. Les fuseaux nommés (pytz…) passent intacts, pour conserver
+    leur `TZID`.
+    """
+    if isinstance(valeur.tzinfo, timezone):
+        return valeur.astimezone(_importe_vobject().icalendar.utc)
+    return valeur

--- a/src/automatheque.schema/automatheque/schema/geolocalisation/__init__.py
+++ b/src/automatheque.schema/automatheque/schema/geolocalisation/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Package destiné à situer les choses dans l'espace."""
+
+from .emplacement import Emplacement
+
+__all__ = ["Emplacement"]

--- a/src/automatheque.schema/automatheque/schema/geolocalisation/emplacement.py
+++ b/src/automatheque.schema/automatheque/schema/geolocalisation/emplacement.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""Emplacement : relie une position GPS et une adresse.
+
+Le passage de la position GPS à l'adresse et vice versa s'appelle en anglais
+le *geocoding* (et *nominatim*). Ce module n'en fait rien : il ne porte que le
+vocabulaire. Interroger un service de géocodage est l'affaire d'un
+connecteur — par exemple `localisation_gps`.
+"""
+
+from math import cos, radians, sqrt
+from typing import Tuple
+
+import attr
+
+
+@attr.s
+class Emplacement:
+    """Un lieu, décrit par ses coordonnées, son adresse, ou les deux.
+
+    Les composantes de l'adresse (`rue`, `ville`, `pays`…) sont facultatives :
+    elles sont remplies par un géocodage inverse quand il y en a un.
+    """
+
+    latitude: float = attr.ib(default=0, converter=float)
+    longitude: float = attr.ib(default=0, converter=float)
+    adresse: str = attr.ib(default="")
+
+    precision: str = attr.ib(kw_only=True, default="")
+    qualite: str = attr.ib(kw_only=True, default="")
+    numero_adresse: str = attr.ib(kw_only=True, default="")
+    rue: str = attr.ib(kw_only=True, default="")
+    ville: str = attr.ib(kw_only=True, default="")
+    etat: str = attr.ib(kw_only=True, default="")
+    pays: str = attr.ib(kw_only=True, default="")
+    code_postal: str = attr.ib(kw_only=True, default="")
+
+    # Attribut supplémentaire pour stocker un nom personnalisé, par ex :
+    # "Maison" ou "Bureau" etc. que l'on pourra remplir à la main ou à partir
+    # des contacts ou autre.
+    nom_personnalise: str = attr.ib(kw_only=True, default="")
+
+    def valide(self) -> bool:
+        """Renvoie si l'emplacement est valide ou non.
+
+        Un emplacement vaut par ses coordonnées **ou** par son adresse : l'un
+        des deux suffit à le situer.
+        """
+        return bool((self.latitude and self.longitude) or self.adresse)
+
+    @staticmethod
+    def decimal_en_dms(decimal) -> Tuple[float, float, float, int]:
+        """Convertit des degrés décimaux en degrés / minutes / secondes.
+
+        :param decimal: angle en degrés décimaux (ex: -38.2410611)
+        :returns: tuple `(degrés, minutes, secondes, signe)`, le signe valant
+                  1 ou -1 — les trois premières valeurs sont **absolues**
+        """
+        decimal = float(decimal)
+        decimal_abs = abs(decimal)
+        minutes, secondes = divmod(decimal_abs * 3600, 60)
+        degres, minutes = divmod(minutes, 60)
+        signe = 1 if decimal >= 0 else -1
+        return (degres, minutes, secondes, signe)
+
+    @staticmethod
+    def dms_en_decimal(degres, minutes, secondes, direction=" ") -> float:
+        """Convertit des degrés / minutes / secondes en degrés décimaux.
+
+        :param direction: point cardinal ; `W` et `S` donnent un angle négatif
+        """
+        signe = -1 if direction and direction[0] in "WSws" else 1
+        return (
+            float(degres) + (float(minutes) / 60) + (float(secondes) / 3600)
+        ) * signe
+
+    @staticmethod
+    def dms_en_chaine(decimal, axe: str = "latitude") -> str:
+        """Formate des degrés décimaux à la façon d'exiftool.
+
+        Exemple de sortie : ``38 deg 14' 27.82" S``.
+
+        :param axe: `latitude` ou `longitude`, qui décide du point cardinal
+        """
+        degres, minutes, secondes, _signe = Emplacement.decimal_en_dms(decimal)
+        if axe == "latitude":
+            direction = "N" if float(decimal) >= 0 else "S"
+        elif axe == "longitude":
+            direction = "E" if float(decimal) >= 0 else "W"
+        else:
+            raise ValueError("axe doit valoir 'latitude' ou 'longitude'")
+        return "{} deg {}' {}\" {}".format(degres, minutes, secondes, direction)
+
+    def distance(self, lat, lon) -> float:
+        """Renvoie une distance approximative, en mètres, avec une autre paire.
+
+        Cette distance n'est valable que pour des points proches. Ne pas
+        l'utiliser pour des calculs précis ou des points éloignés.
+
+        Récupéré de https://github.com/jmathai/elodie (`localstorage.py`) et
+        http://stackoverflow.com/questions/15736995.
+
+        :param lat: latitude du point à mesurer
+        :param lon: longitude du point à mesurer
+        """
+        # Conversion degrés "décimaux" en radians
+        lon1, lat1, lon2, lat2 = list(
+            map(radians, [lon, lat, self.longitude, self.latitude])
+        )
+
+        r = 6371000  # rayon de la Terre, en mètres
+        x = (lon2 - lon1) * cos(0.5 * (lat2 + lat1))
+        y = lat2 - lat1
+        return r * sqrt(x * x + y * y)

--- a/src/automatheque.schema/automatheque/schema/image/__init__.py
+++ b/src/automatheque.schema/automatheque/schema/image/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""Package destiné à gérer des images (photo ...)."""
+
+from .photo import Photo
+from .tags import BaseTags
+
+__all__ = ["BaseTags", "Photo"]

--- a/src/automatheque.schema/automatheque/schema/image/photo.py
+++ b/src/automatheque.schema/automatheque/schema/image/photo.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Photo : une image et ses étiquettes.
+
+La classe est réduite au vocabulaire — les extensions reconnues, les
+étiquettes, le contrôle de validité. Elle ne sait ni se renommer, ni se
+décomposer : ces comportements sont apportés par sous-classage, comme
+`schema` le demande.
+
+```py
+from automatheque.decomposition import Decomposable
+from automatheque.renommage import Renommable
+from automatheque.schema.image import Photo
+
+
+class PhotoRangeable(Photo, Renommable, Decomposable):
+    ...
+```
+"""
+
+import os
+from typing import Optional
+
+import attr
+
+from automatheque.schema.media import Media
+
+from .tags import BaseTags
+
+
+@attr.s
+class Photo(Media):
+    """Une photo : un fichier image, et ce qu'on sait de lui.
+
+    :param source: chemin complet vers le fichier
+    :param tags: étiquettes de l'image ; par défaut des `BaseTags` vides,
+                 rattachées à la même source. Un adaptateur (exiftool, fichier
+                 « sidecar »…) se substitue à elles en passant sa propre
+                 sous-classe de `BaseTags`.
+    """
+
+    # Extensions valides pour les photos. TODO que ça ?
+    extensions = ("arw", "cr2", "dng", "gif", "jpeg", "jpg", "nef", "rw2")
+
+    tags: BaseTags = attr.ib(
+        default=attr.Factory(lambda self: BaseTags(source=self.source), takes_self=True)
+    )
+
+    @property
+    def basename(self) -> Optional[str]:
+        """Nom du fichier, sans son répertoire."""
+        if self.source is None:
+            return None
+        return os.path.basename(self.source)
+
+    def charge_tags(self) -> BaseTags:
+        """Demande aux étiquettes de se remplir, et les renvoie.
+
+        Sans adaptateur, c'est un aller-retour sans effet : `BaseTags.charge()`
+        ne sait pas d'où viendraient les valeurs.
+        """
+        self.tags = self.tags.charge()
+        return self.tags

--- a/src/automatheque.schema/automatheque/schema/image/tags.py
+++ b/src/automatheque.schema/automatheque/schema/image/tags.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Le vocabulaire des étiquettes d'une image.
+
+`BaseTags` dit **ce qu'on sait** d'une photo — un album, une date de prise de
+vue, des coordonnées, un appareil. Elle ne dit pas *où* c'est écrit, ni
+comment l'y lire.
+
+Le code d'origine mélangeait les deux : son adaptateur exiftool héritait de
+cette classe, et écrire un attribut lançait un processus externe. Les deux
+sont désormais séparés — un adaptateur sous-classe `BaseTags` et surcharge
+`charge()`, mais il vit chez qui a besoin d'exiftool, pas ici.
+"""
+
+from datetime import datetime
+from typing import Optional, Tuple
+
+import attr
+
+
+@attr.s
+class BaseTags:
+    """Les étiquettes d'une image, sans rien savoir de leur stockage.
+
+    :param source: chemin du fichier décrit, quand il y en a un
+    """
+
+    # Extensions reconnues, à déclarer par les familles qui spécialisent.
+    extensions: Tuple[str, ...] = ()
+
+    # Attributs qu'un adaptateur est censé charger. Une famille qui n'utilise
+    # pas toute la liste (les vidéos, par exemple) n'en remonte qu'une partie.
+    ATTRIBUTS_CHARGES = (
+        "album",
+        "evenement",
+        "auteur",
+        "date_prise_de_vue",
+        "date_creation_fichier",
+        "date_modification_fichier",
+        "latitude",
+        "longitude",
+        "timezone",
+        "pays",
+        "province_etat",
+        "ville",
+        "lieu_quartier",
+        "fabriquant_appareil",
+        "modele_appareil",
+        "nom_origine",
+        "titre",
+        "description",
+        "evaluation",
+    )
+
+    # Un fuseau s'écrit « Europe/Paris », or « / » n'a pas sa place dans un nom
+    # de fichier. Ce séparateur le remplace quand le fuseau transite par un
+    # chemin, dans un sens comme dans l'autre.
+    TIMEZONE_SEPARATEUR = "%"
+
+    # Nom du fichier décrit. Une chaîne, rien de plus : la classe ne l'ouvre
+    # jamais.
+    source: Optional[str] = attr.ib(default=None, repr=False)
+
+    # Quoi, et de qui :
+    album: Optional[str] = attr.ib(default=None, kw_only=True)
+    evenement: Optional[object] = attr.ib(default=None, kw_only=True)
+    auteur: Optional[str] = attr.ib(default=None, kw_only=True)
+    titre: Optional[str] = attr.ib(default=None, kw_only=True)
+    description: Optional[str] = attr.ib(default=None, kw_only=True)
+    evaluation: Optional[int] = attr.ib(default=None, kw_only=True)
+    nom_origine: Optional[str] = attr.ib(default=None, kw_only=True)
+
+    # Quand :
+    date_prise_de_vue: Optional[datetime] = attr.ib(default=None, kw_only=True)
+    date_creation_fichier: Optional[datetime] = attr.ib(default=None, kw_only=True)
+    date_modification_fichier: Optional[datetime] = attr.ib(default=None, kw_only=True)
+    # Les dates des fichiers ne sont pas toujours lisibles avec leur fuseau ;
+    # on le stocke donc à part plutôt que de le deviner. Cf.
+    # TIMEZONE_SEPARATEUR pour son écriture dans un chemin.
+    timezone: Optional[str] = attr.ib(default=None, kw_only=True)
+
+    # Où :
+    coordonnees_gps: Optional[object] = attr.ib(default=None, kw_only=True)
+    latitude: Optional[float] = attr.ib(default=None, kw_only=True)
+    longitude: Optional[float] = attr.ib(default=None, kw_only=True)
+    lieu_quartier: Optional[str] = attr.ib(default=None, kw_only=True)
+    ville: Optional[str] = attr.ib(default=None, kw_only=True)
+    province_etat: Optional[str] = attr.ib(default=None, kw_only=True)
+    pays: Optional[str] = attr.ib(default=None, kw_only=True)
+
+    # Avec quoi :
+    fabriquant_appareil: Optional[str] = attr.ib(default=None, kw_only=True)
+    modele_appareil: Optional[str] = attr.ib(default=None, kw_only=True)
+
+    def charge(self) -> "BaseTags":
+        """Remplit les étiquettes depuis la source. À surcharger.
+
+        Ici, il n'y a rien à charger : la classe ne sait pas d'où viendraient
+        les valeurs. Un adaptateur — exiftool, un fichier « sidecar », une
+        base — surcharge cette méthode et renvoie `self`.
+        """
+        return self

--- a/src/automatheque.schema/automatheque/schema/media.py
+++ b/src/automatheque.schema/automatheque/schema/media.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Media : ce qui est commun aux familles `image`, `video`, `audio`, `texte`.
+
+Un média, ici, c'est un fichier et ce qu'on peut dire de lui **sans
+l'ouvrir** : son chemin, son extension, son type MIME deviné. La classe ne
+lit rien sur le disque — reconnaître un contenu réel est l'affaire d'un
+adaptateur.
+"""
+
+import mimetypes
+import os
+from typing import Optional, Tuple
+
+import attr
+
+
+@attr.s
+class Media:
+    """Classe de base pour tous les médias.
+
+    Les familles la spécialisent en déclarant leurs `extensions` :
+
+    ```py
+    @attr.s
+    class Photo(Media):
+        extensions = ("jpg", "png")
+    ```
+
+    :param source: chemin complet vers le fichier
+    """
+
+    # Extensions reconnues par la famille. Vide ici : `valide()` d'un `Media`
+    # nu est donc toujours faux, ce qui est la bonne réponse — on ne sait pas
+    # de quelle famille il relève.
+    extensions: Tuple[str, ...] = ()
+
+    source: Optional[str] = attr.ib(default=None)
+    # Empreinte du contenu, calculée par qui sait le faire (déduplication,
+    # recherche de similaires). Jamais remplie ici : la calculer réclame de
+    # lire le fichier.
+    empreinte: Optional[str] = attr.ib(init=False, default=None)
+
+    @property
+    def extension(self) -> str:
+        """Extension du fichier, en minuscules et sans le point."""
+        return os.path.splitext(self.source)[1][1:].lower()
+
+    @property
+    def mimetype(self) -> Optional[str]:
+        """Type MIME **deviné d'après le nom**, ou None s'il est inconnu.
+
+        Deviné, pas constaté : `mimetypes` lit l'extension, pas le contenu.
+        """
+        return mimetypes.guess_type(self.source)[0]
+
+    def valide(self) -> bool:
+        """Renvoie si l'extension du fichier est reconnue par la famille.
+
+        C'est un contrôle de **nom**, pas de contenu.
+        """
+        return self.extension in self.extensions

--- a/src/automatheque.schema/pyproject.toml
+++ b/src/automatheque.schema/pyproject.toml
@@ -24,9 +24,17 @@ Home = "https://github.com/jaegerbobomb/automatheque"
 Repository = "https://github.com/jaegerbobomb/automatheque.git"
 
 [project.optional-dependencies]
+# `schema.calendrier` ne réclame vobject que pour convertir depuis/vers un
+# VEVENT iCalendar, à la frontière. La structure `Evenement` elle-même est
+# pure et s'utilise sans lui : la dépendance est donc optionnelle, et schema
+# reste installable sans rien tirer de plus qu'attrs.
+calendrier = [
+    "vobject",
+]
 dev = [
     "pytest",
     "tox",
+    "vobject",
 ]
 
 [build-system]

--- a/src/automatheque.schema/tests/calendrier/test_evenement.py
+++ b/src/automatheque.schema/tests/calendrier/test_evenement.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""Tests de `schema.calendrier`."""
+
+from datetime import date, datetime, timezone
+
+import pytest
+from automatheque.schema.calendrier import Evenement
+
+vobject = pytest.importorskip("vobject")
+
+
+VEVENT = """BEGIN:VEVENT
+UID:1234@exemple.org
+SUMMARY:Voyage au Japon
+LOCATION:Osaka
+DESCRIPTION:Deux semaines
+DTSTART:20130317T010000Z
+DTEND:20130331T040000Z
+END:VEVENT
+"""
+
+VEVENT_JOURNEE_ENTIERE = """BEGIN:VEVENT
+UID:5678@exemple.org
+SUMMARY:JRPASS
+DTSTART;VALUE=DATE:20150509
+DTEND;VALUE=DATE:20150516
+END:VEVENT
+"""
+
+
+def test_structure_pure_sans_vevent():
+    """`Evenement` s'utilise sans jamais toucher à iCalendar."""
+    ev = Evenement(titre="Anniversaire", date_debut=datetime(2024, 5, 1, 12, 0))
+    assert ev.titre == "Anniversaire"
+    assert ev.date_fin is None
+
+
+def test_dates_naives_deviennent_tz_aware():
+    ev = Evenement(date_debut=datetime(2024, 5, 1, 12, 0))
+    assert ev.date_debut.tzinfo is not None
+    assert ev.date_debut.utcoffset().total_seconds() == 0
+
+
+def test_date_nue_devient_datetime_a_minuit():
+    ev = Evenement(date_debut=date(2024, 5, 1))
+    assert ev.date_debut == datetime(2024, 5, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def test_date_deja_tz_aware_est_conservee():
+    attendu = datetime(2024, 5, 1, 12, 0, tzinfo=timezone.utc)
+    assert Evenement(date_debut=attendu).date_debut == attendu
+
+
+def test_depuis_vevent_serialise():
+    ev = Evenement.depuis_vevent(VEVENT, etag="etag-1", url="https://exemple/1")
+    assert ev.titre == "Voyage au Japon"
+    assert ev.lieu == "Osaka"
+    assert ev.description == "Deux semaines"
+    assert ev.uid == "1234@exemple.org"
+    assert ev.etag == "etag-1"
+    assert ev.url == "https://exemple/1"
+    assert ev.date_debut == datetime(2013, 3, 17, 1, 0, tzinfo=timezone.utc)
+    assert ev.date_fin == datetime(2013, 3, 31, 4, 0, tzinfo=timezone.utc)
+
+
+def test_depuis_vevent_instance_vobject():
+    ev = Evenement.depuis_vevent(vobject.readOne(VEVENT))
+    assert ev.titre == "Voyage au Japon"
+
+
+def test_depuis_vevent_journee_entiere():
+    """Un DTSTART de type DATE devient une datetime à minuit UTC."""
+    ev = Evenement.depuis_vevent(VEVENT_JOURNEE_ENTIERE)
+    assert ev.date_debut == datetime(2015, 5, 9, 0, 0, tzinfo=timezone.utc)
+    assert ev.lieu is None
+
+
+def test_depuis_vevent_sans_duree_ni_fin():
+    sans_fin = VEVENT.replace("DTEND:20130331T040000Z\n", "")
+    assert Evenement.depuis_vevent(sans_fin).date_fin is None
+
+
+def test_depuis_vevent_avec_duration_non_gere():
+    avec_duree = VEVENT.replace("DTEND:20130331T040000Z", "DURATION:PT1H")
+    with pytest.raises(NotImplementedError):
+        Evenement.depuis_vevent(avec_duree)
+
+
+def test_vers_vevent():
+    ev = Evenement(
+        titre="Voyage au Japon",
+        lieu="Osaka",
+        uid="1234@exemple.org",
+        date_debut=datetime(2013, 3, 17, 1, 0, tzinfo=timezone.utc),
+        date_fin=datetime(2013, 3, 31, 4, 0, tzinfo=timezone.utc),
+    )
+    vevent = ev.vers_vevent()
+    assert vevent.summary.value == "Voyage au Japon"
+    assert vevent.location.value == "Osaka"
+    assert vevent.dtstart.value == ev.date_debut
+    assert "Voyage au Japon" in vevent.serialize()
+
+
+def test_vers_vevent_n_ecrit_pas_les_champs_vides():
+    vevent = Evenement(titre="Sans lieu").vers_vevent()
+    assert not hasattr(vevent, "location")
+
+
+def test_aller_retour_vevent():
+    ev = Evenement.depuis_vevent(VEVENT)
+    retour = Evenement.depuis_vevent(ev.vers_vevent())
+    assert retour == Evenement(
+        titre=ev.titre,
+        lieu=ev.lieu,
+        description=ev.description,
+        uid=ev.uid,
+        date_debut=ev.date_debut,
+        date_fin=ev.date_fin,
+    )
+
+
+def test_date_fin_abregee_ne_garde_que_ce_qui_change():
+    ev = Evenement(date_debut=date(2018, 3, 14), date_fin=date(2018, 4, 12))
+    assert ev.date_fin_abregee == [4, 12]
+
+
+def test_date_fin_abregee_avec_changement_d_annee():
+    ev = Evenement(date_debut=date(2018, 12, 30), date_fin=date(2019, 1, 2))
+    assert ev.date_fin_abregee == [2019, 1, 2]
+
+
+def test_date_fin_abregee_vide_le_meme_jour():
+    ev = Evenement(
+        date_debut=datetime(2018, 3, 14, 9, 0), date_fin=datetime(2018, 3, 14, 18, 0)
+    )
+    assert ev.date_fin_abregee == []
+
+
+def test_date_fin_abregee_vide_sans_date_de_fin():
+    assert Evenement(date_debut=date(2018, 3, 14)).date_fin_abregee == []

--- a/src/automatheque.schema/tests/geolocalisation/test_emplacement.py
+++ b/src/automatheque.schema/tests/geolocalisation/test_emplacement.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Tests de `schema.geolocalisation`."""
+
+import pytest
+from automatheque.schema.geolocalisation import Emplacement
+
+
+def test_coordonnees_converties_en_float():
+    e = Emplacement("48.8584", "2.2945")
+    assert e.latitude == pytest.approx(48.8584)
+    assert e.longitude == pytest.approx(2.2945)
+
+
+def test_valide_avec_des_coordonnees():
+    assert Emplacement(48.8584, 2.2945).valide()
+
+
+def test_valide_avec_une_adresse_seule():
+    assert Emplacement(adresse="5 avenue Anatole France, Paris").valide()
+
+
+def test_invalide_si_vide():
+    assert not Emplacement().valide()
+
+
+def test_invalide_si_une_seule_coordonnee():
+    assert not Emplacement(latitude=48.8584).valide()
+
+
+def test_decimal_en_dms():
+    """Régression : les divmod avaient disparu, la fonction ne tournait pas."""
+    degres, minutes, secondes, signe = Emplacement.decimal_en_dms(-38.2410611)
+    assert (degres, signe) == (38.0, -1)
+    assert minutes == 14.0
+    assert secondes == pytest.approx(27.82, abs=0.01)
+
+
+def test_decimal_en_dms_positif():
+    assert Emplacement.decimal_en_dms(48.5)[3] == 1
+
+
+def test_dms_en_decimal():
+    assert Emplacement.dms_en_decimal(38, 14, 27.82, "S") == pytest.approx(
+        -38.2410611, abs=1e-6
+    )
+    assert Emplacement.dms_en_decimal(38, 14, 27.82, "N") == pytest.approx(
+        38.2410611, abs=1e-6
+    )
+
+
+def test_dms_en_decimal_sans_direction():
+    assert Emplacement.dms_en_decimal(10, 30, 0) == pytest.approx(10.5)
+
+
+def test_aller_retour_dms():
+    degres, minutes, secondes, _ = Emplacement.decimal_en_dms(48.8584)
+    assert Emplacement.dms_en_decimal(degres, minutes, secondes) == pytest.approx(
+        48.8584, abs=1e-9
+    )
+
+
+def test_dms_en_chaine():
+    assert Emplacement.dms_en_chaine(-38.5, "latitude").endswith(" S")
+    assert Emplacement.dms_en_chaine(38.5, "latitude").endswith(" N")
+    assert Emplacement.dms_en_chaine(-2.5, "longitude").endswith(" W")
+    assert Emplacement.dms_en_chaine(2.5, "longitude").endswith(" E")
+
+
+def test_dms_en_chaine_refuse_un_axe_inconnu():
+    with pytest.raises(ValueError):
+        Emplacement.dms_en_chaine(2.5, "altitude")
+
+
+def test_distance_est_nulle_pour_le_meme_point():
+    e = Emplacement(48.8584, 2.2945)
+    assert e.distance(48.8584, 2.2945) == pytest.approx(0)
+
+
+def test_distance_approximative_entre_deux_points_proches():
+    """Tour Eiffel → Arc de Triomphe : environ 1,7 km à vol d'oiseau."""
+    eiffel = Emplacement(48.8584, 2.2945)
+    assert eiffel.distance(48.8738, 2.2950) == pytest.approx(1700, abs=100)
+
+
+def test_distance_croit_avec_l_ecart():
+    eiffel = Emplacement(48.8584, 2.2945)
+    assert eiffel.distance(48.8738, 2.2950) < eiffel.distance(48.9, 2.2950)

--- a/src/automatheque.schema/tests/image/test_image.py
+++ b/src/automatheque.schema/tests/image/test_image.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Tests de `schema.image`."""
+
+from datetime import datetime, timezone
+
+import attr
+from automatheque.schema.image import BaseTags, Photo
+from automatheque.schema.media import Media
+
+
+def test_photo_est_un_media():
+    assert isinstance(Photo(source="/photos/vacances.jpg"), Media)
+
+
+def test_photo_valide_selon_son_extension():
+    assert Photo(source="/photos/vacances.JPG").valide()
+    assert Photo(source="/photos/brut.cr2").valide()
+    assert not Photo(source="/photos/notes.txt").valide()
+
+
+def test_photo_valide_sans_ouvrir_le_fichier():
+    """Aucun accès disque : le fichier n'a pas besoin d'exister."""
+    assert Photo(source="/nexiste/pas/du/tout.jpg").valide()
+
+
+def test_basename():
+    assert Photo(source="/photos/2019/vacances.jpg").basename == "vacances.jpg"
+
+
+def test_basename_sans_source():
+    assert Photo().basename is None
+
+
+def test_tags_par_defaut_rattaches_a_la_source():
+    photo = Photo(source="/photos/vacances.jpg")
+    assert isinstance(photo.tags, BaseTags)
+    assert photo.tags.source == "/photos/vacances.jpg"
+
+
+def test_tags_par_defaut_propres_a_chaque_photo():
+    """La fabrique est rejouée à chaque instanciation, pas partagée."""
+    a, b = Photo(source="/a.jpg"), Photo(source="/b.jpg")
+    a.tags.album = "A"
+    assert b.tags.album is None
+
+
+def test_tags_fournis_a_la_construction():
+    tags = BaseTags(source="/photos/vacances.jpg", album="Vacances")
+    assert Photo("/photos/vacances.jpg", tags).tags.album == "Vacances"
+
+
+def test_tags_vides_par_defaut():
+    tags = BaseTags()
+    for attribut in BaseTags.ATTRIBUTS_CHARGES:
+        assert getattr(tags, attribut) is None
+
+
+def test_tags_acceptent_le_vocabulaire_complet():
+    tags = BaseTags(
+        source="/photos/vacances.jpg",
+        album="Japon",
+        auteur="Photographe",
+        titre="Osaka de nuit",
+        description="Vue depuis l'hôtel",
+        evaluation=5,
+        nom_origine="DSC_0001.jpg",
+        date_prise_de_vue=datetime(2013, 3, 17, 1, 0, tzinfo=timezone.utc),
+        timezone="Asia/Tokyo",
+        latitude=34.6937,
+        longitude=135.5023,
+        ville="Osaka",
+        pays="JP",
+    )
+    assert tags.album == "Japon"
+    assert tags.latitude == 34.6937
+    assert tags.timezone == "Asia/Tokyo"
+
+
+def test_charge_sans_adaptateur_ne_fait_rien():
+    tags = BaseTags(source="/photos/vacances.jpg")
+    assert tags.charge() is tags
+    assert tags.album is None
+
+
+def test_un_adaptateur_surcharge_charge():
+    """Le scénario visé : l'adaptateur d'I/O est une sous-classe, pas la base."""
+
+    @attr.s
+    class TagsFigees(BaseTags):
+        def charge(self):
+            self.album = "Depuis l'adaptateur"
+            return self
+
+    photo = Photo(source="/photos/vacances.jpg")
+    photo.tags = TagsFigees(source=photo.source)
+    assert photo.charge_tags().album == "Depuis l'adaptateur"
+
+
+def test_repr_montre_les_etiquettes():
+    """Régression : le motif attr.ib + property masquait les valeurs."""
+    assert "album='Japon'" in repr(BaseTags(album="Japon"))

--- a/src/automatheque.schema/tests/test_media.py
+++ b/src/automatheque.schema/tests/test_media.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Tests de `schema.media`."""
+
+import attr
+from automatheque.schema.media import Media
+
+
+@attr.s
+class Image(Media):
+    """Une famille qui déclare ses extensions."""
+
+    extensions = ("jpg", "png")
+
+
+def test_extension_en_minuscules_sans_le_point():
+    assert Media(source="/photos/vacances.JPG").extension == "jpg"
+
+
+def test_extension_vide_si_le_fichier_n_en_a_pas():
+    assert Media(source="/photos/LISEZMOI").extension == ""
+
+
+def test_mimetype_devine_depuis_le_nom():
+    assert Media(source="/photos/vacances.jpg").mimetype == "image/jpeg"
+
+
+def test_mimetype_inconnu_renvoie_none():
+    assert Media(source="/photos/vacances.inconnu").mimetype is None
+
+
+def test_valide_selon_les_extensions_de_la_famille():
+    assert Image(source="/photos/vacances.jpg").valide()
+    assert Image(source="/photos/vacances.PNG").valide()
+    assert not Image(source="/photos/vacances.gif").valide()
+
+
+def test_media_nu_n_est_jamais_valide():
+    """Sans famille, aucune extension n'est reconnue."""
+    assert not Media(source="/photos/vacances.jpg").valide()
+
+
+def test_empreinte_absente_par_defaut():
+    """La calculer réclamerait de lire le fichier : ce n'est pas fait ici."""
+    assert Media(source="/photos/vacances.jpg").empreinte is None
+
+
+def test_empreinte_hors_du_constructeur():
+    m = Media(source="/photos/vacances.jpg")
+    m.empreinte = "abc123"
+    assert m.empreinte == "abc123"


### PR DESCRIPTION
## Description

**Rattrapage de merge, aucun code nouveau.** #112 et #113 ont bien été mergées, mais dans la branche `claude/socle-2-decomposition` — pas dans `main`. Cette PR y verse ce qui manque.

État actuel de `main` (`845d3cc`) :

| Commit | Sujet | Dans `main` |
|---|---|---|
| `669a040` | ci : dérivation `src/*` | ✅ |
| `e82436d` | `automatheque.decomposition` | ✅ |
| `158b595` | `schema` geolocalisation + calendrier | ❌ |
| `5561037` | `schema` media + image | ❌ |
| `c3524ff` | `automatheque.renommage` | ❌ |
| `e0b0631` | README : les deux distributions | ❌ |

## Pourquoi c'est arrivé

Les quatre PR étaient empilées, chacune basée sur la précédente. GitHub ne re-cible une PR dépendante sur `main` que si la branche de base est **supprimée** au merge. `claude/socle-2-decomposition` ayant survécu au merge de #111, #112 est restée pointée dessus et y a versé son contenu ; #113 a ensuite été re-ciblée sur elle et a fait de même.

## Vérification

Fusion à blanc de cette branche dans `main` : l'arbre obtenu est **exactement** la pile relue en #112/#113, plus la release 0.20.0. Les cinq distributions sont présentes (`automatheque`, `.factrice`, `.schema`, `.decomposition`, `.renommage`) et les 291 tests passent.

Les six commits d'origine sont conservés tels quels, signatures comprises.

## À faire au merge

**Coche « Delete branch » ou supprime `claude/socle-2-decomposition` juste après**, sinon le même piège se rejouera avec la PR de correctifs qui suit.

Ne rien taguer avant que cette PR soit mergée : en l'état, une release ne partirait qu'avec `decomposition`, sans `schema` ni `renommage`.