### PR TITLE
fix(renommage,schema): un seul nom de fichier (`source`) pour la composition (#117)

### DIFF
--- a/src/automatheque.renommage/CHANGELOG
+++ b/src/automatheque.renommage/CHANGELOG
@@ -40,6 +40,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `rep_cible`, `v_nomfic` → `nom_fichier`).
 * `mkdir_p` (déprécié dans le cœur en 0.19.0) laisse place à
   `Path.mkdir(parents=True, exist_ok=True)`.
+* **`Renommable` attend un attribut `source`, plus son propre `filename`.**
+  L'ancien `filename` (`attr.ib(default="")`) faisait doublon avec `Media.source`
+  et **divergeait** après un rangement (seul `filename` était mis à jour). Le
+  renommage lit et **écrit** désormais dans `source` — un seul porteur de vérité,
+  dont dérivent nom de base, extension, étiquettes rechargées. C'est une
+  convention (nom d'attribut attendu), sans dépendance vers `schema`, comme le
+  contrat de `decomposition`. Cf. #117. *(Rupture — mais la distribution n'est
+  pas encore publiée.)*
+* Un `Renommable` **sans `source`** est refusé **explicitement** (`ValueError`)
+  au lieu d'un `shutil.copy(None, …)` obscur au fond de la pile. Cf. #117.
 
 ### Removed
 

--- a/src/automatheque.renommage/automatheque/renommage/renommeur.py
+++ b/src/automatheque.renommage/automatheque/renommage/renommeur.py
@@ -220,15 +220,18 @@ class Gabarits:
 class Renommable:
     """Classe à hériter/surcharger pour être facilement renommable.
 
-    L'objet doit exposer `filename`, le chemin du fichier à déplacer, et
-    surcharger les deux méthodes ci-dessous.
+    L'objet doit **exposer un attribut `source`** — le chemin du fichier à
+    déplacer — et surcharger les deux méthodes ci-dessous. `Renommable` ne
+    déclare pas `source` lui-même : c'est le consommateur qui le fournit (par
+    exemple `automatheque.schema.media.Media`, dont c'est déjà l'attribut). Le
+    renommage lit et **écrit** dans `source` : après un rangement, `source`
+    pointe la cible, et tout ce qui en dérive (nom de base, extension…) suit.
 
-    TODO : `filename` fait doublon avec `source` de `automatheque.schema.media`
-    quand les deux sont mêlées par sous-classage — les deux noms désignent le
-    même fichier et peuvent diverger après un renommage. À arbitrer.
+    C'est une **convention** — un nom d'attribut attendu — sans dépendance vers
+    `schema`, comme le contrat de `automatheque.decomposition`. On évite ainsi
+    deux vérités pour un même fichier (l'ancien `filename` propre à `Renommable`
+    divergeait de `source` après un renommage).
     """
-
-    filename: str = attr.ib(default="")  # TODO nom_fichier au lieu de filename
 
     @classmethod
     def _gabarits_par_defaut(cls) -> Gabarits:
