### PR TITLE
feat(greffon): découverte par points d'entrée (#13) + plancher Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
 
@@ -51,10 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Installe Python 3.9 (plus basse version supportée par la CI)
+      - name: Installe Python 3.10 (plus basse version supportée par la CI)
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Installe les planchers déclarés par factrice (depuis PyPI)
         # Les planchers sont *dérivés* du pyproject de factrice (et non codés en

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,18 +2,18 @@
 packages = ["src/*"]
 version = "0.22.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
-# pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.9" dans les
-# 3 paquets) : on développe sur un interpréteur récent tout en supportant 3.9.
-# ruff/mypy ciblent volontairement 3.9 (le plancher) pour détecter toute
+# pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.10" dans les
+# paquets) : on développe sur un interpréteur récent tout en supportant 3.10.
+# ruff/mypy ciblent volontairement 3.10 (le plancher) pour détecter toute
 # incompatibilité avec la plus ancienne version supportée. Cf. #32.
 python-version = "3.11"
 
 # --- Outillage qualité (cf. issue #16) ---
 
 [tool.ruff]
-# Cible le plancher supporté (cf. requires-python = ">=3.9") afin de repérer
-# l'usage de syntaxe trop récente pour 3.9.
-target-version = "py39"
+# Cible le plancher supporté (cf. requires-python = ">=3.10") afin de repérer
+# l'usage de syntaxe trop récente pour 3.10.
+target-version = "py310"
 # Les setup.py sont générés par monas, on ne les lint/formate pas.
 extend-exclude = ["**/setup.py"]
 
