### PR TITLE
release: 0.22.0 (schema, decomposition, renommage)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.21.1"
+version = "0.22.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
 # 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.

--- a/src/automatheque.decomposition/CHANGELOG
+++ b/src/automatheque.decomposition/CHANGELOG
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.22.0] - 2026-08-08
 
 ### Fixed
 

--- a/src/automatheque.decomposition/pyproject.toml
+++ b/src/automatheque.decomposition/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.decomposition"
-version = "0.21.0"
+version = "0.22.0"
 description = "Décomposition de chaînes et d'arborescences par patrons"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque.renommage/CHANGELOG
+++ b/src/automatheque.renommage/CHANGELOG
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.22.0] - 2026-08-08
 
 ### Fixed
 

--- a/src/automatheque.renommage/pyproject.toml
+++ b/src/automatheque.renommage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.renommage"
-version = "0.21.1"
+version = "0.22.0"
 description = "Renommage et rangement de fichiers par gabarits"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Ce journal a été introduit a posteriori (cf. #34). Les entrées sont
 > reconstituées depuis l'historique git et peuvent donc être moins détaillées.
 
-## [Unreleased]
+## [0.22.0] - 2026-08-08
 
 ### Fixed
 

--- a/src/automatheque.schema/pyproject.toml
+++ b/src/automatheque.schema/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.schema"
-version = "0.21.0"
+version = "0.22.0"
 description = "Domaine pour des classes courantes et partagées"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}


### PR DESCRIPTION
Release groupée des correctifs de la revue du socle média (#125, #126, #127).
Le tag `0.22.0` publie les paquets dont `version == tag` (cf. `release.yml`),
donc **3 des 5** :

| Paquet | 0.21 → | Publié en 0.22.0 ? | Ce qui change |
|---|---|---|---|
| `automatheque.schema` | 0.21.0 → **0.22.0** | ✅ | `courriel` : validation au constructeur, destinataire unique |
| `automatheque.decomposition` | 0.21.0 → **0.22.0** | ✅ | contrat `source` (**rupture**, #117) + robustesse |
| `automatheque.renommage` | 0.21.1 → **0.22.0** | ✅ | robustesse copie/condition/chemin/config |
| `automatheque` | 0.21.0 (inchangé) | ❌ (skippé) | — |
| `automatheque.factrice` | 0.21.0 (inchangé) | ❌ (skippé) | — |

`monas` passe à **0.22.0** (= max, invariant lockstep respecté). Cœur et factrice
n'ont pas changé depuis 0.21.0 : le tag les ignore proprement. Pins inter-paquets
tous en `>=` plancher, rien de cassé.

## Note de rupture — `automatheque.decomposition`

Le contrat `Decomposable` attend désormais l'attribut **`source`** (et non plus
`filename`) pour les analyses d'arborescence — aligné sur `Media`/`Renommable`.
Un consommateur qui exposait `filename` doit le renommer `source`. L'analyse par
défaut (`ARBO_UN_NIVEAU`, qui lit `basename`) n'est pas concernée. Cf. #117.

## Vérifications

* Suites `schema` / `decomposition` / `renommage` : **133 passés** (1 skip =
  extra `vobject`).
* Build (`uv`) : `Version: 0.22.0`, `License: LGPL-3.0-or-later`, `LICENSE` +
  `GPL-3.0.txt` présents.

## Après le merge

Tag `0.22.0` → publie les 3 paquets.