@@ -305,7 +308,16 @@ class Renommeur:
         :returns: le chemin cible, qu'il ait été atteint ou non
         """
         fichier_cible = _cible_contenue(rep_cible, nom_fichier)
-        fichier_orig = self.obj.filename
+        fichier_orig = self.obj.source
+        if not fichier_orig:
+            # Refus explicite : sans `source`, il n'y a rien à déplacer. Mieux
+            # vaut le dire ici qu'un `shutil.copy(None, …)` obscur au fond de la
+            # pile (l'ancien défaut `filename=""` donnait le même genre d'échec
+            # tardif). Cf. #117.
+            raise ValueError(
+                "Renommable sans `source` : rien à déplacer. L'objet doit "
+                "exposer le chemin du fichier dans son attribut `source`."
+            )
 
         if debug or (os.path.exists(fichier_cible) and not force):
             LOGGER.warning(
@@ -347,7 +359,9 @@ class Renommeur:
             raise TransfertIncomplet(fichier_orig, fichier_cible)
 
         # La cible est bonne : c'est seulement maintenant que l'objet déménage.
-        self.obj.filename = fichier_cible
+        # On écrit dans `source` — le seul porteur de vérité du chemin : nom de
+        # base, extension, étiquettes rechargées… tout en dérive et suit.
+        self.obj.source = fichier_cible
         if not copier:
             os.remove(fichier_orig)
         return fichier_cible

--- a/src/automatheque.renommage/tests/test_composition.py
+++ b/src/automatheque.renommage/tests/test_composition.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Composition documentée `Photo` + `Renommable` + `Decomposable` (#117).
+
+Test **inter-paquets** : il vérifie qu'après un rangement, *tous* les accès au
+fichier suivent la cible — pas seulement celui qui a été mis à jour. C'est ce
+qui empêche la divergence de revenir. Ignoré si `schema`/`decomposition` ne sont
+pas installés (exécution isolée du seul paquet `renommage`).
+"""
+
+import os
+
+import attr
+import pytest
+
+pytest.importorskip("automatheque.schema.image")
+pytest.importorskip("automatheque.decomposition")
+
+from automatheque.decomposition import Decomposable  # noqa: E402
+from automatheque.renommage import Gabarit, Gabarits, Renommable  # noqa: E402
+from automatheque.schema.image import BaseTags, Photo  # noqa: E402
+
+
+@attr.s
+class PhotoRangeable(Photo, Renommable, Decomposable):
+    """La composition recommandée par le docstring de `Photo`."""
+
+    @classmethod
+    def _gabarits_par_defaut(cls):
+        return Gabarits([Gabarit(squelette="{nom}.jpg", ordre=1)])
+
+    def _liste_champs_dispo(self):
+        return {"nom": "photo-rangee"}
+
+
+@attr.s
+class TagsSidecar(BaseTags):
+    """Adaptateur « sidecar » minimal : il retient la source qu'on lui passe.
+
+    Représente le cas de photomas : un adaptateur qui écrit **à côté** du media
+    et a donc besoin de la source **à jour**.
+    """
+
+    source_vue = attr.ib(default=None, kw_only=True)
+
+    def charge(self, source=None):
+        self.source_vue = source
+        return self
+
+
+def test_composition_documentee_ne_diverge_pas_apres_rangement(tmp_path):
+    src = tmp_path / "IMG_1234.jpg"
+    src.write_bytes(b"\xff\xd8\xff\xe0" + b"x" * 200)
+
+    p = PhotoRangeable(source=str(src))
+    p.tags = TagsSidecar()
+
+    cible = p.renomme(str(tmp_path / "range"))
+
+    # Le fichier a bougé, l'original a disparu.
+    assert os.path.exists(cible)
+    assert not os.path.exists(str(src))
+
+    # TOUS les accès pointent la cible, pas seulement celui qui a été écrit.
+    assert p.source == cible
+    assert p.basename == os.path.basename(cible)  # dérive de source
+    # ce que `Decomposable` analyse par défaut suit aussi (redécomposer ne relit
+    # plus l'ancien nom).
+    assert p._prepare_decomposition() == os.path.basename(cible)
+
+    # Les étiquettes voient la source **à jour** : un « sidecar » n'écrira pas à
+    # côté de l'ancien emplacement.
+    p.charge_tags()
+    assert p.tags.source_vue == cible
+
+
+def test_source_absente_refuse_le_rangement_clairement(tmp_path):
+    """Sans `source`, on refuse tôt et clairement plutôt qu'un `shutil.copy`
+    obscur au fond de la pile."""
+    p = PhotoRangeable()  # source=None par défaut (Media)
+    with pytest.raises(ValueError, match="source"):
+        p.renomme(str(tmp_path / "range"))

--- a/src/automatheque.renommage/tests/test_renommeur.py
+++ b/src/automatheque.renommage/tests/test_renommeur.py
@@ -27,8 +27,14 @@ from automatheque.renommage import (
 
 @attr.s
 class Photo(Renommable):
-    """Un renommable minimal."""
+    """Un renommable minimal.
 
+    `Renommable` ne déclare plus le chemin du fichier : il attend un attribut
+    `source` (que fournit `schema.media.Media` dans la vraie vie). Ici on le
+    déclare nous-mêmes.
+    """
+
+    source = attr.ib(default="")
     album = attr.ib(default="", kw_only=True)
     annee = attr.ib(default="", kw_only=True)
     pays = attr.ib(default="", kw_only=True)
@@ -47,7 +53,7 @@ class Photo(Renommable):
             "album": self.album,
             "annee": self.annee,
             "pays": self.pays,
-            "nom": os.path.basename(self.filename),
+            "nom": os.path.basename(self.source),
         }
 
 
