### PR TITLE
fix(schema): courriel — validation au constructeur, destinataire unique

### DIFF
--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -10,6 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Ce journal a été introduit a posteriori (cf. #34). Les entrées sont
 > reconstituées depuis l'historique git et peuvent donc être moins détaillées.
 
+## [Unreleased]
+
+### Fixed
+
+* **`courriel` : le constructeur court-circuitait la validation des adresses.**
+  Les champs privés `_emetteur`/`_destinataires` sont posés **en direct** par
+  attrs, sans passer par les setters qui valident et normalisent (`formataddr`) :
+  `Courriel(emetteur="pas-un-email")` **passait** là où `c.emetteur = "..."`
+  lève, et un tuple `("Bob", "bob@x")` restait brut au lieu d'être formaté en
+  `"Bob <bob@x>"` (un consommateur comme `factrice`, qui attend une chaîne
+  RFC 5322, recevait alors un tuple). Un `__attrs_post_init__` rejoue désormais
+  la même validation à la construction ; `emetteur=None` (le défaut, rempli plus
+  tard) reste permis.
+* **`courriel` : un destinataire passé en chaîne était éclaté caractère par
+  caractère.** `c.destinataires = "solo@x.com"` faisait `for d in "solo@x.com"` —
+  chaque lettre validée puis rejetée (`ValueError` sur `"s"`). Une chaîne unique
+  est désormais traitée comme **un** destinataire.
+* `courriel` : suppression d'un import commenté mort
+  (`# from automatheque.schema.medium import Medium`) — le module s'appelle
+  `media`, et `Medium` n'existe pas.
+
 ## [0.21.0] - 2026-08-07
 
 ### Added

--- a/src/automatheque.schema/automatheque/schema/texte/courriel.py
+++ b/src/automatheque.schema/automatheque/schema/texte/courriel.py
@@ -7,8 +7,6 @@ from typing import Callable, List, Sequence, Tuple, Union
 
 import attr
 
-# from automatheque.schema.medium import Medium
-
 
 def maintenant() -> datetime:
     """Horodatage courant, **tz-aware** (UTC).
@@ -46,6 +44,24 @@ class Courriel:
     teste_adresse_valide: Callable[[str], Tuple[bool, str]] = attr.ib(
         init=False, default=lambda e: ("@" in e, ""), kw_only=True
     )
+
+    def __attrs_post_init__(self):
+        """Fait passer les valeurs du constructeur par la même validation que
+        les setters.
+
+        attrs affecte `_emetteur`/`_destinataires` **en direct**, sans passer
+        par `@emetteur.setter`/`@destinataires.setter` (validation +
+        normalisation `formataddr`). Sans ce post-init,
+        `Courriel(emetteur="pas-un-email")` passerait là où
+        `c.emetteur = "pas-un-email"` lève, et un tuple `("Bob", "bob@x")`
+        resterait brut au lieu d'être formaté. Un émetteur non fourni (`None`)
+        reste permis : il est souvent rempli plus tard (p. ex. par `factrice`).
+        """
+        if self._emetteur is not None:
+            self._emetteur = self._controle_format_email(self._emetteur, "emetteur")
+        if self._destinataires:
+            # Rejoue le setter (valide, normalise, gère la chaîne unique).
+            self.destinataires = self._destinataires
 
     def _controle_format_email(self, valeur: Union[tuple, str], champ: str):
         """Renvoie l'email contrôlé pour le champ indiqué.
@@ -90,8 +106,14 @@ class Courriel:
     @destinataires.setter
     def destinataires(self, valeur):
         """Ajoute les destinataires à la liste."""
+        # Une chaîne unique est **un** destinataire, pas une suite de
+        # caractères : `for d in "solo@x.com"` itérerait `s`, `o`, `l`… et
+        # `_controle_format_email` lèverait sur le premier. Toute autre séquence
+        # (liste, tuple de destinataires) est parcourue telle quelle.
+        if isinstance(valeur, str):
+            valeur = [valeur]
         self._destinataires = []  # Ràz destinataires
-        for d in [d for d in valeur or []]:
+        for d in valeur or []:
             self.ajouter_destinataire(d)
 
     def ajouter_piece_jointe(self, fichier: Path):

--- a/src/automatheque.schema/tests/texte/test_courriel.py
+++ b/src/automatheque.schema/tests/texte/test_courriel.py
@@ -59,3 +59,36 @@ def test_date_envoi_datetime_naif_retrocompat():
     c._date_envoi = datetime(2020, 1, 2, 3, 4, 5)  # naïf
     rendu = c.date_envoi
     assert "02 Jan 2020" in rendu
+
+
+def test_constructeur_valide_l_emetteur_comme_le_setter():
+    """Le constructeur ne doit pas court-circuiter la validation des adresses."""
+    with pytest.raises(ValueError):
+        Courriel(sujet="s", emetteur="pas-un-email")
+
+
+def test_constructeur_formate_un_emetteur_tuple():
+    """Un tuple `(nom, adresse)` est normalisé en chaîne RFC 5322, comme via
+    le setter — pas laissé brut."""
+    c = Courriel(sujet="s", emetteur=("Bob", "bob@x.com"))
+    assert c.emetteur == "Bob <bob@x.com>"
+
+
+def test_constructeur_emetteur_none_reste_permis():
+    """`emetteur=None` (le défaut) n'est pas validé : il est rempli plus tard."""
+    assert Courriel(sujet="s").emetteur is None
+
+
+def test_constructeur_valide_les_destinataires():
+    """Les destinataires passés au constructeur sont validés/normalisés."""
+    c = Courriel(sujet="s", destinataires=["Bob <bob@x.com>", ("Ana", "ana@x.com")])
+    assert c.destinataires == ["Bob <bob@x.com>", "Ana <ana@x.com>"]
+    with pytest.raises(ValueError):
+        Courriel(sujet="s", destinataires=["pas-un-email"])
+
+
+def test_destinataire_chaine_unique_n_est_pas_eclatee_en_caracteres():
+    """Régression : `destinataires = "solo@x.com"` validait `s`, `o`, `l`…"""
+    c = Courriel(sujet="s")
+    c.destinataires = "solo@x.com"
+    assert c.destinataires == ["solo@x.com"]


### PR DESCRIPTION
Trois défauts de `schema.texte.Courriel` relevés par la revue du socle média.
Suites **schema (55)** et **factrice (29, consommateur de `Courriel`)** vertes,
`ruff check`/`format` verts.

## 1 — [MOYEN] Le constructeur court-circuitait la validation des adresses

Les champs privés `_emetteur`/`_destinataires` sont posés **en direct** par
attrs (`self._emetteur = emetteur`), sans passer par les `@….setter` qui
valident et normalisent via `formataddr`. Résultat, construction et affectation
divergeaient :

* `Courriel(emetteur="pas-un-email")` **passait**, là où
  `c.emetteur = "pas-un-email"` lève ;
* `Courriel(emetteur=("Bob", "bob@x.com"))` laissait le **tuple brut**, là où
  l'affectation donne `"Bob <bob@x.com>"` — un consommateur comme `factrice`,
  qui attend une chaîne RFC 5322 (`_msg["From"] = courriel.emetteur`), recevait
  alors un tuple.

Un `__attrs_post_init__` rejoue désormais la même validation/normalisation à la
construction. `emetteur=None` (le défaut, rempli plus tard par `factrice`) reste
permis.

## 2 — [BAS] Un destinataire en chaîne était éclaté caractère par caractère

`c.destinataires = "solo@x.com"` faisait `for d in "solo@x.com"` : chaque lettre
validée puis rejetée (`ValueError` sur `"s"`). Une chaîne unique est désormais
traitée comme **un** destinataire (les listes/tuples de destinataires restent
parcourus tels quels).

## 3 — [TRIVIAL] Import commenté mort

`# from automatheque.schema.medium import Medium` — le module s'appelle `media`,
et `Medium` n'existe pas. Supprimé.

## Compatibilité

Tous les usages de `factrice` construisent avec un émetteur **valide** (ou
`None`) et des destinataires en **liste** — la suite factrice reste verte, ce qui
confirme l'absence de régression pour le consommateur réel.