### PR TITLE
fix(renommage,schema): trois bugs qui perdent ou corrompent des données

### DIFF
--- a/src/automatheque.renommage/CHANGELOG
+++ b/src/automatheque.renommage/CHANGELOG
@@ -21,9 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   données, il n'a pas à pouvoir exécuter du code.
 * Des exceptions nommées, là où le module levait des `ValueError` avec un
   message : `AucunGabaritApplicable`, `GabaritInapplicable`,
-  `ConditionInvalide`, `TransfertIncomplet`, sous une base commune
-  `RenommageEchec`. Les trois premières héritent aussi de `ValueError`, donc
-  un appelant qui l'attrapait continue de fonctionner.
+  `ConditionInvalide`, `CibleHorsRepertoire`, `TransfertIncomplet`, sous une
+  base commune `RenommageEchec`. Toutes sauf la dernière héritent aussi de
+  `ValueError`, donc un appelant qui l'attrapait continue de fonctionner.
 
 ### Changed
 
@@ -54,6 +54,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **Évasion du répertoire cible par les métadonnées des fichiers traités.**
+  Même canal non fiable que l'injection ci-dessous, laissé ouvert côté chemin :
+  les champs d'un squelette viennent des métadonnées, et
+  `os.path.join(rep_cible, nom)` **jette `rep_cible`** dès que `nom` est
+  absolu. Un album valant `/tmp/ailleurs` déplaçait donc le fichier hors du
+  répertoire demandé, puis supprimait l'original ; un album valant `../..`
+  remontait l'arborescence. Deux défenses désormais : chaque champ **chaîne**
+  est assaini (séparateurs neutralisés par `enleve_caracteres_invalides`,
+  segments `.` et `..` remplacés) — les valeurs non-chaînes passent intactes
+  pour que `{date:%Y}` continue de fonctionner, et les séparateurs du
+  *squelette* sont conservés puisque c'est par eux que l'auteur décrit son
+  arborescence ; puis le chemin final est vérifié comme contenu dans
+  `rep_cible`, faute de quoi `CibleHorsRepertoire` est levée sans rien
+  déplacer.
+* **Une cible corrompue survivait à `TransfertIncomplet`.** Le fichier
+  tronqué restait sur le disque ; l'essai suivant tombait sur la garde
+  « fichier existe », renvoyait le chemin **sans erreur**, et l'appelant
+  croyait le fichier rangé alors qu'il était corrompu. La cible est maintenant
+  effacée avant de lever — l'original, lui, n'est jamais touché.
+* Une copie qui n'a rien écrit (cible absente après un `ENOTSUP` avalé) donnait
+  un `FileNotFoundError` au lieu de `TransfertIncomplet`.
 * **Injection de code par les métadonnées des fichiers traités.** La condition
   d'un gabarit était formatée avec les champs de l'objet — un album, une
   ville, une description, c'est-à-dire des chaînes venues des fichiers

--- a/src/automatheque.renommage/README.md
+++ b/src/automatheque.renommage/README.md
@@ -99,7 +99,25 @@ d'un fichier de configuration présent au bon endroit, et intestable sans lui.
 Le déplacement est une copie, suivie d'une vérification de taille, suivie de
 la suppression de l'original. `shutil.move` seul ne dirait pas si la copie
 s'est mal passée d'un système de fichiers à l'autre ; ici, une cible qui ne
-correspond pas lève `TransfertIncomplet` **et laisse l'original en place**.
+correspond pas lève `TransfertIncomplet`, **efface la cible douteuse** et
+**laisse l'original en place**.
+
+## Les champs ne peuvent pas sortir du répertoire cible
+
+Les champs d'un squelette viennent des métadonnées des fichiers traités — un
+album, une ville, un titre. Substitués tels quels, ils sortiraient du
+répertoire demandé : `os.path.join` jette son premier argument dès que le
+second est absolu, et `..` remonte d'un niveau.
+
+Chaque champ **chaîne** est donc assaini avant substitution — séparateurs
+neutralisés, segments `.` et `..` remplacés. Les valeurs non-chaînes passent
+intactes, sans quoi `{date:%Y}` cesserait de fonctionner. Les séparateurs du
+**squelette**, eux, sont conservés : c'est par eux que tu décris ton
+arborescence.
+
+En dernier recours, le chemin final est vérifié comme contenu dans le
+répertoire cible ; sinon `CibleHorsRepertoire` est levée sans rien déplacer.
+Un squelette **absolu** tombe donc sous cette garde.
 
 ## Requirement
 