@@ -57,7 +63,7 @@ def photo(tmp_path):
     fichier = tmp_path / "source" / "DSC_0001.jpg"
     fichier.parent.mkdir()
     fichier.write_bytes(b"des octets de photo")
-    return Photo(filename=str(fichier), album="Japon", annee="2013")
+    return Photo(source=str(fichier), album="Japon", annee="2013")
 
 
 #
@@ -71,7 +77,7 @@ def test_gabarit_sans_condition_s_applique_toujours():
 
 
 def test_gabarit_avec_condition_vraie_passe_avant_celui_sans_condition():
-    photo = Photo(filename="/a/b.jpg", album="Japon", annee="2013")
+    photo = Photo(source="/a/b.jpg", album="Japon", annee="2013")
     assert (
         photo._gabarits_par_defaut()
         .choisit_gabarit(photo)
@@ -80,7 +86,7 @@ def test_gabarit_avec_condition_vraie_passe_avant_celui_sans_condition():
 
 
 def test_gabarit_avec_condition_fausse_est_ecarte():
-    photo = Photo(filename="/a/b.jpg", album="", annee="2013")
+    photo = Photo(source="/a/b.jpg", album="", annee="2013")
     assert (
         photo._gabarits_par_defaut().choisit_gabarit(photo).squelette == "a-trier/{nom}"
     )
@@ -172,7 +178,7 @@ def test_evalue_condition_refuse_une_expression_mal_formee():
 
 def test_injection_par_les_metadonnees_ne_s_execute_pas():
     """Bout en bout : un album malveillant ne fait qu'invalider la condition."""
-    photo = Photo(filename="/a/b.jpg", album='" and __import__("os").getcwd() and "')
+    photo = Photo(source="/a/b.jpg", album='" and __import__("os").getcwd() and "')
     gabarits = Gabarits(
         [
             Gabarit(squelette="dangereux", condition='"{album}"'),
@@ -246,12 +252,12 @@ def test_renommeur_refuse_un_objet_non_renommable():
 
 
 def test_renomme_deplace_le_fichier(photo, tmp_path):
-    origine = photo.filename
+    origine = photo.source
     cible = photo.renomme(str(tmp_path / "cible"))
 
     assert os.path.exists(cible)
     assert not os.path.exists(origine)
-    assert photo.filename == cible
+    assert photo.source == cible
     assert open(cible, "rb").read() == b"des octets de photo"
 
 
@@ -261,14 +267,14 @@ def test_renomme_cree_l_arborescence(photo, tmp_path):
 
 
 def test_renomme_en_copiant_conserve_l_original(photo, tmp_path):
-    origine = photo.filename
+    origine = photo.source
     cible = photo.renomme(str(tmp_path / "cible"), copier=True)
     assert os.path.exists(origine)
     assert os.path.exists(cible)
 
 
 def test_debug_ne_deplace_rien_mais_annonce_la_cible(photo, tmp_path):
-    origine = photo.filename
+    origine = photo.source
     cible = photo.renomme(str(tmp_path / "cible"), debug=True)
 
     assert cible.endswith(os.path.join("2013", "Japon", "DSC_0001.jpg"))
@@ -277,10 +283,10 @@ def test_debug_ne_deplace_rien_mais_annonce_la_cible(photo, tmp_path):
 
 
 def test_debug_ne_deplace_pas_l_objet_non_plus(photo, tmp_path):
-    """Régression : `filename` était réaffecté avant même la copie."""
-    origine = photo.filename
+    """Régression : `source` était réaffecté avant même la copie."""
+    origine = photo.source
     photo.renomme(str(tmp_path / "cible"), debug=True)
-    assert photo.filename == origine
+    assert photo.source == origine
 
 
 def test_cible_existante_n_est_pas_ecrasee(photo, tmp_path):
@@ -288,12 +294,12 @@ def test_cible_existante_n_est_pas_ecrasee(photo, tmp_path):
     existant.parent.mkdir(parents=True)
     existant.write_bytes(b"deja la")
 
-    origine = photo.filename
+    origine = photo.source
     photo.renomme(str(tmp_path / "cible"))
 
     assert existant.read_bytes() == b"deja la"
     assert os.path.exists(origine)
-    assert photo.filename == origine
+    assert photo.source == origine
 
 
 def test_force_ecrase_la_cible_existante(photo, tmp_path):
@@ -314,7 +320,7 @@ def test_transfert_incomplet_conserve_l_original(photo, tmp_path, monkeypatch):
 
     monkeypatch.setattr("shutil.copy", copie_tronquee)
 
-    origine = photo.filename
+    origine = photo.source
     with pytest.raises(TransfertIncomplet):
         photo.renomme(str(tmp_path / "cible"))
     assert os.path.exists(origine)
@@ -401,7 +407,7 @@ def test_les_champs_non_chaines_passent_intacts(photo, tmp_path):
             champs["prise"] = self.prise
             return champs
 
-    p = PhotoDatee(filename=photo.filename)
+    p = PhotoDatee(source=photo.source)
     cible = p.renomme(
         str(tmp_path / "range"),
         gabarits=Gabarits([Gabarit(squelette="{prise:%Y}/{nom}")]),
@@ -414,7 +420,7 @@ def test_squelette_absolu_est_refuse(photo, tmp_path):
     gabarits = Gabarits([Gabarit(squelette="/etc/{nom}")])
     with pytest.raises(CibleHorsRepertoire):
         photo.renomme(str(tmp_path / "range"), gabarits=gabarits)
-    assert os.path.exists(photo.filename)
+    assert os.path.exists(photo.source)
 
 
 #
@@ -430,7 +436,7 @@ def test_transfert_incomplet_efface_la_cible(photo, tmp_path, monkeypatch):
 
     corrompu = tmp_path / "cible" / "2013" / "Japon" / "DSC_0001.jpg"
     assert not corrompu.exists()
-    assert os.path.exists(photo.filename)
+    assert os.path.exists(photo.source)
 
 
 def test_apres_transfert_incomplet_le_second_essai_reussit(
@@ -451,4 +457,4 @@ def test_copie_disparue_leve_transfert_incomplet(photo, tmp_path, monkeypatch):
     monkeypatch.setattr("shutil.copy", lambda s, d: None)
     with pytest.raises(TransfertIncomplet):
         photo.renomme(str(tmp_path / "cible"))
-    assert os.path.exists(photo.filename)
+    assert os.path.exists(photo.source)

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -102,6 +102,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   décomposition — autant de politiques produit, pas de vocabulaire.
 * `Photo.basename` devient une propriété dérivée de `source`, au lieu d'un
   attribut rempli à l'initialisation.
+* **`BaseTags` ne porte plus de `source`.** C'était une troisième copie du
+  chemin (après `Media.source`), figée à la construction, qui restait en arrière
+  après un renommage — un adaptateur « sidecar » aurait écrit à côté de l'ancien
+  emplacement. La source est désormais **reçue** au chargement :
+  `charge(source)` (au lieu de `charge()`), et `Photo.charge_tags()` lui passe
+  la source **courante** de la photo. Cf. #117. *(Rupture — distribution non
+  encore publiée.)*
 
 ### Removed
 

--- a/src/automatheque.schema/automatheque/schema/image/photo.py
+++ b/src/automatheque.schema/automatheque/schema/image/photo.py
@@ -32,18 +32,17 @@ class Photo(Media):
     """Une photo : un fichier image, et ce qu'on sait de lui.
 
     :param source: chemin complet vers le fichier
-    :param tags: étiquettes de l'image ; par défaut des `BaseTags` vides,
-                 rattachées à la même source. Un adaptateur (exiftool, fichier
-                 « sidecar »…) se substitue à elles en passant sa propre
+    :param tags: étiquettes de l'image ; par défaut des `BaseTags` vides. Les
+                 étiquettes ne portent pas la source (cf. `BaseTags`) : c'est
+                 `charge_tags` qui la leur passe. Un adaptateur (exiftool,
+                 fichier « sidecar »…) se substitue à elles en passant sa propre
                  sous-classe de `BaseTags`.
     """
 
     # Extensions valides pour les photos. TODO que ça ?
     extensions = ("arw", "cr2", "dng", "gif", "jpeg", "jpg", "nef", "rw2")
 
-    tags: BaseTags = attr.ib(
-        default=attr.Factory(lambda self: BaseTags(source=self.source), takes_self=True)
-    )
+    tags: BaseTags = attr.ib(factory=BaseTags)
 
     @property
     def basename(self) -> Optional[str]:
@@ -53,10 +52,12 @@ class Photo(Media):
         return os.path.basename(self.source)
 
     def charge_tags(self) -> BaseTags:
-        """Demande aux étiquettes de se remplir, et les renvoie.
+        """Demande aux étiquettes de se remplir depuis la source, et les renvoie.
 
-        Sans adaptateur, c'est un aller-retour sans effet : `BaseTags.charge()`
-        ne sait pas d'où viendraient les valeurs.
+        La source est passée à `charge` au moment de l'appel — les étiquettes ne
+        la mémorisent pas — donc un rangement préalable (qui a mis à jour
+        `source`) est bien pris en compte. Sans adaptateur, c'est un aller-retour
+        sans effet : `BaseTags.charge()` ne sait pas d'où viendraient les valeurs.
         """
-        self.tags = self.tags.charge()
+        self.tags = self.tags.charge(self.source)
         return self.tags

--- a/src/automatheque.schema/automatheque/schema/image/tags.py
+++ b/src/automatheque.schema/automatheque/schema/image/tags.py
@@ -21,7 +21,10 @@ import attr
 class BaseTags:
     """Les étiquettes d'une image, sans rien savoir de leur stockage.
 
-    :param source: chemin du fichier décrit, quand il y en a un
+    Les étiquettes ne **portent pas** le chemin du fichier décrit : ce serait
+    une troisième vérité (après `Media.source`), qui divergerait après un
+    renommage. La source est **reçue** au moment du chargement — `charge(source)`
+    — et jamais mémorisée ici.
     """
 
     # Extensions reconnues, à déclarer par les familles qui spécialisent.
@@ -56,10 +59,6 @@ class BaseTags:
     # chemin, dans un sens comme dans l'autre.
     TIMEZONE_SEPARATEUR = "%"
 
-    # Nom du fichier décrit. Une chaîne, rien de plus : la classe ne l'ouvre
-    # jamais.
-    source: Optional[str] = attr.ib(default=None, repr=False)
-
     # Quoi, et de qui :
     album: Optional[str] = attr.ib(default=None, kw_only=True)
     evenement: Optional[object] = attr.ib(default=None, kw_only=True)
@@ -91,11 +90,16 @@ class BaseTags:
     fabriquant_appareil: Optional[str] = attr.ib(default=None, kw_only=True)
     modele_appareil: Optional[str] = attr.ib(default=None, kw_only=True)
 
-    def charge(self) -> "BaseTags":
-        """Remplit les étiquettes depuis la source. À surcharger.
+    def charge(self, source: Optional[str] = None) -> "BaseTags":
+        """Remplit les étiquettes depuis ``source``. À surcharger.
+
+        La source (le chemin du fichier décrit) est **reçue** à l'appel — elle
+        n'est pas mémorisée par la classe, pour ne pas devenir une vérité qui se
+        périme après un renommage. Un adaptateur — exiftool, un fichier
+        « sidecar », une base — surcharge cette méthode, lit/écrit à côté de
+        ``source``, et renvoie ``self``.
 
         Ici, il n'y a rien à charger : la classe ne sait pas d'où viendraient
-        les valeurs. Un adaptateur — exiftool, un fichier « sidecar », une
-        base — surcharge cette méthode et renvoie `self`.
+        les valeurs. ``source`` est donc ignorée.
         """
         return self

--- a/src/automatheque.schema/tests/image/test_image.py
+++ b/src/automatheque.schema/tests/image/test_image.py
@@ -31,10 +31,11 @@ def test_basename_sans_source():
     assert Photo().basename is None
 
 
-def test_tags_par_defaut_rattaches_a_la_source():
+def test_tags_par_defaut_est_un_basetags_vide():
+    """Les tags par défaut sont des `BaseTags` vides ; ils ne **portent pas** la
+    source — elle leur est passée au chargement (cf. `charge_tags`)."""
     photo = Photo(source="/photos/vacances.jpg")
     assert isinstance(photo.tags, BaseTags)
-    assert photo.tags.source == "/photos/vacances.jpg"
 
 
 def test_tags_par_defaut_propres_a_chaque_photo():
@@ -45,7 +46,7 @@ def test_tags_par_defaut_propres_a_chaque_photo():
 
 
 def test_tags_fournis_a_la_construction():
-    tags = BaseTags(source="/photos/vacances.jpg", album="Vacances")
+    tags = BaseTags(album="Vacances")
     assert Photo("/photos/vacances.jpg", tags).tags.album == "Vacances"
 
 
@@ -57,7 +58,6 @@ def test_tags_vides_par_defaut():
 
 def test_tags_acceptent_le_vocabulaire_complet():
     tags = BaseTags(
-        source="/photos/vacances.jpg",
         album="Japon",
         auteur="Photographe",
         titre="Osaka de nuit",
@@ -77,23 +77,30 @@ def test_tags_acceptent_le_vocabulaire_complet():
 
 
 def test_charge_sans_adaptateur_ne_fait_rien():
-    tags = BaseTags(source="/photos/vacances.jpg")
-    assert tags.charge() is tags
+    tags = BaseTags()
+    assert tags.charge("/photos/vacances.jpg") is tags
     assert tags.album is None
 
 
 def test_un_adaptateur_surcharge_charge():
-    """Le scénario visé : l'adaptateur d'I/O est une sous-classe, pas la base."""
+    """Le scénario visé : l'adaptateur d'I/O est une sous-classe, pas la base ;
+    il **reçoit** la source au chargement (les tags ne la mémorisent jamais)."""
 
     @attr.s
-    class TagsFigees(BaseTags):
-        def charge(self):
+    class TagsSidecar(BaseTags):
+        source_vue = attr.ib(default=None, kw_only=True)
+
+        def charge(self, source=None):
+            self.source_vue = source
             self.album = "Depuis l'adaptateur"
             return self
 
     photo = Photo(source="/photos/vacances.jpg")
-    photo.tags = TagsFigees(source=photo.source)
-    assert photo.charge_tags().album == "Depuis l'adaptateur"
+    photo.tags = TagsSidecar()
+    photo.charge_tags()
+    assert photo.tags.album == "Depuis l'adaptateur"
+    # l'adaptateur a bien vu la source de la photo (pas une copie figée)
+    assert photo.tags.source_vue == "/photos/vacances.jpg"
 
 
 def test_repr_montre_les_etiquettes():


### PR DESCRIPTION
Corrige **#117**. Option **A** retenue (« un seul nom, `source` ») — validé avec toi.

## Le problème : trois vérités pour un chemin

La composition documentée `PhotoRangeable(Photo, Renommable, Decomposable)`
échouait (`shutil.copy('', …)`), puis — avec contournement — **divergeait** :
- `schema.Media` → **`source`** (et `basename`/`extension`/`mimetype` en dérivent) ;
- `renommage.Renommable` → **`filename`** (`attr.ib(default="")`, indépendant) ;
- `image.BaseTags` → **copie figée** de `source` prise à la construction.

Après un rangement, seul `filename` était mis à jour ⇒ `source`, `basename`,
`tags.source` restaient en arrière, **sans jamais lever**.

## La correction (Option A — un seul nom, `source`)

**`renommage` (`Renommable`)**
* attend désormais un attribut **`source`** (convention, sans dépendance vers
  `schema`, comme le contrat de `decomposition`) au lieu de son propre
  `filename` ; le renommage **lit et écrit** dans `source` → tout ce qui en
  dérive suit ;
* un `Renommable` **sans `source`** est refusé **explicitement** (`ValueError`)
  au lieu d'un `shutil.copy(None, …)` obscur.

**`schema` (`BaseTags` / `Photo`)**
* `BaseTags` **ne stocke plus** `source` (la troisième copie) : elle la **reçoit**
  au chargement — `charge(source)` — et `Photo.charge_tags()` lui passe la source
  **courante**. Un adaptateur « sidecar » (photomas) écrit ainsi au bon endroit
  après un renommage.

## Tests

* migration `filename` → `source` des tests `renommage`, adaptation des tests
  `schema.image` ;
* **nouveau test inter-paquets** `test_composition.py` : range la composition
  documentée et vérifie que **tous** les accès (`source`, `basename`, ce que
  `Decomposable` analyse, la source vue par un adaptateur de tags) pointent la
  cible — c'est le garde-fou contre le retour de la divergence.

Suite complète **293 passés** (1 skip = extra `vobject`), `ruff`/`format`/`mypy`
(cœur) verts.

## Note de périmètre

`Decomposable` référence encore `filename` pour son option de **remontée
d'arborescence** (`DECOMPOSE_ANALYSE_ARBO_*`) — un chemin distinct, non emprunté
par la composition de base (qui analyse le `basename`). C'est un candidat pour
**#116** (revue du socle média), pas pour ici.

## Versioning

`automatheque.renommage` et `automatheque.schema` — distributions **non encore
publiées** : rupture sans coût. Bump/release à décider ensuite.
