### PR TITLE
release: 0.21.0 (cœur, factrice, schema, decomposition — renommage en 0.21.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.20.0"
+version = "0.21.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.decomposition/CHANGELOG
+++ b/src/automatheque.decomposition/CHANGELOG
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.21.0] - 2026-08-07
 
 ### Added
 
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **Licence embarquée dans les distributions.** Le sdist ne contenait pas le
+  texte de la licence — non-conformité **LGPL-3.0-or-later**. `LICENSE` (LGPL) et
+  `GPL-3.0.txt` (dont la LGPL n'est que le jeu de permissions additionnelles) sont
+  désormais inclus dans le sdist et le wheel (`license-files`). Cf. #116.
 * **`MAX_INFOS` inutilisable sur une classe `attrs` à *slots*** (`attrs.define`,
   le style moderne) : le score lisait `obj.__dict__`, absent des slots ;
   l'`AttributeError` était avalée et ressortait en `DecompositionEchecTousPatrons`

--- a/src/automatheque.decomposition/pyproject.toml
+++ b/src/automatheque.decomposition/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.decomposition"
-version = "0.19.0"
+version = "0.21.0"
 description = "Décomposition de chaînes et d'arborescences par patrons"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-08-07
+
+### Fixed
+
+* **Licence embarquée dans les distributions.** Le sdist ne contenait pas le
+  texte de la licence — non-conformité **LGPL-3.0-or-later**. `LICENSE` (LGPL) et
+  `GPL-3.0.txt` (dont la LGPL n'est que le jeu de permissions additionnelles) sont
+  désormais inclus dans le sdist et le wheel (`license-files`). Cf. #116.
+
 ## [0.20.0] - 2026-07-30
 
 ### Added

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.factrice"
-version = "0.20.0"
+version = "0.21.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque.renommage/CHANGELOG
+++ b/src/automatheque.renommage/CHANGELOG
@@ -64,6 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **Licence embarquée dans les distributions.** Le sdist ne contenait pas le
+  texte de la licence — non-conformité **LGPL-3.0-or-later**. `LICENSE` (LGPL) et
+  `GPL-3.0.txt` (dont la LGPL n'est que le jeu de permissions additionnelles) sont
+  désormais inclus dans le sdist et le wheel (`license-files`). Cf. #116.
 * **Parsing des gabarits en configuration trop permissif.** `except (ValueError,
   SyntaxError)` ne couvrait pas le dépaquetage : `r1 = 5` donnait un `TypeError`
   obscur, et surtout `r1 = 'abc'` était **accepté** (dépaqueté en

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Ce journal a été introduit a posteriori (cf. #34). Les entrées sont
 > reconstituées depuis l'historique git et peuvent donc être moins détaillées.
 
-## [Unreleased]
+## [0.21.0] - 2026-08-07
 
 ### Added
 
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **Licence embarquée dans les distributions.** Le sdist ne contenait pas le
+  texte de la licence — non-conformité **LGPL-3.0-or-later**. `LICENSE` (LGPL) et
+  `GPL-3.0.txt` (dont la LGPL n'est que le jeu de permissions additionnelles) sont
+  désormais inclus dans le sdist et le wheel (`license-files`). Cf. #116.
 * **`Media` explosait sur `source=None`** (le défaut) : `extension`, `mimetype`
   et `valide()` levaient `TypeError` là où `Photo.basename` gère le cas. Ils
   renvoient désormais `""` / `None` / `False`. Cf. #116.

--- a/src/automatheque.schema/pyproject.toml
+++ b/src/automatheque.schema/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.schema"
-version = "0.15.0"
+version = "0.21.0"
 description = "Domaine pour des classes courantes et partagées"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-08-07
+
+### Fixed
+
+* **Licence embarquée dans les distributions.** Le sdist ne contenait pas le
+  texte de la licence — non-conformité **LGPL-3.0-or-later**. `LICENSE` (LGPL) et
+  `GPL-3.0.txt` (dont la LGPL n'est que le jeu de permissions additionnelles) sont
+  désormais inclus dans le sdist et le wheel (`license-files`). Cf. #116.
+
 ## [0.20.0] - 2026-07-30
 
 ### Added

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.20.0"
+version = "0.21.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
Bump lockstep vers **0.21.0**. Le tag `0.21.0` publiera les paquets dont
`version == tag` (cf. `release.yml`), donc **4 des 5** :

| Paquet | 0.20 → | Publié en 0.21.0 ? | Pourquoi |
|---|---|---|---|
| `automatheque` | 0.20.0 → **0.21.0** | ✅ | re-publication : licence dans les distributions |
| `automatheque.factrice` | 0.20.0 → **0.21.0** | ✅ | idem |
| `automatheque.schema` | 0.15.0 → **0.21.0** | ✅ | idem + correctifs socle média (#116) |
| `automatheque.decomposition` | 0.19.0 → **0.21.0** | ✅ | **première publication** |
| `automatheque.renommage` | 0.19.0 (inchangé) | ❌ (skippé) | **0.21.1 ensuite** |

## Pourquoi `renommage` à part

Un seul *trusted pending publisher* PyPI a pu être créé pour l'instant. On
publie donc `decomposition` (première mise en ligne) dans cette release, et
`renommage` suivra en **0.21.1** une fois son publisher en place. Comme sa
version reste 0.19.0 ≠ tag, le job de release l'ignore proprement. Son
CHANGELOG garde `[Unreleased]` (le bullet licence y est déjà, prêt à être
estampillé).

## Conformité licence

Re-publication des 3 paquets déjà en ligne pour embarquer la licence dans
les distributions (elle en était absente — non-conformité **LGPL-3.0-or-later**,
cf. #116). Vérifié sur un **sdist ET un wheel** construits (`uv build`) :
`Version: 0.21.0`, `License: LGPL-3.0-or-later`, `LICENSE` + `GPL-3.0.txt`
présents (`.dist-info/licenses/`).

## Après le merge

Tag `0.21.0` → publie les 4 paquets. Puis, une fois le publisher de
`renommage` créé : bump `renommage` (+ monas) en 0.21.1, tag `0.21.1` → publie
`renommage` seul.