### PR TITLE
release: 0.23.0 (les 5 paquets)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.monas]
 packages = ["src/*"]
-version = "0.22.0"
+version = "0.23.0"
 # Interpréteur Python de l'environnement de DÉVELOPPEMENT géré par monas. À ne
 # pas confondre avec le plancher SUPPORTÉ (requires-python = ">=3.10" dans les
 # paquets) : on développe sur un interpréteur récent tout en supportant 3.10.

--- a/src/automatheque.decomposition/CHANGELOG
+++ b/src/automatheque.decomposition/CHANGELOG
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.23.0] - 2026-08-08
 
 ### Changed
 

--- a/src/automatheque.decomposition/pyproject.toml
+++ b/src/automatheque.decomposition/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.decomposition"
-version = "0.22.0"
+version = "0.23.0"
 description = "Décomposition de chaînes et d'arborescences par patrons"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque.factrice/CHANGELOG
+++ b/src/automatheque.factrice/CHANGELOG
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versions antérieures sont reconstituées depuis l'historique git et peuvent
 > donc être moins détaillées.
 
-## [Unreleased]
+## [0.23.0] - 2026-08-08
 
 ### Changed
 

--- a/src/automatheque.factrice/pyproject.toml
+++ b/src/automatheque.factrice/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.factrice"
-version = "0.21.0"
+version = "0.23.0"
 description = "Librairie et app simplifiée d'envoi de mail"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque.renommage/CHANGELOG
+++ b/src/automatheque.renommage/CHANGELOG
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.23.0] - 2026-08-08
 
 ### Changed
 

--- a/src/automatheque.renommage/pyproject.toml
+++ b/src/automatheque.renommage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.renommage"
-version = "0.22.0"
+version = "0.23.0"
 description = "Renommage et rangement de fichiers par gabarits"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque.schema/CHANGELOG
+++ b/src/automatheque.schema/CHANGELOG
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Ce journal a été introduit a posteriori (cf. #34). Les entrées sont
 > reconstituées depuis l'historique git et peuvent donc être moins détaillées.
 
-## [Unreleased]
+## [0.23.0] - 2026-08-08
 
 ### Changed
 

--- a/src/automatheque.schema/pyproject.toml
+++ b/src/automatheque.schema/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque.schema"
-version = "0.22.0"
+version = "0.23.0"
 description = "Domaine pour des classes courantes et partagées"
 authors = [{name = "Marc", email = "githubmarc@maj44.com"}]
 license = {text = "LGPL-3.0-or-later"}

--- a/src/automatheque/CHANGELOG
+++ b/src/automatheque/CHANGELOG
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.23.0] - 2026-08-08
 
 ### Added
 

--- a/src/automatheque/pyproject.toml
+++ b/src/automatheque/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automatheque"
-version = "0.21.0"
+version = "0.23.0"
 description = "Bibliothèque pour se faciliter le scripting !"
 authors = [
     { name = "Marc", email = "githubmarc@maj44.com" },


### PR DESCRIPTION
Bump lockstep vers **0.23.0**. Le tag `0.23.0` publie **les 5 paquets** (tous à
0.23.0).

| Paquet | 0.2x → | Contenu |
|---|---|---|
| `automatheque` | 0.21.0 → **0.23.0** | `util.parallele` (#47) + découverte greffon (#13) + plancher 3.10 |
| `automatheque.factrice` | 0.21.0 → **0.23.0** | plancher 3.10 (republication métadonnée) |
| `automatheque.schema` | 0.22.0 → **0.23.0** | plancher 3.10 |
| `automatheque.decomposition` | 0.22.0 → **0.23.0** | plancher 3.10 |
| `automatheque.renommage` | 0.22.0 → **0.23.0** | plancher 3.10 |

## Contenu

* **`util.parallele.parallelise`** (#47) : exécution parallèle bornée (threads /
  processus), **limite de débit** optionnelle, **collecte des erreurs par tâche**
  (`Resultat`, `r.reussi`, `r.valeur_ou_leve()`), résultats **dans l'ordre**.
* **Découverte des greffons par points d'entrée** (#13) :
  `decouvre_monteurs(...)` + `pydoc.locate` → `importlib`.
* **Plancher Python 3.10** (abandon de 3.9) sur les **5 paquets** :
  `requires-python >=3.10`, classifiers et CI **3.10 → 3.14**. Les 4 paquets sans
  changement de code sont republiés uniquement pour porter cette métadonnée
  (sinon leurs versions publiées continuent d'annoncer `>=3.9`).

## Vérifications

* Suite complète (5 paquets) : **327 passés** (1 skip = extra `vobject`).
* Build (`uv`) : `Version: 0.23.0`, `Requires-Python: >=3.10`,
  `License: LGPL-3.0-or-later`, `LICENSE` + `GPL-3.0.txt` présents ; module
  `parallele` embarqué.

## Après le merge

Tag `0.23.0` → publie les 5 paquets.