### PR TITLE
fix(renommage): robustesse copie, condition, chemin, configuration

### DIFF
--- a/src/automatheque.renommage/CHANGELOG
+++ b/src/automatheque.renommage/CHANGELOG
@@ -7,6 +7,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* **Une cible tronquée survivait à un échec de copie (hors `ENOTSUP`).** La
+  branche « la taille ne colle pas » effaçait bien le reliquat avant de lever,
+  mais pas celle où `shutil.copy` **lève** (disque plein, E/S…) : un fichier
+  partiel restait sur le disque, et l'essai suivant tombait sur la garde
+  « fichier existe », renvoyant le chemin **sans erreur** — l'appelant croyait
+  le fichier rangé alors qu'il était tronqué. La cible partielle est maintenant
+  effacée dans les deux cas ; l'original n'est jamais touché. (Même défaut que
+  celui déjà clos côté « taille » en 0.21.1, resté ouvert sur ce chemin.)
+* **`teste_condition` masquait les vrais bugs du consommateur.** Un
+  `except Exception` avalait aussi ce que levait le `_liste_champs_dispo()` de
+  l'appelant (typo, `NotImplementedError`), en le déguisant en « condition
+  fausse » — le développeur ne voyait jamais l'erreur. La projection des champs
+  est désormais appelée **hors** du `try`, et le `try` ne rattrape que les
+  erreurs de formatage/évaluation de la condition
+  (`KeyError`/`IndexError`/`AttributeError`/`ValueError`/`TypeError`/`ConditionInvalide`).
+* **Un champ de tête vide sortait le fichier du répertoire cible.** Un squelette
+  `{annee}/{album}/{nom}` avec `annee=""` se formatait en `/Japon/…`, un chemin
+  **absolu** : `os.path.join(rep_cible, …)` jetait alors `rep_cible`, et le
+  rangement échouait sur un `CibleHorsRepertoire` pour un simple champ manquant.
+  Les segments vides sont désormais rabotés (le champ manquant devient un
+  segment sauté). Un squelette **écrit** absolu (`/etc/{nom}`), lui, reste
+  refusé — c'est une erreur d'auteur, distinguée à la source et non sur le rendu.
+* `Gabarits.depuis_configuration` : un `ordre` non entier
+  (`['{nom}', '', '9']`) passait la validation d'arité pour n'exploser qu'au
+  `sorted(key=ordre)` de `gabarits_valides`, en `TypeError` sans rapport avec la
+  configuration. Les types du triplet (squelette/condition en chaîne, ordre
+  entier) sont désormais vérifiés à la lecture, avec le même `ValueError`
+  contextualisé. Suite de #116.
+* `_efface` : ne journalise plus un avertissement quand la cible **n'existait
+  pas** (`FileNotFoundError`) — conforme à sa docstring (« sans se plaindre s'il
+  n'est pas là »).
+
 ## [0.21.1] - 2026-08-08
 
 ### Added

--- a/src/automatheque.renommage/automatheque/renommage/renommeur.py
+++ b/src/automatheque.renommage/automatheque/renommage/renommeur.py
@@ -15,6 +15,7 @@ import ast
 import errno
 import logging
 import os
+import re
 import shutil
 from operator import attrgetter
 from pathlib import Path
@@ -28,6 +29,7 @@ from .condition import evalue_condition
 from .exceptions import (
     AucunGabaritApplicable,
     CibleHorsRepertoire,
+    ConditionInvalide,
     GabaritInapplicable,
     TransfertIncomplet,
 )
@@ -86,8 +88,35 @@ def _efface(chemin):
     """Supprime un fichier sans se plaindre s'il n'est pas là."""
     try:
         os.remove(chemin)
+    except FileNotFoundError:
+        pass  # rien à effacer : la copie n'a rien écrit
     except OSError:  # pragma: no cover - dépend du système de fichiers
         LOGGER.warning("Impossible de supprimer la cible incomplète %s", chemin)
+
+
+def _nom_relatif(nom_fichier: str, squelette_absolu: bool) -> str:
+    """Réduit le nom formaté à un chemin propre, sans segment vide.
+
+    Un champ de **tête** vide — `{annee}/{album}/{nom}` avec `annee=""` — laisse
+    un séparateur en tête (`"/Japon/x.jpg"`) qui rend le chemin **absolu** :
+    `os.path.join(rep_cible, …)` jette alors `rep_cible`, et le fichier
+    quitterait le répertoire cible (rattrapé plus loin par `CibleHorsRepertoire`,
+    mais pour rien — un champ manquant est bénin). On retire donc les segments
+    vides (tête, queue, séparateurs doublés) : le champ manquant devient un
+    segment sauté.
+
+    En revanche, un squelette **écrit** absolu (`"/etc/{nom}"`) est une erreur
+    d'auteur : on le laisse absolu pour que `_cible_contenue` le refuse. D'où le
+    drapeau `squelette_absolu`, décidé sur le squelette et non sur son rendu —
+    les deux sont indiscernables une fois formatés.
+    """
+    segments = [s for s in re.split(r"[/\\]+", nom_fichier) if s]
+    if not segments:
+        return nom_fichier
+    chemin = os.path.join(*segments)
+    if squelette_absolu:
+        chemin = os.sep + chemin
+    return chemin
 
 
 @attr.s
@@ -177,6 +206,19 @@ class Gabarits:
             if len(triplet) != 3:
                 raise ValueError(erreur)
             squelette, condition, ordre = triplet
+            # Arité bonne, mais les types comptent aussi : un `ordre` non entier
+            # (`['{nom}', '', '9']`) passe ici pour n'exploser qu'au
+            # `sorted(key=ordre)` de `gabarits_valides`, en `TypeError` sans
+            # rapport avec la configuration. On le refuse donc à la source.
+            if not (
+                isinstance(squelette, str)
+                and isinstance(condition, str)
+                and isinstance(ordre, int)
+                and not isinstance(ordre, bool)
+            ):
+                raise ValueError(
+                    erreur + " (squelette et condition en chaîne, ordre entier)"
+                )
             gabarits.append(
                 Gabarit(squelette=squelette, condition=condition, ordre=ordre)
             )
@@ -218,12 +260,25 @@ class Gabarits:
 
         Une condition qui ne s'évalue pas — champ absent, expression mal
         formée — est **fausse**, pas fatale : le gabarit suivant est essayé.
+
+        Le catch est **restreint** aux erreurs de *formatage* et d'*évaluation*
+        de la condition. Un bug réel du `_liste_champs_dispo()` du consommateur
+        (typo, `NotImplementedError`) doit remonter, pas se déguiser en
+        « condition fausse » ; on l'appelle donc **hors** du `try`.
         """
+        champs = obj._liste_champs_dispo()
         try:
-            formatee = condition.format(**obj._liste_champs_dispo())
+            formatee = condition.format(**champs)
             return bool(evalue_condition(formatee))
-        except Exception:
-            LOGGER.exception("Erreur durant le test de la condition.")
+        except (
+            KeyError,
+            IndexError,
+            AttributeError,
+            ValueError,
+            TypeError,
+            ConditionInvalide,
+        ):
+            LOGGER.debug("Condition écartée (non évaluable) : %s", condition)
             return False
 
 
@@ -304,9 +359,16 @@ class Renommeur:
         gabarit = self.gabarits.choisit_gabarit(self.obj)
         LOGGER.debug("Gabarit choisi : %s", gabarit)
         try:
-            return gabarit.squelette.format(**champs)
+            nom = gabarit.squelette.format(**champs)
         except (KeyError, IndexError, ValueError, AttributeError, TypeError) as exc:
             raise GabaritInapplicable(gabarit.squelette, str(exc)) from exc
+        # `squelette_absolu` est décidé sur le squelette, pas sur son rendu : un
+        # champ de tête vide (`{annee}/…` avec `annee=""`) rend `nom` absolu par
+        # accident et le ferait quitter rep_cible — on rabote alors les segments
+        # vides ; un squelette **écrit** absolu (`/etc/{nom}`) reste absolu pour
+        # que `_cible_contenue` le refuse.
+        squelette_absolu = gabarit.squelette.startswith(("/", os.sep))
+        return _nom_relatif(nom, squelette_absolu)
 
     def _renomme(self, rep_cible, nom_fichier, debug=False, force=False, copier=False):
         """Déplace le fichier vers `rep_cible/nom_fichier`.
@@ -347,6 +409,12 @@ class Renommeur:
             shutil.copy(fichier_orig, fichier_cible)
         except OSError as exc:
             if exc.errno != errno.ENOTSUP:
+                # La copie a pu écrire une cible **partielle** avant d'échouer
+                # (disque plein, E/S…). On l'efface avant de propager — comme la
+                # branche « taille » ci-dessous : sinon le prochain essai tombe
+                # sur la garde « fichier existe » et renvoie ce reliquat tronqué
+                # comme un succès. L'original, lui, n'a jamais été touché.
+                _efface(fichier_cible)
                 LOGGER.error(
                     "[E] Echec shutil.copy(%s, %s) : %s",
                     fichier_orig,

--- a/src/automatheque.renommage/tests/test_renommeur.py
+++ b/src/automatheque.renommage/tests/test_renommeur.py
@@ -478,3 +478,70 @@ def test_copie_disparue_leve_transfert_incomplet(photo, tmp_path, monkeypatch):
     with pytest.raises(TransfertIncomplet):
         photo.renomme(str(tmp_path / "cible"))
     assert os.path.exists(photo.source)
+
+
+def _copie_partielle_puis_echoue(source, cible):
+    """Écrit une cible tronquée, puis échoue comme un disque plein (≠ ENOTSUP)."""
+    import errno as _errno
+
+    with open(cible, "wb") as f:
+        f.write(b"partiel")
+    raise OSError(_errno.ENOSPC, "disque plein")
+
+
+def test_echec_de_copie_efface_la_cible_partielle(photo, tmp_path, monkeypatch):
+    """Une copie qui échoue (hors ENOTSUP) après avoir écrit un reliquat ne doit
+    pas le laisser sur le disque : sinon la garde « fichier existe » du prochain
+    essai le prendrait pour un succès. L'original n'est jamais touché."""
+    monkeypatch.setattr("shutil.copy", _copie_partielle_puis_echoue)
+    with pytest.raises(OSError):
+        photo.renomme(str(tmp_path / "cible"))
+
+    corrompu = tmp_path / "cible" / "2013" / "Japon" / "DSC_0001.jpg"
+    assert not corrompu.exists()
+    assert os.path.exists(photo.source)
+
+
+def test_apres_echec_de_copie_le_second_essai_reussit(photo, tmp_path, monkeypatch):
+    """Régression : le reliquat tronqué faisait passer le 2e essai pour un succès."""
+    monkeypatch.setattr("shutil.copy", _copie_partielle_puis_echoue)
+    with pytest.raises(OSError):
+        photo.renomme(str(tmp_path / "cible"))
+
+    monkeypatch.undo()  # la copie remarche
+    cible = photo.renomme(str(tmp_path / "cible"))
+    assert open(cible, "rb").read() == b"des octets de photo"
+
+
+def test_teste_condition_ne_masque_pas_un_bug_du_consommateur():
+    """Une condition non évaluable est fausse ; un **bug** du `_liste_champs_dispo`
+    du consommateur (typo, `NotImplementedError`…) doit remonter, pas se déguiser
+    en « condition fausse »."""
+
+    class PhotoCassee(Photo):
+        def _liste_champs_dispo(self):
+            raise RuntimeError("bug dans la projection des champs")
+
+    gabarits = Gabarits([Gabarit(squelette="x", condition='"{album}"')])
+    with pytest.raises(RuntimeError):
+        gabarits.choisit_gabarit(PhotoCassee(album="Japon"))
+
+
+def test_champ_de_tete_vide_ne_rend_pas_le_chemin_absolu(photo, tmp_path):
+    """`{annee}/{album}/{nom}` avec `annee=""` donnait `/Japon/…`, absolu, qui
+    jetait rep_cible (`CibleHorsRepertoire`). Le champ manquant est un segment
+    sauté, pas une évasion — le fichier se range sous rep_cible."""
+    photo.annee = ""
+    gabarits = Gabarits([Gabarit(squelette="{annee}/{album}/{nom}")])
+    cible = photo.renomme(str(tmp_path / "range"), gabarits=gabarits)
+
+    assert cible.startswith(str(tmp_path / "range"))
+    assert cible.endswith(os.path.join("Japon", "DSC_0001.jpg"))
+    assert os.path.exists(cible)
+
+
+def test_gabarits_depuis_configuration_refuse_un_ordre_non_entier():
+    """`['{nom}', '', '9']` : arité bonne, mais un `ordre` chaîne explosait au
+    `sorted(key=ordre)`, loin de la config. Refusé à la source."""
+    with pytest.raises(ValueError):
+        Gabarits.depuis_configuration(_config("[renommage]\nr1 = ['{nom}', '', '9']\n"))


### PR DESCRIPTION
Quatre défauts confirmés par la revue du socle média, un test de non-régression
chacun. Suite renommage : **52 passés** (dont la composition inter-paquets),
`ruff check`/`format` verts.

## 1 — [HAUT] Cible tronquée laissée sur disque quand `shutil.copy` **lève**

La branche « la taille ne colle pas » effaçait bien le reliquat avant de lever
(`_efface`), mais **pas** celle où la copie échoue par exception (disque plein,
E/S… — errno ≠ `ENOTSUP`) : un fichier partiel restait sur le disque. L'essai
suivant tombait alors sur la garde « fichier existe » et renvoyait le chemin
**sans erreur** — l'appelant croyait le fichier rangé alors qu'il était tronqué.
C'est exactement la fausse-réussite déjà close côté « taille » en 0.21.1, restée
ouverte sur ce chemin. On efface désormais la cible partielle dans les deux cas ;
l'original n'est jamais touché.

## 2 — [MOYEN] `teste_condition` masquait les vrais bugs du consommateur

`except Exception` avalait aussi ce que levait le `_liste_champs_dispo()` de
l'appelant (typo, `NotImplementedError`), déguisé en « condition fausse » : le
développeur ne voyait jamais l'erreur. La projection des champs est désormais
appelée **hors** du `try`, et le `try` ne rattrape que les erreurs de formatage
/évaluation de la condition (`KeyError`/`IndexError`/`AttributeError`/`ValueError`
/`TypeError`/`ConditionInvalide`).

## 3 — [MOYEN] Un champ de tête vide sortait le fichier du répertoire cible

`{annee}/{album}/{nom}` avec `annee=""` se formatait en `/Japon/…`, un chemin
**absolu** : `os.path.join(rep_cible, …)` jetait `rep_cible`, et le rangement
échouait sur `CibleHorsRepertoire` pour un simple champ manquant. Les segments
vides sont rabotés (le champ manquant devient un segment sauté). Un squelette
**écrit** absolu (`/etc/{nom}`) reste refusé — c'est une erreur d'auteur,
distinguée **à la source** (le squelette) et non sur son rendu, une fois formaté
les deux étant indiscernables.

## 4 — [MOYEN] `depuis_configuration` ne validait pas le type de `ordre`

`['{nom}', '', '9']` passait la validation d'arité pour n'exploser qu'au
`sorted(key=ordre)` de `gabarits_valides`, en `TypeError` sans rapport avec la
configuration. Les types du triplet (squelette/condition en chaîne, ordre
entier) sont vérifiés à la lecture, avec le même `ValueError` contextualisé.
Suite de #116.

## Bonus

`_efface` ne journalise plus d'avertissement quand la cible **n'existait pas**
(`FileNotFoundError`) — conforme à sa docstring (« sans se plaindre s'il n'est
pas là »).