--- a/src/automatheque.renommage/automatheque/renommage/__init__.py
+++ b/src/automatheque.renommage/automatheque/renommage/__init__.py
@@ -4,6 +4,7 @@
 from .condition import evalue_condition
 from .exceptions import (
     AucunGabaritApplicable,
+    CibleHorsRepertoire,
     ConditionInvalide,
     GabaritInapplicable,
     RenommageEchec,
@@ -20,6 +21,7 @@ from .renommeur import (
 __all__ = [
     "SECTION_CONFIG_PAR_DEFAUT",
     "AucunGabaritApplicable",
+    "CibleHorsRepertoire",
     "ConditionInvalide",
     "Gabarit",
     "Gabarits",

--- a/src/automatheque.renommage/automatheque/renommage/exceptions.py
+++ b/src/automatheque.renommage/automatheque/renommage/exceptions.py
@@ -57,6 +57,24 @@ class ConditionInvalide(RenommageEchec, ValueError):
         super().__init__("Condition invalide : '{}'. {}".format(condition, raison))
 
 
+class CibleHorsRepertoire(RenommageEchec, ValueError):
+    """Le chemin construit sort du répertoire cible demandé.
+
+    Garde-fou de dernier recours : les champs qui alimentent un squelette sont
+    déjà assainis un par un. Si malgré cela le chemin s'échappe — un squelette
+    absolu, une combinaison inattendue — le déplacement est refusé plutôt que
+    d'écrire ailleurs que là où l'appelant l'a demandé.
+    """
+
+    def __init__(self, cible, rep_cible):
+        """Initialisation."""
+        self.cible = cible
+        self.rep_cible = rep_cible
+        super().__init__(
+            "La cible '{}' sort du répertoire '{}'.".format(cible, rep_cible)
+        )
+
+
 class TransfertIncomplet(RenommageEchec):
     """La copie vers la cible n'a pas produit un fichier identique.
 

--- a/src/automatheque.renommage/automatheque/renommage/renommeur.py
+++ b/src/automatheque.renommage/automatheque/renommage/renommeur.py
@@ -22,9 +22,12 @@ from typing import Iterator, List, Optional
 
 import attr
 
+from automatheque.util.fichier import enleve_caracteres_invalides
+
 from .condition import evalue_condition
 from .exceptions import (
     AucunGabaritApplicable,
+    CibleHorsRepertoire,
     GabaritInapplicable,
     TransfertIncomplet,
 )
@@ -33,6 +36,58 @@ LOGGER = logging.getLogger(__name__)
 
 # Section de configuration lue par défaut par `Gabarits.depuis_configuration`.
 SECTION_CONFIG_PAR_DEFAUT = "renommage"
+
+# Valeurs de champ qui, laissées telles quelles, désignent un répertoire au
+# lieu d'un nom : elles feraient remonter l'arborescence.
+_SEGMENTS_RELATIFS = (".", "..")
+
+
+def _assainit_champ(valeur):
+    """Neutralise ce qu'une valeur de champ pourrait faire au chemin.
+
+    Les champs d'un squelette viennent des **métadonnées des fichiers
+    traités** — un album, une ville, un titre. Substitués tels quels, ils
+    peuvent sortir du répertoire cible : `os.path.join` jette son premier
+    argument dès que le second est absolu, et `..` remonte d'un niveau.
+
+    Seules les chaînes sont assainies. Les autres valeurs — dates, nombres,
+    objets — passent intactes, sans quoi les spécificateurs de format des
+    squelettes (`{date:%Y}`) cesseraient de fonctionner ; elles n'ont de toute
+    façon pas de séparateur à porter avant leur propre formatage.
+
+    Les séparateurs présents dans le **squelette**, eux, sont conservés :
+    c'est par eux que l'auteur du gabarit décrit son arborescence.
+    """
+    if not isinstance(valeur, str):
+        return valeur
+    valeur = enleve_caracteres_invalides(valeur)
+    if valeur.strip() in _SEGMENTS_RELATIFS:
+        return "_" * len(valeur.strip())
+    return valeur
+
+
+def _cible_contenue(rep_cible, nom_fichier):
+    """Renvoie le chemin cible, après avoir vérifié qu'il reste dans le répertoire.
+
+    Deuxième ligne de défense, après l'assainissement des champs : un squelette
+    absolu, ou une combinaison qu'on n'avait pas prévue, ne doit pas pouvoir
+    écrire ailleurs que sous `rep_cible`.
+
+    :raise CibleHorsRepertoire: si le chemin construit s'en échappe
+    """
+    racine = os.path.abspath(rep_cible)
+    cible = os.path.abspath(os.path.join(racine, nom_fichier))
+    if cible != racine and not cible.startswith(racine + os.sep):
+        raise CibleHorsRepertoire(cible, racine)
+    return cible
+
+
+def _efface(chemin):
+    """Supprime un fichier sans se plaindre s'il n'est pas là."""
+    try:
+        os.remove(chemin)
+    except OSError:  # pragma: no cover - dépend du système de fichiers
+        LOGGER.warning("Impossible de supprimer la cible incomplète %s", chemin)
 
 
 @attr.s
@@ -228,7 +283,10 @@ class Renommeur:
         :raise AucunGabaritApplicable: si aucun gabarit ne convient
         :raise GabaritInapplicable: si le squelette retenu ne peut être formaté
         """
-        champs = self.obj._liste_champs_dispo()
+        champs = {
+            cle: _assainit_champ(valeur)
+            for cle, valeur in self.obj._liste_champs_dispo().items()
+        }
         gabarit = self.gabarits.choisit_gabarit(self.obj)
         LOGGER.debug("Gabarit choisi : %s", gabarit)
         try:
@@ -243,9 +301,10 @@ class Renommeur:
         la suppression de l'original — `shutil.move` ne dirait pas si la copie
         s'est mal passée entre deux systèmes de fichiers.
 
+        :raise CibleHorsRepertoire: si le chemin construit sort de `rep_cible`
         :returns: le chemin cible, qu'il ait été atteint ou non
         """
-        fichier_cible = os.path.join(rep_cible, nom_fichier)
+        fichier_cible = _cible_contenue(rep_cible, nom_fichier)
         fichier_orig = self.obj.filename
 
         if debug or (os.path.exists(fichier_cible) and not force):
@@ -276,7 +335,15 @@ class Renommeur:
             # les attributs d'un fichier. Le transfert s'est peut-être bien
             # passé malgré tout : on le vérifie juste après.
 
-        if os.path.getsize(fichier_cible) != os.path.getsize(fichier_orig):
+        if not os.path.exists(fichier_cible) or os.path.getsize(
+            fichier_cible
+        ) != os.path.getsize(fichier_orig):
+            # La cible ne vaut rien : on l'efface avant de lever. La laisser
+            # ferait passer le prochain essai par la garde « fichier existe »,
+            # qui rendrait le chemin sans erreur — l'appelant croirait le
+            # fichier rangé alors qu'il est tronqué. L'original, lui, n'a
+            # jamais été touché.
+            _efface(fichier_cible)
             raise TransfertIncomplet(fichier_orig, fichier_cible)
 
         # La cible est bonne : c'est seulement maintenant que l'objet déménage.

--- a/src/automatheque.renommage/tests/test_renommeur.py
+++ b/src/automatheque.renommage/tests/test_renommeur.py
@@ -13,6 +13,7 @@ import attr
 import pytest
 from automatheque.renommage import (
     AucunGabaritApplicable,
+    CibleHorsRepertoire,
     ConditionInvalide,
     Gabarit,
     GabaritInapplicable,
@@ -339,3 +340,115 @@ def test_aucun_attribut_etendu_n_est_ecrit(photo, tmp_path):
     """Le renommage n'écrit plus de xattr : la provenance va ailleurs."""
     cible = photo.renomme(str(tmp_path / "cible"))
     assert not os.listxattr(cible)
+
+
+#
+# Chemins : les champs viennent des métadonnées des fichiers traités
+#
+
+
+def test_champ_absolu_ne_sort_pas_du_repertoire_cible(photo, tmp_path):
+    """Régression : `os.path.join` jette son 1er argument si le 2e est absolu.
+
+    Un album valant `/tmp/ailleurs` déplaçait le fichier hors de `rep_cible`,
+    puis supprimait l'original.
+    """
+    ailleurs = str(tmp_path / "AILLEURS")
+    photo.album = ailleurs
+    cible = photo.renomme(
+        str(tmp_path / "range"), gabarits=Gabarits([Gabarit(squelette="{album}/{nom}")])
+    )
+
+    assert cible.startswith(str(tmp_path / "range"))
+    assert not os.path.exists(ailleurs)
+    assert os.path.exists(cible)
+
+
+def test_champ_avec_traversee_ne_remonte_pas(photo, tmp_path):
+    photo.album = "../../EVADE"
+    cible = photo.renomme(
+        str(tmp_path / "range"), gabarits=Gabarits([Gabarit(squelette="{album}/{nom}")])
+    )
+
+    assert os.path.normpath(cible).startswith(str(tmp_path / "range"))
+    assert "EVADE" in os.path.basename(os.path.dirname(cible))
+
+
+def test_champ_point_point_seul_est_neutralise(photo, tmp_path):
+    photo.album = ".."
+    cible = photo.renomme(
+        str(tmp_path / "range"), gabarits=Gabarits([Gabarit(squelette="{album}/{nom}")])
+    )
+    assert os.path.normpath(cible).startswith(str(tmp_path / "range"))
+
+
+def test_les_separateurs_du_squelette_sont_conserves(photo, tmp_path):
+    """L'assainissement porte sur les champs, pas sur le gabarit lui-même."""
+    cible = photo.renomme(str(tmp_path / "range"))
+    assert cible == str(tmp_path / "range" / "2013" / "Japon" / "DSC_0001.jpg")
+
+
+def test_les_champs_non_chaines_passent_intacts(photo, tmp_path):
+    """Sinon les spécificateurs de format (`{date:%Y}`) cesseraient de marcher."""
+    from datetime import datetime
+
+    @attr.s
+    class PhotoDatee(Photo):
+        prise = attr.ib(default=datetime(2013, 3, 17), kw_only=True)
+
+        def _liste_champs_dispo(self):
+            champs = super()._liste_champs_dispo()
+            champs["prise"] = self.prise
+            return champs
+
+    p = PhotoDatee(filename=photo.filename)
+    cible = p.renomme(
+        str(tmp_path / "range"),
+        gabarits=Gabarits([Gabarit(squelette="{prise:%Y}/{nom}")]),
+    )
+    assert os.path.dirname(cible).endswith("2013")
+
+
+def test_squelette_absolu_est_refuse(photo, tmp_path):
+    """Garde-fou de dernier recours, après l'assainissement des champs."""
+    gabarits = Gabarits([Gabarit(squelette="/etc/{nom}")])
+    with pytest.raises(CibleHorsRepertoire):
+        photo.renomme(str(tmp_path / "range"), gabarits=gabarits)
+    assert os.path.exists(photo.filename)
+
+
+#
+# Transfert incomplet : la cible ne doit pas survivre
+#
+
+
+def test_transfert_incomplet_efface_la_cible(photo, tmp_path, monkeypatch):
+    monkeypatch.setattr("shutil.copy", lambda s, d: open(d, "wb").write(b"TRONQ"))
+
+    with pytest.raises(TransfertIncomplet):
+        photo.renomme(str(tmp_path / "cible"))
+
+    corrompu = tmp_path / "cible" / "2013" / "Japon" / "DSC_0001.jpg"
+    assert not corrompu.exists()
+    assert os.path.exists(photo.filename)
+
+
+def test_apres_transfert_incomplet_le_second_essai_reussit(
+    photo, tmp_path, monkeypatch
+):
+    """Régression : la cible tronquée faisait passer le 2e essai pour un succès."""
+    monkeypatch.setattr("shutil.copy", lambda s, d: open(d, "wb").write(b"TRONQ"))
+    with pytest.raises(TransfertIncomplet):
+        photo.renomme(str(tmp_path / "cible"))
+
+    monkeypatch.undo()  # la copie remarche
+    cible = photo.renomme(str(tmp_path / "cible"))
+    assert open(cible, "rb").read() == b"des octets de photo"
+
+
+def test_copie_disparue_leve_transfert_incomplet(photo, tmp_path, monkeypatch):
+    """Une copie qui n'a rien écrit ne doit pas donner un FileNotFoundError."""
+    monkeypatch.setattr("shutil.copy", lambda s, d: None)
+    with pytest.raises(TransfertIncomplet):
+        photo.renomme(str(tmp_path / "cible"))
+    assert os.path.exists(photo.filename)

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* `Emplacement.valide()` : un point sur l'**équateur** ou sur le **méridien de
+  Greenwich** était déclaré invalide. Le test s'écrivait
+  `if (self.latitude and self.longitude)`, et zéro est *falsy* — or `0.0` est
+  une coordonnée parfaitement valide. Le test porte désormais sur la
+  **présence** (`is not None`), et les coordonnées ont `None` pour défaut au
+  lieu de `0` : « pas de coordonnée » se distingue enfin de « coordonnée
+  nulle ». `distance()` lève un `ValueError` explicite si l'emplacement de
+  départ n'en a pas, plutôt qu'un `TypeError` obscur.
+  *Migration :* un `Emplacement()` sans coordonnées expose `latitude is None`
+  là où il exposait `0.0`.
 * `Media` : `is_valid()` et `get_mimetype()` lisaient `self.filename`, un
   attribut que la classe **ne définit pas** — elle a `source`. Les deux
   méthodes levaient donc systématiquement `AttributeError` sur un `Media` ;

--- a/src/automatheque.schema/automatheque/schema/geolocalisation/emplacement.py
+++ b/src/automatheque.schema/automatheque/schema/geolocalisation/emplacement.py
@@ -8,7 +8,7 @@ connecteur — par exemple `localisation_gps`.
 """
 
 from math import cos, radians, sqrt
-from typing import Tuple
+from typing import Optional, Tuple
 
 import attr
 
@@ -21,8 +21,16 @@ class Emplacement:
     elles sont remplies par un géocodage inverse quand il y en a un.
     """
 
-    latitude: float = attr.ib(default=0, converter=float)
-    longitude: float = attr.ib(default=0, converter=float)
+    # `None` — et non `0` — pour « pas de coordonnée » : zéro est une latitude
+    # et une longitude parfaitement valides (l'équateur, le méridien de
+    # Greenwich), qu'on ne peut pas distinguer d'une absence si on les
+    # confond.
+    latitude: Optional[float] = attr.ib(
+        default=None, converter=attr.converters.optional(float)
+    )
+    longitude: Optional[float] = attr.ib(
+        default=None, converter=attr.converters.optional(float)
+    )
     adresse: str = attr.ib(default="")
 
     precision: str = attr.ib(kw_only=True, default="")
@@ -44,8 +52,13 @@ class Emplacement:
 
         Un emplacement vaut par ses coordonnées **ou** par son adresse : l'un
         des deux suffit à le situer.
+
+        Le test porte sur la **présence** des coordonnées, pas sur leur
+        valeur : un point sur l'équateur ou sur le méridien de Greenwich a une
+        coordonnée nulle et n'en est pas moins situé.
         """
-        return bool((self.latitude and self.longitude) or self.adresse)
+        a_des_coordonnees = self.latitude is not None and self.longitude is not None
+        return a_des_coordonnees or bool(self.adresse)
 
     @staticmethod
     def decimal_en_dms(decimal) -> Tuple[float, float, float, int]:
@@ -101,7 +114,13 @@ class Emplacement:
 
         :param lat: latitude du point à mesurer
         :param lon: longitude du point à mesurer
+        :raise ValueError: si cet emplacement n'a pas de coordonnées
         """
+        if self.latitude is None or self.longitude is None:
+            raise ValueError(
+                "Emplacement sans coordonnées : distance incalculable "
+                "(latitude={!r}, longitude={!r})".format(self.latitude, self.longitude)
+            )
         # Conversion degrés "décimaux" en radians
         lon1, lat1, lon2, lat2 = list(
             map(radians, [lon, lat, self.longitude, self.latitude])

--- a/src/automatheque.schema/tests/geolocalisation/test_emplacement.py
+++ b/src/automatheque.schema/tests/geolocalisation/test_emplacement.py
@@ -85,3 +85,38 @@ def test_distance_approximative_entre_deux_points_proches():
 def test_distance_croit_avec_l_ecart():
     eiffel = Emplacement(48.8584, 2.2945)
     assert eiffel.distance(48.8738, 2.2950) < eiffel.distance(48.9, 2.2950)
+
+
+def test_valide_sur_l_equateur():
+    """Régression : `if latitude and longitude` — zéro est falsy."""
+    assert Emplacement(0.0, 9.45).valide()
+
+
+def test_valide_sur_le_meridien_de_greenwich():
+    assert Emplacement(51.48, 0.0).valide()
+
+
+def test_valide_a_l_intersection_des_deux():
+    assert Emplacement(0.0, 0.0).valide()
+
+
+def test_coordonnees_absentes_par_defaut():
+    """`None` et non `0` : « pas de coordonnée » se distingue de « zéro »."""
+    e = Emplacement()
+    assert e.latitude is None and e.longitude is None
+    assert not e.valide()
+
+
+def test_une_seule_coordonnee_ne_suffit_pas():
+    assert not Emplacement(latitude=48.8584).valide()
+    assert not Emplacement(longitude=2.2945).valide()
+
+
+def test_distance_sans_coordonnees_leve_une_erreur_claire():
+    with pytest.raises(ValueError, match="sans coordonnées"):
+        Emplacement(adresse="quelque part").distance(48.8584, 2.2945)
+
+
+def test_distance_depuis_l_equateur():
+    """Le point de départ est valide : la distance doit se calculer."""
+    assert Emplacement(0.0, 0.0).distance(0.0, 0.0) == pytest.approx(0)


### PR DESCRIPTION
> Reprend proprement le travail de `claude/correctifs-socle` (commits **non vérifiés** — signés avec une clé non enregistrée — et branche mal nommée). Ici : branche propre, commit **signé et vérifié** (dwwm93).

## Description

Trois bugs des deux nouvelles distributions qui **perdent ou corrompent des
données** :

### 1. `renommage` — le chemin cible peut sortir du répertoire demandé
Les champs d'un squelette viennent des **métadonnées des fichiers** (album,
ville, titre). Substitués tels quels : `os.path.join` **jette sa base** dès que
le champ est un chemin absolu, et `..` **remonte** l'arborescence — le fichier
atterrit ailleurs que là où l'appelant l'a demandé.
* `_assainit_champ` assainit les champs **chaîne** (`enleve_caracteres_invalides`,
  neutralise `.`/`..`) — les non-chaînes (dates, nombres) passent intactes pour
  préserver `{date:%Y}` ;
* `_cible_contenue` **vérifie** que le chemin construit reste sous `rep_cible`,
  sinon `CibleHorsRepertoire` (nouvelle exception).

### 2. `renommage` — une copie tronquée était laissée en place
Si la copie est incomplète (tailles différentes), l'ancienne cible restait sur
le disque : au **prochain essai**, la garde « le fichier existe déjà » renvoyait
le chemin **sans erreur** → l'appelant croyait le fichier rangé alors qu'il est
**tronqué**. Désormais la cible incomplète est **effacée** avant de lever
`TransfertIncomplet` (l'original n'est jamais touché). Garde aussi contre une
cible absente (`os.path.exists` avant `getsize`).

### 3. `schema` — `Emplacement` confondait « (0, 0) » et « pas de coordonnées »
`latitude`/`longitude` valaient `0` par défaut : l'équateur / le méridien de
Greenwich (coordonnées **nulles mais valides**) étaient indistinguables d'une
absence. Défaut → **`None`** ; `est_valide` teste la **présence** (pas la
véracité) ; `distance_*` lève `ValueError` si les coordonnées manquent.

## Tests

Nouveaux tests pour chaque bug (`test_renommeur.py`, `test_emplacement.py`).
Suite complète **291 passés** (1 skip = extra `vobject`), `ruff`/`format`/`mypy`
(cœur) verts.

## Versioning

`automatheque.renommage` et `automatheque.schema` — à intégrer avant la 1.0
(bump/release à décider ensuite).
