### PR TITLE
feat(util): exécution parallèle bornée avec limite de débit (#47)

### DIFF
--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `util.parallele` : **exécution parallèle bornée** (#47). `parallelise(fonction,
+  elements, workers=…, debit=…, processus=…)` applique une fonction à chaque
+  élément sur un pool borné (threads par défaut, processus en option), en option
+  sous une **limite de débit** (appels/seconde). Les résultats reviennent **dans
+  l'ordre**, chacun dans un `Resultat` (valeur **ou** exception) : une tâche qui
+  échoue n'interrompt pas les autres (`r.reussi`, `r.valeur_ou_leve()`). Se
+  compose avec `reessaye` (#7) — décorer la fonction suffit.
 * `greffon` : **auto-découverte des greffons par points d'entrée** (#13).
   `FabriqueGreffon.decouvre_monteurs(groupe="automatheque.greffons")` scanne
   les paquets installés (`importlib.metadata.entry_points`) et enregistre leurs

--- a/src/automatheque/automatheque/util/__init__.py
+++ b/src/automatheque/automatheque/util/__init__.py
@@ -3,6 +3,9 @@
 # Imports depuis fichier
 from .fichier import enleve_caracteres_invalides
 
+# Imports depuis parallele
+from .parallele import Resultat, parallelise
+
 # Imports depuis reessaye
 from .reessaye import reessaye
 
@@ -15,6 +18,9 @@ from .structures_python import dict_merge
 __all__ = [
     # .fichier
     "enleve_caracteres_invalides",
+    # .parallele
+    "parallelise",
+    "Resultat",
     # .reessaye
     "reessaye",
     # .repertoire

--- a/src/automatheque/automatheque/util/parallele.py
+++ b/src/automatheque/automatheque/util/parallele.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""Exécution parallèle bornée, avec limite de débit.
+
+Besoin récurrent en scripting : lancer N tâches **en parallèle** — souvent des
+appels réseau — sans saturer une API ni la machine. `parallelise` applique une
+fonction à chaque élément d'une collection sur un pool borné, en option sous une
+**limite de débit** (« ≤ 5 appels/seconde »), et **collecte les exceptions par
+tâche** plutôt que de s'arrêter au premier échec.
+
+Exemple ::
+
+    from automatheque.util import parallelise, reessaye
+
+    @reessaye(tentatives=3, exceptions=(ConnectionError,))
+    def telecharge(url):
+        ...
+
+    resultats = parallelise(telecharge, urls, workers=8, debit=5)
+    reussis = [r.valeur for r in resultats if r.reussi]
+    for echec in (r for r in resultats if not r.reussi):
+        LOGGER.warning("%s : %s", echec.element, echec.erreur)
+
+Se compose naturellement avec `reessaye` (#7) : décorer la fonction suffit.
+"""
+
+import logging
+import threading
+import time
+from concurrent.futures import (
+    ProcessPoolExecutor,
+    ThreadPoolExecutor,
+    as_completed,
+)
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import attr
+
+LOGGER = logging.getLogger(__name__)
+
+
+@attr.s
+class Resultat:
+    """Le résultat d'une tâche : sa valeur, **ou** l'exception qu'elle a levée.
+
+    `valeur` vaut `None` aussi bien pour une tâche qui a renvoyé `None` que pour
+    une tâche en échec : c'est `reussi` (et non `valeur`) qui distingue les deux.
+    """
+
+    element = attr.ib()
+    valeur = attr.ib(default=None)
+    erreur: Optional[BaseException] = attr.ib(default=None)
+
+    @property
+    def reussi(self) -> bool:
+        """Vrai si la tâche s'est terminée sans exception."""
+        return self.erreur is None
+
+    def valeur_ou_leve(self):
+        """Renvoie la valeur, ou **relève** l'exception si la tâche a échoué."""
+        if self.erreur is not None:
+            raise self.erreur
+        return self.valeur
+
+
+class _LimiteurDebit:
+    """Espace les départs pour ne pas dépasser `debit` appels par seconde.
+
+    Chaque tâche appelle `attend()` avant de partir. Le calcul de l'instant du
+    prochain départ autorisé est sérialisé sous verrou ; l'attente proprement
+    dite se fait **hors** du verrou, pour ne pas bloquer les autres.
+    """
+
+    def __init__(self, debit: float):
+        self._intervalle = 1.0 / debit
+        self._verrou = threading.Lock()
+        self._prochain_depart = 0.0
+
+    def attend(self) -> None:
+        with self._verrou:
+            maintenant = time.monotonic()
+            depart = max(maintenant, self._prochain_depart)
+            self._prochain_depart = depart + self._intervalle
+            a_patienter = depart - maintenant
+        if a_patienter > 0:
+            time.sleep(a_patienter)
+
+
+def parallelise(
+    fonction: Callable[[Any], Any],
+    elements: Iterable[Any],
+    *,
+    workers: Optional[int] = None,
+    debit: Optional[float] = None,
+    processus: bool = False,
+) -> List[Resultat]:
+    """Applique `fonction` à chaque élément, en parallèle et borné.
+
+    Les résultats sont renvoyés **dans l'ordre des éléments**, chacun enveloppé
+    dans un :class:`Resultat` (valeur ou exception). Une tâche qui échoue
+    n'interrompt pas les autres.
+
+    :param fonction: appelée en `fonction(element)` pour chaque élément.
+    :param elements: itérable d'entrées (consommé en entier au départ).
+    :param workers: nombre maximal de tâches simultanées. `None` (défaut) laisse
+        l'exécuteur choisir.
+    :param debit: limite de débit, en **appels par seconde** ; les départs sont
+        espacés en conséquence. `None` (défaut) ne limite pas.
+    :param processus: `True` pour un pool de **processus** (tâches gourmandes en
+        CPU) au lieu de threads (défaut, adapté aux entrées/sorties). En mode
+        processus, `fonction` et les éléments doivent être *picklables*.
+    :return: la liste des :class:`Resultat`, dans l'ordre des éléments.
+    :raise ValueError: si `workers` < 1, ou si `debit` <= 0.
+    """
+    if workers is not None and workers < 1:
+        raise ValueError("workers doit être >= 1")
+    if debit is not None and debit <= 0:
+        raise ValueError("debit doit être > 0 (appels par seconde)")
+
+    elements = list(elements)
+    if not elements:
+        return []
+
+    limiteur = _LimiteurDebit(debit) if debit else None
+    classe_executeur = ProcessPoolExecutor if processus else ThreadPoolExecutor
+    par_index: Dict[int, Resultat] = {}
+
+    with classe_executeur(max_workers=workers) as executeur:
+        # Le débit est régulé au **départ** (dans ce thread) : la cadence de
+        # soumission borne la cadence de démarrage, quel que soit le nombre de
+        # workers, et fonctionne aussi bien avec un pool de processus.
+        futur_vers_index = {}
+        for index, element in enumerate(elements):
+            if limiteur is not None:
+                limiteur.attend()
+            futur_vers_index[executeur.submit(fonction, element)] = index
+
+        for futur in as_completed(futur_vers_index):
+            index = futur_vers_index[futur]
+            element = elements[index]
+            try:
+                par_index[index] = Resultat(element, valeur=futur.result())
+            except Exception as exc:
+                LOGGER.debug("Tâche %r a échoué : %s", element, exc)
+                par_index[index] = Resultat(element, erreur=exc)
+
+    return [par_index[i] for i in range(len(elements))]

--- a/src/automatheque/tests/util/test_parallele.py
+++ b/src/automatheque/tests/util/test_parallele.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Tests de l'exécution parallèle bornée (#47)."""
+
+import threading
+import time
+
+import pytest
+from automatheque.util import Resultat, parallelise
+
+
+def test_applique_la_fonction_et_preserve_l_ordre():
+    res = parallelise(lambda x: x * 10, [1, 2, 3], workers=3)
+    assert [r.valeur for r in res] == [10, 20, 30]
+    assert all(isinstance(r, Resultat) and r.reussi for r in res)
+
+
+def test_ordre_preserve_malgre_des_durees_differentes():
+    """Le premier élément est le plus lent : il finit dernier mais reste 1er."""
+
+    def lent_si_zero(x):
+        time.sleep(0.03 if x == 0 else 0)
+        return x
+
+    res = parallelise(lent_si_zero, [0, 1, 2], workers=3)
+    assert [r.valeur for r in res] == [0, 1, 2]
+
+
+def test_les_erreurs_sont_collectees_par_tache_pas_un_arret_brutal():
+    def peut_echouer(x):
+        if x == 2:
+            raise ValueError("deux interdit")
+        return x * 10
+
+    res = parallelise(peut_echouer, [1, 2, 3], workers=3)
+    assert res[0].reussi and res[0].valeur == 10
+    assert not res[1].reussi and isinstance(res[1].erreur, ValueError)
+    assert res[2].reussi and res[2].valeur == 30
+
+
+def test_valeur_ou_leve():
+    res = parallelise(lambda x: 1 / x, [1, 0], workers=2)
+    assert res[0].valeur_ou_leve() == 1
+    with pytest.raises(ZeroDivisionError):
+        res[1].valeur_ou_leve()
+
+
+def test_execute_reellement_en_parallele():
+    """`Barrier(4)` ne se débloque que si les 4 tâches y arrivent **ensemble** ;
+    sans parallélisme réel, `wait()` expirerait (`BrokenBarrierError`)."""
+    barriere = threading.Barrier(4, timeout=5)
+
+    def rejoint_les_autres(x):
+        barriere.wait()
+        return x
+
+    res = parallelise(rejoint_les_autres, range(4), workers=4)
+    assert [r.valeur for r in res] == [0, 1, 2, 3]
+    assert all(r.reussi for r in res)
+
+
+def test_debit_limite_la_cadence_de_depart():
+    debut = time.monotonic()
+    res = parallelise(lambda x: x, range(4), workers=4, debit=20)  # 20/s → 0.05s
+    ecoule = time.monotonic() - debut
+    assert all(r.reussi for r in res)
+    # 4 départs espacés de 0.05s = 3 intervalles = 0.15s (marge : >= 0.12).
+    assert ecoule >= 0.12
+
+
+def test_mode_processus_avec_une_fonction_picklable():
+    # `abs` est un builtin picklable : évite les soucis d'import du module de
+    # test par les sous-processus.
+    res = parallelise(abs, [-1, -2, 3], processus=True)
+    assert [r.valeur for r in res] == [1, 2, 3]
+
+
+def test_liste_vide_renvoie_une_liste_vide():
+    assert parallelise(lambda x: x, []) == []
+
+
+def test_parametres_invalides():
+    with pytest.raises(ValueError):
+        parallelise(lambda x: x, [1], workers=0)
+    with pytest.raises(ValueError):
+        parallelise(lambda x: x, [1], debit=0)


### PR DESCRIPTION
Ferme **#47**. `Closes #47`.

## `util.parallele.parallelise`

```python
from automatheque.util import parallelise, reessaye

@reessaye(tentatives=3, exceptions=(ConnectionError,))
def telecharge(url): ...

resultats = parallelise(telecharge, urls, workers=8, debit=5)   # ≤ 5 appels/s
reussis = [r.valeur for r in resultats if r.reussi]
```

`parallelise(fonction, elements, *, workers=None, debit=None, processus=False)` :

* **pool borné** au-dessus de `concurrent.futures` — threads par défaut (IO), ou
  **processus** (`processus=True`) pour le CPU-bound ;
* **limite de débit** optionnelle (`debit`, en appels/seconde) : les départs
  sont espacés par un limiteur thread-safe. La régulation se fait **au départ**
  (cadence de soumission), ce qui borne la cadence de démarrage quel que soit le
  nombre de workers — et marche aussi avec un pool de processus ;
* **collecte des exceptions par tâche** (pas d'arrêt brutal) : chaque résultat
  est un `Resultat` (`element`, `valeur`, `erreur`), avec `r.reussi` et
  `r.valeur_ou_leve()`. Les résultats reviennent **dans l'ordre des éléments** ;
* se **compose** avec `reessaye` (#7) — décorer la fonction suffit — et sera prêt
  pour le futur client HTTP (#11).

## Décisions d'implémentation (les points « à trancher » de l'issue)

* **API** : une simple fonction `parallelise(fonction, elements, …)` de style
  `map`, plutôt qu'un décorateur ou un context manager — la plus directe à
  composer avec `reessaye`.
* **Threads par défaut**, processus en option : le besoin premier est IO-bound.

## Tests

Ordre préservé (même avec des durées différentes), collecte des erreurs,
**parallélisme réel** (via `threading.Barrier`), **limite de débit** (mesure du
temps), mode **processus**, liste vide, paramètres invalides. Suite cœur :
**165 passés** ; `ruff` + `mypy` verts avec les versions épinglées CI.