### PR TITLE
release: 0.21.1 (renommage)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.21.0"
+version = "0.21.1"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.renommage/CHANGELOG
+++ b/src/automatheque.renommage/CHANGELOG
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.21.1] - 2026-08-08
 
 ### Added
 

--- a/src/automatheque.renommage/pyproject.toml
+++ b/src/automatheque.renommage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.renommage"
-version = "0.19.0"
+version = "0.21.1"
 description = "Renommage et rangement de fichiers par gabarits"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}


### PR DESCRIPTION
Second temps de la 0.21. Publie **`automatheque.renommage`** (première mise en
ligne), son *trusted publisher* PyPI étant désormais en place.

| Paquet | Version | Publié par le tag `0.21.1` ? |
|---|---|---|
| `automatheque.renommage` | 0.19.0 → **0.21.1** | ✅ **première publication** |
| `automatheque` | 0.21.0 (inchangé) | ❌ (déjà publié en 0.21.0) |
| `automatheque.factrice` | 0.21.0 (inchangé) | ❌ |
| `automatheque.schema` | 0.21.0 (inchangé) | ❌ |
| `automatheque.decomposition` | 0.21.0 (inchangé) | ❌ |

Le tag `0.21.1` ne publie que les paquets dont `version == tag` (cf.
`release.yml`) : seul `renommage` correspond, les 4 autres (à 0.21.0) sont
ignorés proprement.

`monas` passe à **0.21.1** (= max des versions, invariant lockstep respecté).
CHANGELOG `renommage` estampillé `[0.21.1] - 2026-08-08`.

## Conformité licence

Vérifié sur un **sdist ET un wheel** construits (`uv build`) : `Version: 0.21.1`,
`License: LGPL-3.0-or-later`, `LICENSE` + `GPL-3.0.txt` présents
(`.dist-info/licenses/`).

## Après le merge

Tag `0.21.1` → publie `renommage`. La 0.21 est alors complète (5/5 paquets
publiés, licence conforme partout).