### PR TITLE
fix(decomposition): contrat `source` + robustesse (extraction vs callback, source vide)

### DIFF
--- a/src/automatheque.decomposition/CHANGELOG
+++ b/src/automatheque.decomposition/CHANGELOG
@@ -7,6 +7,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* **Le contrat `Decomposable` attend `source`, plus `filename`.** Le chemin
+  complet lu par les analyses d'arborescence (`DECOMPOSE_ANALYSE_ARBO_*`) est
+  désormais l'attribut `source` — le même nom que chez
+  `automatheque.schema.media.Media` et `automatheque.renommage.Renommable`. Un
+  seul porteur de vérité du chemin pour tout le socle média : un objet composé
+  (`class Rangeable(Photo, Renommable, Decomposable)`) exposait `source` (via
+  `Media`) mais pas `filename`, si bien que `remonte_arborescence(self.obj.filename, …)`
+  levait un `AttributeError` dès qu'on demandait une analyse d'arborescence.
+  Cf. #117. *(Rupture — mais convention d'attribut ; l'analyse par défaut
+  `ARBO_UN_NIVEAU`, qui lit `basename`, n'est pas concernée.)*
+
 ## [0.21.0] - 2026-08-07
 
 ### Added

--- a/src/automatheque.decomposition/CHANGELOG
+++ b/src/automatheque.decomposition/CHANGELOG
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* **`_exec_decomposition` masquait les bugs de l'appelant en « aucun patron
+  trouvé ».** Un `except Exception` englobant attrapait aussi ce que levait
+  l'`appel_en_retour` du consommateur (le callback qui reverse le résultat dans
+  l'objet — dépaquetage impossible, `AttributeError`…) et le traduisait en
+  `DecompositionEchecTousPatrons`, envoyant déboguer au mauvais endroit. Le
+  `try` ne couvre désormais que l'**extraction** (source + regex, propre à un
+  décomposeur : un échec y est journalisé et on passe au suivant) ;
+  `appel_en_retour`, qui est le **contrat de l'appelant**, est joué **hors** du
+  `try` et ses erreurs remontent.
+* `Decomposable._prepare_decomposition` : `if valeur` retombait sur le
+  `basename` pour une source `""` fournie **explicitement**, alors que la
+  docstring ne vise que l'absence. Seul `None` retombe désormais sur le basename
+  (même piège *falsy* que `pos=0` et la capture vide corrigés en #116).
+
 ### Changed
 
 * **Le contrat `Decomposable` attend `source`, plus `filename`.** Le chemin

--- a/src/automatheque.decomposition/README.md
+++ b/src/automatheque.decomposition/README.md
@@ -29,7 +29,7 @@ tirer les dépendances du renommage.
 * **`Decomposeurs`** — un jeu de patrons, itérable. À sous-classer pour
   décrire une famille de médias (séries, films, photos…).
 * **`Decomposable`** — mixin à faire hériter par l'objet à décomposer. Il doit
-  exposer `basename` (la chaîne analysée par défaut) et `filename` (le chemin
+  exposer `basename` (la chaîne analysée par défaut) et `source` (le chemin
   complet, remonté niveau par niveau).
 * **`Identificateur`** — l'algorithme : il joue les patrons sur l'objet selon
   les options demandées, et choisit la décomposition la plus pertinente.
@@ -78,14 +78,14 @@ class SerieDecomposeurs(Decomposeurs):
 
 @attr.s
 class Episode(Decomposable):
-    filename = attr.ib(default="")
+    source = attr.ib(default="")
     basename = attr.ib(default="")
     serie = attr.ib(default=None)
     saison = attr.ib(default=None)
     episode = attr.ib(default=None)
 
 
-ep = Episode(filename="/media/Ma.Serie.S01E02.avi", basename="Ma.Serie.S01E02.avi")
+ep = Episode(source="/media/Ma.Serie.S01E02.avi", basename="Ma.Serie.S01E02.avi")
 ep.decompose(decomposeurs=SerieDecomposeurs())
 # ep.serie == "Ma.Serie", ep.saison == "01", ep.episode == "02"
 ```

--- a/src/automatheque.decomposition/automatheque/decomposition/decomposeur.py
+++ b/src/automatheque.decomposition/automatheque/decomposition/decomposeur.py
@@ -155,9 +155,16 @@ class Decomposable(object):
     décomposition :
 
     * ``basename`` — la chaîne analysée par défaut ;
-    * ``filename`` — le chemin complet, remonté niveau par niveau par les
+    * ``source`` — le chemin complet, remonté niveau par niveau par les
       options :data:`DECOMPOSE_ANALYSE_ARBO_COMPLETE` et
       :data:`DECOMPOSE_ANALYSE_ARBO_CONCATENE`.
+
+    C'est une **convention** — un nom d'attribut attendu — sans dépendance vers
+    `schema`. Le chemin est nommé ``source``, comme chez
+    `automatheque.schema.media.Media` et `automatheque.renommage.Renommable` :
+    un seul porteur de vérité du chemin pour tout le socle média, dont dérive
+    aussi ``basename``. (Auparavant ``filename``, qui divergeait de
+    ``Media.source`` ; cf. #117.)
 
     TODO : on pourrait donner le nom de la propriété à l'initialisation de
     Decomposable, si on veut en prendre une autre.
@@ -405,7 +412,7 @@ class Identificateur(object):
         if sortir is not _CONTINUER:
             return sortir
 
-        # TODO par défaut on prend self.obj.filename et basename comme valeurs
+        # TODO par défaut on prend self.obj.source et basename comme valeurs
         # on pourrait en prendre d'autres et/ou le rendre paramétrable
         #
         # `remonte_arborescence` lève `ValueError` si le fichier n'est pas sous
@@ -414,7 +421,7 @@ class Identificateur(object):
         # option » plutôt que de laisser l'exception interrompre la boucle. #116
         if DECOMPOSE_ANALYSE_ARBO_COMPLETE in options_analyse:
             try:
-                for parent in remonte_arborescence(self.obj.filename, racine):
+                for parent in remonte_arborescence(self.obj.source, racine):
                     succes_, sortir = self._exec_decomposition(
                         options_resultat=options_resultat, valeur=parent.name
                     )
@@ -426,7 +433,7 @@ class Identificateur(object):
         if DECOMPOSE_ANALYSE_ARBO_CONCATENE in options_analyse:
             valeur_orig = self.obj.basename
             try:
-                for parent in remonte_arborescence(self.obj.filename, racine):
+                for parent in remonte_arborescence(self.obj.source, racine):
                     valeur_orig = "{} {}".format(parent.name, valeur_orig)
                     succes_, sortir = self._exec_decomposition(
                         options_resultat=options_resultat, valeur=valeur_orig

--- a/src/automatheque.decomposition/automatheque/decomposition/decomposeur.py
+++ b/src/automatheque.decomposition/automatheque/decomposition/decomposeur.py
@@ -189,7 +189,11 @@ class Decomposable(object):
         :param valeur:  valeur à préparer si présente, sinon basename par
                         défaut
         """
-        if valeur:
+        # `is not None` et non `if valeur` : seule l'**absence** (`None`) retombe
+        # sur le basename. Une valeur `""` fournie explicitement est une valeur,
+        # pas une absence (même distinction *falsy* que `pos=0` et la capture
+        # vide corrigés en #116).
+        if valeur is not None:
             return valeur
         return self.basename
 
@@ -300,52 +304,61 @@ class Identificateur(object):
                     decomposeur.chaine, valeur or self.obj.basename
                 )
             )
+            # Le `try` ne couvre que l'**extraction** — propre à ce décomposeur
+            # (sa source, sa regex). Un patron qui ne capture rien, ou dont la
+            # source échoue, ne doit pas interrompre les autres : on journalise
+            # et on passe au suivant. En revanche `appel_en_retour` (reverser le
+            # résultat dans l'objet) est le **contrat de l'appelant** : une
+            # erreur dedans est un vrai bug, laissé remonter — pas maquillé en
+            # « aucun patron trouvé » comme le faisait le `except Exception`
+            # englobant d'origine.
             try:
                 resultats = decomposeur._decomposer(self.obj, valeur)
                 try:
                     resultats = resultats[0]
                 except IndexError:
                     raise DecompositionEchecPatron(decomposeur)
-                if options_resultat == DECOMPOSE_RESULTAT_PREMIER_NON_NUL:
-                    # Puis on appelle le callback pour remplir l'objet :
-                    decomposeur.appel_en_retour(self.obj, resultats)
-                    decomposition_reussie = True
-                    sortir = resultats
-                    # on s'arrête ici
-                    break
-                elif options_resultat == DECOMPOSE_RESULTAT_CUMULE:
-                    # Puis on appelle le callback pour remplir l'objet :
-                    decomposeur.appel_en_retour(self.obj, resultats)
-                    decomposition_reussie = True
-                    # mais on continue le traitement :
-                    continue
-                elif options_resultat == DECOMPOSE_RESULTAT_MAX_INFOS:
-                    obj_temoin = deepcopy(self.obj_temoin)
-                    decomposeur.appel_en_retour(obj_temoin, resultats)
-
-                    # On compare la taille des deux objets sérialisés, grosso
-                    # modo. On n'attribue un modificateur qu'à l'objet témoin
-                    # pour prendre en compte la « qualité » du décomposeur en
-                    # cours.
-                    temoin = self._score_max_infos(obj_temoin, decomposeur.poids)
-                    if temoin >= self._score_max_infos(self.obj):
-                        # Puis on appelle le callback pour remplir l'objet :
-                        decomposeur.appel_en_retour(self.obj, resultats)
-                        decomposition_reussie = True
-                    # mais on continue le traitement :
-                    continue
             except DecompositionEchecPatron:
                 LOGGER.debug(
                     "Echec de la décomposition: {} {}".format(
                         valeur, decomposeur.chaine
                     )
                 )
+                continue
             except Exception:
                 LOGGER.exception(
-                    "Echec durant la décomposition: {} {}".format(
+                    "Echec durant l'extraction: {} {}".format(
                         valeur, decomposeur.chaine
                     )
                 )
+                continue
+
+            if options_resultat == DECOMPOSE_RESULTAT_PREMIER_NON_NUL:
+                # Puis on appelle le callback pour remplir l'objet :
+                decomposeur.appel_en_retour(self.obj, resultats)
+                decomposition_reussie = True
+                sortir = resultats
+                # on s'arrête ici
+                break
+            elif options_resultat == DECOMPOSE_RESULTAT_CUMULE:
+                # Puis on appelle le callback pour remplir l'objet :
+                decomposeur.appel_en_retour(self.obj, resultats)
+                decomposition_reussie = True
+                # mais on continue le traitement :
+                continue
+            elif options_resultat == DECOMPOSE_RESULTAT_MAX_INFOS:
+                obj_temoin = deepcopy(self.obj_temoin)
+                decomposeur.appel_en_retour(obj_temoin, resultats)
+
+                # On compare la taille des deux objets sérialisés, grosso modo.
+                # On n'attribue un modificateur qu'à l'objet témoin pour prendre
+                # en compte la « qualité » du décomposeur en cours.
+                temoin = self._score_max_infos(obj_temoin, decomposeur.poids)
+                if temoin >= self._score_max_infos(self.obj):
+                    # Puis on appelle le callback pour remplir l'objet :
+                    decomposeur.appel_en_retour(self.obj, resultats)
+                    decomposition_reussie = True
+                # mais on continue le traitement :
                 continue
 
         LOGGER.debug("exec decomposition obj resultant : {}".format(self.obj))

--- a/src/automatheque.decomposition/tests/test_decomposeur.py
+++ b/src/automatheque.decomposition/tests/test_decomposeur.py
@@ -48,7 +48,7 @@ class SerieDecomposeurs(Decomposeurs):
 class Episode(Decomposable):
     """Objet décomposable minimal."""
 
-    filename = attr.ib(default="")
+    source = attr.ib(default="")
     basename = attr.ib(default="")
     serie = attr.ib(default=None)
     saison = attr.ib(default=None)
@@ -72,14 +72,14 @@ class EpisodeSlots(Decomposable):
     sérialise l'objet)."""
 
     basename = attr.ib(default="")
-    filename = attr.ib(default="")
+    source = attr.ib(default="")
     serie = attr.ib(default=None)
     saison = attr.ib(default=None)
     episode = attr.ib(default=None)
 
 
 def test_decompose_le_basename():
-    ep = Episode(filename="/media/Ma.Serie.S01E02.avi", basename="Ma.Serie.S01E02.avi")
+    ep = Episode(source="/media/Ma.Serie.S01E02.avi", basename="Ma.Serie.S01E02.avi")
     ep.decompose(decomposeurs=SerieDecomposeurs())
     assert (ep.serie, ep.saison, ep.episode) == ("Ma.Serie", "01", "02")
 
@@ -139,9 +139,7 @@ def test_appel_source_explicite_est_utilise():
 
 def test_analyse_arborescence_complete_remonte_les_niveaux():
     """Le patron ne matche aucun niveau seul, mais matche un répertoire."""
-    ep = Episode(
-        filename="/media/series/Ma.Serie.S01E02/video.avi", basename="video.avi"
-    )
+    ep = Episode(source="/media/series/Ma.Serie.S01E02/video.avi", basename="video.avi")
     ep.decompose(
         racine="/media",
         decomposeurs=SerieDecomposeurs(),
@@ -152,7 +150,7 @@ def test_analyse_arborescence_complete_remonte_les_niveaux():
 
 def test_analyse_arborescence_concatenee():
     """Aucun niveau ne porte l'information complète, leur concaténation si."""
-    ep = Episode(filename="/media/series/Ma.Serie/S01E02.avi", basename="S01E02.avi")
+    ep = Episode(source="/media/series/Ma.Serie/S01E02.avi", basename="S01E02.avi")
     ep.decompose(
         racine="/media",
         decomposeurs=SerieDecomposeurs(),
@@ -162,9 +160,7 @@ def test_analyse_arborescence_concatenee():
 
 
 def test_options_analyse_acceptent_une_collection():
-    ep = Episode(
-        filename="/media/series/Ma.Serie.S01E02/video.avi", basename="video.avi"
-    )
+    ep = Episode(source="/media/series/Ma.Serie.S01E02/video.avi", basename="video.avi")
     ep.decompose(
         racine="/media",
         decomposeurs=SerieDecomposeurs(),
@@ -220,15 +216,13 @@ def test_resultat_max_infos_garde_la_decomposition_la_plus_riche():
 
 
 def test_auto_decompose_trouve_une_combinaison_qui_marche():
-    ep = Episode(
-        filename="/media/series/Ma.Serie.S01E02/video.avi", basename="video.avi"
-    )
+    ep = Episode(source="/media/series/Ma.Serie.S01E02/video.avi", basename="video.avi")
     ep.auto_decompose(racine="/media", decomposeurs=SerieDecomposeurs())
     assert ep.serie == "Ma.Serie"
 
 
 def test_auto_decompose_echoue_si_rien_ne_marche():
-    ep = Episode(filename="/media/series/rien/video.avi", basename="video.avi")
+    ep = Episode(source="/media/series/rien/video.avi", basename="video.avi")
     with pytest.raises(DecompositionEchecTousPatrons):
         ep.auto_decompose(racine="/media", decomposeurs=SerieDecomposeurs())
 
@@ -267,7 +261,7 @@ def test_racine_hors_chemin_donne_un_echec_d_analyse_pas_un_valueerror():
     """#116-2 : une racine qui ne contient pas le fichier levait un `ValueError`
     qui traversait `auto_decompose` au lieu d'un échec d'analyse propre."""
     ep = Episode(
-        filename="/media/x/Ma.Serie.S01E02/v.avi",
+        source="/media/x/Ma.Serie.S01E02/v.avi",
         basename="v.avi",  # ne matche pas le patron série
     )
     with pytest.raises(DecompositionEchecTousPatrons):

--- a/src/automatheque.decomposition/tests/test_decomposeur.py
+++ b/src/automatheque.decomposition/tests/test_decomposeur.py
@@ -293,3 +293,45 @@ def test_decomposer_respecte_pos_zero_et_endpos_seul():
     obj = Episode(basename="")
     assert dec._decomposer(obj, pos=0, endpos=3) == ["a", "b", "c"]
     assert dec._decomposer(obj, endpos=2) == ["a", "b"]
+
+
+# --- Robustesse : ne pas masquer les vrais bugs ------------------------------
+
+
+def test_un_bug_du_callback_remonte_pas_maquille_en_aucun_patron():
+    """Le patron **matche**, mais l'`appel_en_retour` du consommateur a un bug
+    (ici un dépaquetage impossible). C'est une erreur de l'appelant : elle doit
+    remonter, pas être avalée en `DecompositionEchecTousPatrons` (« aucun patron
+    trouvé »), ce qui envoyait déboguer au mauvais endroit."""
+
+    def _callback_bogue(obj, resultats):
+        # `resultats` est une seule capture (chaîne) : ce dépaquetage lève.
+        a, b, c = resultats
+
+    decs = SerieDecomposeurs()
+    decs.decomposeurs = [Decomposeur(r"(.+)", _callback_bogue)]
+
+    ep = Episode(basename="peu importe")
+    with pytest.raises((ValueError, TypeError)):
+        ep.decompose(decomposeurs=decs)
+
+
+def test_un_patron_qui_ne_matche_pas_n_interrompt_pas_les_autres():
+    """Un décomposeur qui ne capture rien est sauté ; un suivant qui matche
+    l'emporte. (L'extraction reste tolérante, seul le callback ne l'est pas.)"""
+    decs = SerieDecomposeurs()
+    decs.decomposeurs = [
+        Decomposeur(r"^ZZZ(\d+)", _remplit_annee),  # ne matche pas
+        Decomposeur(r"(.+)[. ]S(\d{2})E(\d{2})", _remplit_serie, drapeaux=re.I),
+    ]
+    ep = Episode(basename="Ma.Serie.S01E02.avi")
+    ep.decompose(decomposeurs=decs)
+    assert (ep.serie, ep.saison, ep.episode) == ("Ma.Serie", "01", "02")
+
+
+def test_prepare_decomposition_respecte_une_valeur_vide_explicite():
+    """Une source `""` fournie explicitement est une valeur, pas une absence :
+    seule `None` retombe sur le basename (même piège *falsy* que #116)."""
+    ep = Episode(basename="defaut.avi")
+    assert ep._prepare_decomposition("") == ""
+    assert ep._prepare_decomposition(None) == "defaut.avi"


### PR DESCRIPTION
Deux thèmes, un commit chacun. Suite decomposition : **26 passés** (dont la
composition inter-paquets), `ruff check`/`format` verts.

## 1 — Le contrat `Decomposable` attend `source`, plus `filename` (« migrer vers source »)

Aligne decomposition sur le reste du socle média : le chemin complet lu par les
analyses d'arborescence (`DECOMPOSE_ANALYSE_ARBO_COMPLETE` / `_CONCATENE`) est
désormais l'attribut **`source`**, comme chez `automatheque.schema.media.Media`
et `automatheque.renommage.Renommable` (cf. #117).

Un objet composé, cas d'usage visé — `class PhotoRangeable(Photo, Renommable,
Decomposable)` — expose `source` (via `Media`/`Photo`) et `basename`, mais **pas**
`filename`. Or `Identificateur.identifie` lisait `self.obj.filename` :
`remonte_arborescence(self.obj.filename, racine)` levait donc un `AttributeError`
dès qu'on demandait une analyse d'arborescence. C'est l'incohérence `filename`
vs `source` que #117 a levée côté `Renommable`/`Media`, restée ouverte ici.
Contrat, tests et README migrés. L'analyse **par défaut** `ARBO_UN_NIVEAU`, qui
lit `basename`, n'est pas concernée.

## 2 — Robustesse : ne plus masquer les bugs de l'appelant

* **`_exec_decomposition` maquillait les bugs de callback en « aucun patron
  trouvé ».** Un `except Exception` englobant attrapait aussi ce que levait
  l'`appel_en_retour` du consommateur (le callback qui reverse le résultat dans
  l'objet — dépaquetage impossible, `AttributeError`…) et le traduisait en
  `DecompositionEchecTousPatrons`, envoyant déboguer au mauvais endroit. Le
  `try` ne couvre désormais que l'**extraction** (source + regex, propre à un
  décomposeur : un échec y est journalisé et on passe au suivant) ;
  `appel_en_retour`, **contrat de l'appelant**, est joué **hors** du `try` et ses
  erreurs remontent. Un décomposeur qui ne matche pas continue de ne pas
  interrompre les autres.
* **`_prepare_decomposition` : `if valeur` piégeait une source `""` explicite.**
  Elle retombait sur le `basename` alors que la docstring ne vise que l'absence.
  Seul `None` y retombe désormais (même piège *falsy* que `pos=0` et la capture
  vide corrigés en #116).

## Rupture

Le point 1 change un **nom d'attribut attendu** (`filename` → `source`), mais la
distribution vient d'être publiée (0.21.1) et c'est une convention, sans
dépendance ajoutée.