@@ -23,7 +23,7 @@ extend-exclude = ["**/setup.py"]
 select = ["E", "F", "W", "I"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 ignore_missing_imports = true
 namespace_packages = true
 explicit_package_bases = true

--- a/src/automatheque.decomposition/CHANGELOG
+++ b/src/automatheque.decomposition/CHANGELOG
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* **Plancher Python relevé à 3.10** (abandon de 3.9) : `requires-python` passe à
+  `>=3.10` ; la CI teste 3.10 à 3.14. Cf. #32.
+
 ## [0.22.0] - 2026-08-08
 
 ### Fixed

--- a/src/automatheque.decomposition/pyproject.toml
+++ b/src/automatheque.decomposition/pyproject.toml
@@ -4,15 +4,16 @@ version = "0.22.0"
 description = "Décomposition de chaînes et d'arborescences par patrons"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* **Plancher Python relevé à 3.10** (abandon de 3.9) : `requires-python` passe à
+  `>=3.10` ; la CI teste 3.10 à 3.14. Cf. #32.
+
 ## [0.21.0] - 2026-08-07
 
 ### Fixed

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -4,15 +4,16 @@ version = "0.21.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [

--- a/src/automatheque.renommage/CHANGELOG
+++ b/src/automatheque.renommage/CHANGELOG
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* **Plancher Python relevé à 3.10** (abandon de 3.9) : `requires-python` passe à
+  `>=3.10` ; la CI teste 3.10 à 3.14. Cf. #32.
+
 ## [0.22.0] - 2026-08-08
 
 ### Fixed

--- a/src/automatheque.renommage/pyproject.toml
+++ b/src/automatheque.renommage/pyproject.toml
@@ -4,15 +4,16 @@ version = "0.22.0"
 description = "Renommage et rangement de fichiers par gabarits"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Ce journal a été introduit a posteriori (cf. #34). Les entrées sont
 > reconstituées depuis l'historique git et peuvent donc être moins détaillées.
 
+## [Unreleased]
+
+### Changed
+
+* **Plancher Python relevé à 3.10** (abandon de 3.9) : `requires-python` passe à
+  `>=3.10` ; la CI teste 3.10 à 3.14. Cf. #32.
+
 ## [0.22.0] - 2026-08-08
 
 ### Fixed

--- a/src/automatheque.schema/pyproject.toml
+++ b/src/automatheque.schema/pyproject.toml
@@ -4,15 +4,16 @@ version = "0.22.0"
 description = "Domaine pour des classes courantes et partagées"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `greffon` : **auto-découverte des greffons par points d'entrée** (#13).
+  `FabriqueGreffon.decouvre_monteurs(groupe="automatheque.greffons")` scanne
+  les paquets installés (`importlib.metadata.entry_points`) et enregistre leurs
+  monteurs, sans que l'application ait à les lister. Un paquet tiers déclare
+  simplement `[project.entry-points."automatheque.greffons"]` dans son
+  `pyproject.toml` : « installe le paquet, c'est découvert ». Compatible py3.9→3.12.
+
+### Changed
+
+* `greffon.FabriqueGreffon.charge_monteurs` : la résolution d'une référence
+  passée en **chaîne** (`"module.Classe"`) passe de `pydoc.locate` à
+  `importlib.import_module` + `getattr` (#13). `pydoc.locate` chargeait
+  n'importe quelle chaîne et renvoyait `None` en cas d'échec — d'où un
+  `issubclass(None, …)` obscur plus loin. La résolution sépare désormais module
+  et attribut et lève un `ValueError` explicite (module introuvable, attribut
+  absent, forme invalide).
+
 ## [0.21.0] - 2026-08-07
 
 ### Fixed

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -16,10 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   les paquets installés (`importlib.metadata.entry_points`) et enregistre leurs
   monteurs, sans que l'application ait à les lister. Un paquet tiers déclare
   simplement `[project.entry-points."automatheque.greffons"]` dans son
-  `pyproject.toml` : « installe le paquet, c'est découvert ». Compatible py3.9→3.12.
+  `pyproject.toml` : « installe le paquet, c'est découvert ».
 
 ### Changed
 
+* **Plancher Python relevé à 3.10** (abandon de 3.9). `requires-python` passe à
+  `>=3.10` ; la CI teste 3.10 à 3.14, et `ruff`/`mypy` ciblent 3.10 (le
+  plancher). La découverte des greffons se réduit ainsi à
+  `entry_points(group=…)` (signature qui n'existe pas en 3.9), sans code de
+  compatibilité.
 * `greffon.FabriqueGreffon.charge_monteurs` : la résolution d'une référence
   passée en **chaîne** (`"module.Classe"`) passe de `pydoc.locate` à
   `importlib.import_module` + `getattr` (#13). `pydoc.locate` chargeait

--- a/src/automatheque/automatheque/greffon/__init__.py
+++ b/src/automatheque/automatheque/greffon/__init__.py
@@ -49,18 +49,8 @@ def _resout_reference(chemin: str):
 
 
 def _points_entree(groupe: str) -> List[Any]:
-    """Points d'entrée d'un groupe, quelle que soit la version de Python (3.9+).
-
-    Depuis 3.10, `entry_points()` renvoie un objet *sélectionnable*
-    (`.select(group=…)`) ; en 3.9, il renvoie un dictionnaire `{groupe: [...]}`.
-    On détecte la première forme et retombe sur la seconde — plutôt que
-    `entry_points(group=…)`, dont la signature n'existe pas en 3.9.
-    """
-    points = entry_points()
-    selection = getattr(points, "select", None)
-    if selection is not None:
-        return list(selection(group=groupe))  # Python 3.10+
-    return list(points.get(groupe, []))  # pragma: no cover - Python 3.9
+    """Points d'entrée d'un groupe (`entry_points(group=…)`, py3.10+)."""
+    return list(entry_points(group=groupe))
 
 
 class FabriqueGreffon(Fabrique):

--- a/src/automatheque/automatheque/greffon/__init__.py
+++ b/src/automatheque/automatheque/greffon/__init__.py
@@ -1,6 +1,8 @@
+import importlib
 import logging
 from abc import ABC, ABCMeta
 from copy import deepcopy
+from importlib.metadata import entry_points
 from typing import Any, List, Optional, Type, Union
 
 from automatheque.conception.structures import Fabrique, Monteur
@@ -11,6 +13,55 @@ from automatheque.greffon.registre import MetaInstancePersistanteRegistre
 
 LOGGER = logging.getLogger(__name__)
 
+# Groupe de points d'entrée où un paquet tiers déclare ses greffons.
+GROUPE_GREFFONS = "automatheque.greffons"
+
+
+def _resout_reference(chemin: str):
+    """Résout ``"module.sousmodule.Objet"`` en l'objet référencé.
+
+    Remplace `pydoc.locate`, qui chargeait n'importe quelle chaîne sans rien
+    valider et renvoyait `None` en cas d'échec — d'où, plus loin, un
+    `issubclass(None, …)` opaque. On sépare explicitement le module de
+    l'attribut, on importe le module, puis on lit l'attribut, avec une erreur
+    claire à chaque étape.
+
+    :raise ValueError: si la chaîne est mal formée, le module introuvable, ou
+                       l'attribut absent.
+    """
+    module_nom, _, attribut = chemin.rpartition(".")
+    if not module_nom or not attribut:
+        raise ValueError(
+            f"Référence de greffon invalide : {chemin!r} (attendu 'module.Classe')"
+        )
+    try:
+        module = importlib.import_module(module_nom)
+    except ImportError as exc:
+        raise ValueError(
+            f"Module introuvable pour le greffon {chemin!r} : {exc}"
+        ) from exc
+    try:
+        return getattr(module, attribut)
+    except AttributeError as exc:
+        raise ValueError(
+            f"{attribut!r} absent du module {module_nom!r} (greffon {chemin!r})"
+        ) from exc
+
+
+def _points_entree(groupe: str) -> List[Any]:
+    """Points d'entrée d'un groupe, quelle que soit la version de Python (3.9+).
+
+    Depuis 3.10, `entry_points()` renvoie un objet *sélectionnable*
+    (`.select(group=…)`) ; en 3.9, il renvoie un dictionnaire `{groupe: [...]}`.
+    On détecte la première forme et retombe sur la seconde — plutôt que
+    `entry_points(group=…)`, dont la signature n'existe pas en 3.9.
+    """
+    points = entry_points()
+    selection = getattr(points, "select", None)
+    if selection is not None:
+        return list(selection(group=groupe))  # Python 3.10+
+    return list(points.get(groupe, []))  # pragma: no cover - Python 3.9
+
 
 class FabriqueGreffon(Fabrique):
     """Classe qui permet d'instancier les Greffons dont les Monteur ont été enregistrés.
@@ -18,6 +69,8 @@ class FabriqueGreffon(Fabrique):
     Il faut :
 
     1. enregistrer les monteurs des greffons avec `fabrique_greffons.charge_monteurs()`
+       (liste explicite), ou `fabrique_greffons.decouvre_monteurs()` pour les
+       découvrir automatiquement parmi les paquets installés (points d'entrée)
     2. instancier le type de greffon demandé, via `fabrique_greffons.active()`,
        qui lance `monteur.cree()` avec les arguments donnés, pour instancier le
        Greffon.
@@ -89,14 +142,12 @@ class FabriqueGreffon(Fabrique):
         Dans tous les cas ensuite il faut les activer un par un dans la configuration.
         """
         monteurs = []
-        # `monteur` est résolu dynamiquement (via pydoc.locate) ou fourni par
-        # l'appelant : son type statique n'est pas connu.
+        # `monteur` est résolu dynamiquement (via `_resout_reference`, importlib)
+        # ou fourni par l'appelant : son type statique n'est pas connu.
         monteur: Any
         for elem in liste_monteurs:
             if isinstance(elem, str):
-                from pydoc import locate
-
-                monteur = locate(elem)  # ou importlib TODO ?
+                monteur = _resout_reference(elem)
             else:
                 monteur = elem
             if issubclass(monteur, Greffon):
@@ -109,6 +160,26 @@ class FabriqueGreffon(Fabrique):
                 )
             monteurs.append(self.enregistre_monteur(monteur.cle, monteur_concret))
         return monteurs
+
+    def decouvre_monteurs(self, groupe: str = GROUPE_GREFFONS) -> List[Monteur]:
+        """Découvre et enregistre les monteurs déclarés en *points d'entrée*.
+
+        Un paquet tiers déclare ses greffons dans ses métadonnées, sans que
+        l'application ait à les lister :
+
+        .. code-block:: toml
+            [project.entry-points."automatheque.greffons"]
+            kodi = "monpaquet.kodi:MonteurKodi"
+
+        C'est l'alternative « installe le paquet, c'est découvert » au
+        `charge_monteurs([...])` explicite — et le remplacement propre du
+        chargement d'une chaîne arbitraire par `pydoc.locate`.
+
+        :param groupe: groupe de points d'entrée à scanner.
+        :return: les monteurs enregistrés.
+        """
+        monteurs = [point.load() for point in _points_entree(groupe)]
+        return self.charge_monteurs(monteurs)
 
     def active_greffons_conf(
         self,

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -6,15 +6,16 @@ authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },
 ]
 license = { text = "LGPL-3.0-or-later" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [

--- a/src/automatheque/tests/greffon/test_greffon.py
+++ b/src/automatheque/tests/greffon/test_greffon.py
@@ -153,3 +153,53 @@ def test_signale_appel_journalise_erreur_et_la_propage(caplog):
         r.levelno == logging.ERROR and "échec" in r.getMessage() for r in caplog.records
     )
     assert not any("fin appel" in r.getMessage() for r in caplog.records)
+
+
+# --- #13 : résolution par chaîne (importlib) + découverte par points d'entrée ---
+
+
+class GreffonParChemin(Greffon):
+    CAPACITES = []
+
+
+def test_charge_monteurs_resout_une_reference_chaine():
+    """Une référence `"module.Classe"` est résolue via importlib (ex-`pydoc.locate`)."""
+    fabrique_greffon.charge_monteurs([f"{__name__}.GreffonParChemin"])
+    assert "parchemin" in fabrique_greffon._monteurs
+    assert issubclass(fabrique_greffon._monteurs["parchemin"], GreffonParChemin)
+
+
+def test_charge_monteurs_reference_introuvable_leve_value_error():
+    """Un chemin invalide donne un `ValueError` clair, pas un `issubclass(None)`
+    obscur (`pydoc.locate` renvoyait `None` en silence)."""
+    with pytest.raises(ValueError):
+        fabrique_greffon.charge_monteurs(["paquet.inexistant.PasDeClasse"])
+    with pytest.raises(ValueError):
+        fabrique_greffon.charge_monteurs([f"{__name__}.PasDansCeModule"])
+
+
+class GreffonDecouvert(Greffon):
+    CAPACITES = []
+
+
+class _FauxPointEntree:
+    """Imite un `importlib.metadata.EntryPoint` : un `.load()` qui rend l'objet."""
+
+    def __init__(self, objet):
+        self._objet = objet
+
+    def load(self):
+        return self._objet
+
+
+def test_decouvre_monteurs_charge_les_points_entree(monkeypatch):
+    """Les monteurs déclarés en points d'entrée sont enregistrés sans liste
+    explicite — « installe le paquet, c'est découvert »."""
+    monkeypatch.setattr(
+        "automatheque.greffon._points_entree",
+        lambda groupe: [_FauxPointEntree(GreffonDecouvert)],
+    )
+    monteurs = fabrique_greffon.decouvre_monteurs()
+    assert "decouvert" in fabrique_greffon._monteurs
+    assert issubclass(fabrique_greffon._monteurs["decouvert"], GreffonDecouvert)
+    assert len(monteurs) == 1


### PR DESCRIPTION
Deux thèmes liés, un commit chacun. `Closes #13`.

## 1 — Découverte des greffons par points d'entrée (#13)

`FabriqueGreffon.decouvre_monteurs(groupe="automatheque.greffons")` scanne les
paquets installés (`importlib.metadata.entry_points`) et enregistre leurs
monteurs — sans que l'application ait à les lister :

```toml
[project.entry-points."automatheque.greffons"]
kodi = "monpaquet.kodi:MonteurKodi"
```

« installe le paquet, c'est découvert », en alternative au
`charge_monteurs([...])` explicite.

Et la résolution d'une référence **chaîne** (`"module.Classe"`) dans
`charge_monteurs` passe de `pydoc.locate` (chargeait n'importe quoi, renvoyait
`None` en silence → `issubclass(None, …)` obscur) à `importlib.import_module` +
`getattr`, avec un `ValueError` explicite. C'est le `# ou importlib TODO ?` que
le code traînait. Aucune rupture : `charge_monteurs` avec une **classe** (ce que
fait `secret`) est inchangé.

## 2 — Fourchette Python : plancher 3.10, testé jusqu'à 3.14

Sur ta remarque. `requires-python = ">=3.10"` **n'a pas de plafond** : 3.13 et
3.14 n'étaient donc pas *bloquées*, mais elles n'étaient ni testées ni
déclarées — ce qui revenait à dire « pas supporté ». On corrige :

* `requires-python` → **`>=3.10`** dans les **5 paquets** (abandon de 3.9) ;
* classifiers trove **3.10 → 3.14** ;
* CI : matrice de tests **3.10, 3.11, 3.12, 3.13, 3.14** ; job « planchers » sur 3.10 ;
* `ruff` `target-version = py310`, `mypy` `python_version = 3.10` (le plancher, pour
  attraper toute syntaxe trop récente).

Bénéfice immédiat côté #13 : la découverte se réduit à `entry_points(group=…)` —
signature qui **n'existe pas** en 3.9, et qui imposait sinon une détection
`.select`/`.get`.

## Vérifications

* Suites croisées (5 paquets) : **318 passés** (1 skip = extra `vobject`).
* `ruff` + `mypy` verts avec les **versions épinglées CI** (`0.16.0` / `1.19.1`) —
  c'est la CI qui a attrapé que `entry_points(group=…)` ne typait pas sous la
  cible 3.9, avant le bump.
* Build : `Requires-Python: >=3.10`, classifiers 3.10–3.14.